### PR TITLE
Fixup roles so that fresh provision succeeds

### DIFF
--- a/deployment/ansible/roles/ashlar.app/meta/main.yml
+++ b/deployment/ansible/roles/ashlar.app/meta/main.yml
@@ -6,5 +6,4 @@
     - { role: "azavea.gunicorn" }
     - { role: "azavea.nginx", nginx_delete_default_site: False }
     - { role: "azavea.nodejs" }
-    - { role: "azavea.postgresql-support"}
     - { role: "ashlar.web"}

--- a/deployment/ansible/roles/ashlar.app/tasks/main.yml
+++ b/deployment/ansible/roles/ashlar.app/tasks/main.yml
@@ -1,27 +1,9 @@
 ---
 
-- name: Install dev packages
-  apt: name={{ item }}
-  with_items:
-    - libgeos-dev
-    - binutils
-    - libproj-dev
-    - gdal-bin
-
 - name: Install python requirements
   pip: name={{ item.name }} version={{ item.version }}
   with_items:
-    - { name: 'Django', version: '1.8' }
-    - { name: 'djangorestframework', version: '3.1.1' }
-    - { name: 'djangorestframework-gis', version: '0.8.1' }
     - { name: 'django-oauth-toolkit', version: '0.8.1' }
-    - { name: 'django-filter', version: '0.9.2' }
-    - { name: 'jsonschema', version: '2.4.0' }
-    - { name: 'django-pgjson', version: '0.2.3' }
-    - { name: 'psycopg2', version: '2.6' }
-    - { name: 'django-extensions', version: '1.5.2' }
-    - { name: 'PyYAML', version: '3.11' }
-  notify: Restart ashlar
 
 - name: Install python dev requirements
   pip: name={{ item.name }} version={{ item.version }}

--- a/deployment/ansible/roles/driver.ashlar/meta/main.yml
+++ b/deployment/ansible/roles/driver.ashlar/meta/main.yml
@@ -1,0 +1,5 @@
+---
+  dependencies:
+    - { role: "azavea.python", python_development: True }
+    - { role: "azavea.pip" }
+    - { role: "azavea.postgresql-support"}  # Installs pg_config, required to pip install psycopg2

--- a/deployment/ansible/roles/driver.ashlar/tasks/main.yml
+++ b/deployment/ansible/roles/driver.ashlar/tasks/main.yml
@@ -1,3 +1,12 @@
 ---
+
+- name: Install dev packages
+  apt: name={{ item }}
+  with_items:
+    - libgeos-dev
+    - binutils
+    - libproj-dev
+    - gdal-bin
+
 - name: Install Ashlar from source
   command: pip install -e /opt/ashlar


### PR DESCRIPTION
Moves some prereqs for pip installing the ashlar dependencies to the `driver.ashlar` role.