### PR TITLE
Feature/related content

### DIFF
--- a/schema_editor/app/index.html
+++ b/schema_editor/app/index.html
@@ -76,6 +76,8 @@
         <script src="scripts/views/recordtype/edit-directive.js"></script>
         <script src="scripts/views/recordtype/detail-controller.js"></script>
         <script src="scripts/views/recordtype/detail-directive.js"></script>
+        <script src="scripts/views/recordtype/detail-add-directive.js"></script>
+        <script src="scripts/views/recordtype/detail-edit-directive.js"></script>
         <script src="scripts/views/recordtype/schema/add-controller.js"></script>
         <script src="scripts/views/recordtype/schema/add-directive.js"></script>
         <script src="scripts/views/recordtype/schema/edit-controller.js"></script>

--- a/schema_editor/app/index.html
+++ b/schema_editor/app/index.html
@@ -55,6 +55,7 @@
         <!-- build:js({.tmp,app}) scripts/scripts.js -->
         <script src="scripts/config.js"></script>
         <script src="scripts/resources/module.js"></script>
+        <script src="scripts/resources/recordschemas-service.js"></script>
         <script src="scripts/resources/recordtypes-service.js"></script>
         <script src="scripts/views/sidebar/module.js"></script>
         <script src="scripts/views/sidebar/sidebar-controller.js"></script>

--- a/schema_editor/app/index.html
+++ b/schema_editor/app/index.html
@@ -54,6 +54,8 @@
 
         <!-- build:js({.tmp,app}) scripts/scripts.js -->
         <script src="scripts/config.js"></script>
+        <script src="scripts/schemas/module.js"></script>
+        <script src="scripts/schemas/schemas-service.js"></script>
         <script src="scripts/resources/module.js"></script>
         <script src="scripts/resources/recordschemas-service.js"></script>
         <script src="scripts/resources/recordtypes-service.js"></script>

--- a/schema_editor/app/scripts/resources/recordschemas-service.js
+++ b/schema_editor/app/scripts/resources/recordschemas-service.js
@@ -1,0 +1,28 @@
+
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordSchemas($resource, Config) {
+        return $resource(Config.api.hostname + '/api/recordschemas/:id/', {id: '@uuid'}, {
+            create: {
+                method: 'POST'
+            },
+            get: {
+                method: 'GET'
+            },
+            query: {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data).results; },
+                isArray: true
+            },
+            update: {
+                method: 'PATCH'
+            }
+        });
+    }
+
+    angular.module('ase.resources')
+    .factory('RecordSchemas', RecordSchemas);
+
+})();

--- a/schema_editor/app/scripts/schemas/module.js
+++ b/schema_editor/app/scripts/schemas/module.js
@@ -1,0 +1,7 @@
+
+(function () {
+    'use strict';
+
+    angular.module('ase.schemas', []);
+
+})();

--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -1,0 +1,27 @@
+
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Schemas() {
+        var module = {
+            Object: Object
+        };
+        return module;
+
+        function Object() {
+            return {
+                type: 'object',
+                title: '',
+                plural_title: '',
+                description: '',
+                properties: {},
+                definitions: {}
+            };
+        }
+    }
+
+    angular.module('ase.schemas')
+    .service('Schemas', Schemas);
+
+})();

--- a/schema_editor/app/scripts/views/recordtype/add-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/add-controller.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /* ngInject */
-    function RTAddController($log, $state, RecordTypes) {
+    function RTAddController($log, $state, RecordSchemas, RecordTypes, Schemas) {
         var ctl = this;
         initialize();
 
@@ -15,10 +15,23 @@
          * Creates the record type and switches to the list view on success
          */
         function submitForm() {
-            RecordTypes.create(ctl.recordType, function() {
-                $state.go('rt.list');
-            }, function(error) {
+            RecordTypes.create(ctl.recordType, onRecordTypeCreateSuccess, function(error) {
                 $log.debug('Error while adding recordType: ', error);
+            });
+        }
+
+        /**
+         * Create blank associated record schema v1 on record type create success
+         * @return {[type]} [description]
+         */
+        function onRecordTypeCreateSuccess(recordType) {
+            RecordSchemas.create({
+                record_type: recordType.uuid,
+                schema: Schemas.Object()
+            }).$promise.then(function () {
+                $state.go('rt.list');
+            }, function (error) {
+                $log.debug('Error while creating recordschema:', error);
             });
         }
     }

--- a/schema_editor/app/scripts/views/recordtype/detail-add-directive.js
+++ b/schema_editor/app/scripts/views/recordtype/detail-add-directive.js
@@ -1,0 +1,55 @@
+
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTDetailAddController($log, $state, $stateParams, RecordSchemas, RecordTypes, Schemas) {
+        var ctl = this;
+        ctl.submitForm = submitForm;
+        initialize();
+
+        function initialize() {
+            ctl.definition = Schemas.Object();
+            RecordTypes.get({ id: $stateParams.uuid }).$promise.then(function (data) {
+                ctl.recordType = data;
+                ctl.currentSchema = RecordSchemas.get({ id: ctl.recordType.current_schema });
+            });
+        }
+
+        function submitForm() {
+            var key = ctl.definition.title;
+            if (ctl.currentSchema.schema.definitions[key]) {
+                $log.debug('Title', key, 'exists for current schema');
+                return;
+            }
+
+            ctl.currentSchema.schema.definitions[key] = ctl.definition;
+            RecordSchemas.create({
+                schema: ctl.currentSchema.schema,
+                record_type: ctl.recordType.uuid
+            }, function (newSchema) {
+                $log.debug(newSchema);
+                $state.go('rt.detail', {uuid: ctl.recordType.uuid});
+            }, function (error) {
+                $log.debug('Error saving new schema: ', error);
+            });
+        }
+    }
+
+    /* ngInject */
+    function RTDetailAdd() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/detail-add-edit-partial.html',
+            controller: 'RTDetailAddController',
+            controllerAs: 'rtDetail',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTDetailAddController', RTDetailAddController)
+    .directive('aseRtDetailAdd', RTDetailAdd);
+
+})();

--- a/schema_editor/app/scripts/views/recordtype/detail-add-edit-partial.html
+++ b/schema_editor/app/scripts/views/recordtype/detail-add-edit-partial.html
@@ -1,0 +1,54 @@
+
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <div class="form-area-heading">
+            <h2 ng-show="!rtDetail.schemaKey">Add New Related Content</h2>
+            <h2 ng-show="rtDetail.schemaKey">Edit Related Content</h2>
+            <div class="content-border"></div>
+        </div>
+
+        <form name="rtForm" novalidate ng-submit="rtDetail.submitForm()">
+            <div class="form-group col-sm-6">
+                <label for="single-title">Single Title</label>
+                <input required type="text" name="label" ng-model="rtDetail.definition.title"
+                       class="form-control" id="single-title" placeholder="Accident"
+                       ng-minlength="3" ng-maxlength="64" />
+                <p ng-show="rtForm.title.$invalid && !rtForm.title.$pristine" class="help-block">
+                    Single Title is required
+                </p>
+                <p ng-show="rtForm.title.$error.minlength" class="help-block">Single Title too short</p>
+                <p ng-show="rtForm.title.$error.maxlength" class="help-block">Single Title too long</p>
+            </div>
+            <div class="form-group col-sm-6">
+                <label for="plural-title">Plural Title</label>
+                <input required type="text" name="plural_label" ng-model="rtDetail.definition.plural_title"
+                       class="form-control" id="plural-title" placeholder="Accidents"
+                       ng-minlength="3" ng-maxlength="64" />
+                <p ng-show="rtForm.plural_title.$invalid && !rtForm.plural_title.$pristine" class="help-block">
+                    Plural Title is required
+                </p>
+                <p ng-show="rtForm.plural_title.$error.minlength" class="help-block">Plural Title too short</p>
+                <p ng-show="rtForm.plural_title.$error.maxlength" class="help-block">Plural Title too long</p>
+            </div>
+            <div class="form-group col-sm-12">
+                <label for="description">Description</label>
+                <textarea required name="description" class="form-control" ng-model="rtDetail.definition.description"
+                          id="description" rows="5" placeholder="Lorem ipsum"
+                          ng-minlength="3" ng-maxlength="255">
+                </textarea>
+                <p ng-show="rtForm.description.$invalid && !rtForm.description.$pristine" class="help-block">
+                    Description is required
+                </p>
+                <p ng-show="rtForm.description.$error.minlength" class="help-block">Description too short</p>
+                <p ng-show="rtForm.description.$error.maxlength" class="help-block">Description too long</p>
+            </div>
+
+            <div class="save-area">
+                <button type="submit" class="btn btn-default" ng-disabled="rtForm.$invalid">
+                    Save
+                </button>
+                <button type="button" ui-sref="rtDetail.detail({uuid: rtDetail.recordType.uuid})" class="btn btn-default">Cancel</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/schema_editor/app/scripts/views/recordtype/detail-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/detail-controller.js
@@ -2,12 +2,15 @@
     'use strict';
 
     /* ngInject */
-    function RTDetailController($stateParams, RecordTypes) {
+    function RTDetailController($stateParams, RecordSchemas, RecordTypes) {
         var ctl = this;
         initialize();
 
         function initialize() {
-            ctl.recordType = RecordTypes.get({ id: $stateParams.uuid });
+            RecordTypes.get({ id: $stateParams.uuid }).$promise.then(function (data) {
+                ctl.recordType = data;
+                ctl.currentSchema = RecordSchemas.get({ id: ctl.recordType.current_schema });
+            });
         }
     }
 

--- a/schema_editor/app/scripts/views/recordtype/detail-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/detail-controller.js
@@ -4,6 +4,7 @@
     /* ngInject */
     function RTDetailController($stateParams, RecordSchemas, RecordTypes) {
         var ctl = this;
+        ctl.deleteSchema = deleteSchema;
         initialize();
 
         function initialize() {
@@ -11,6 +12,17 @@
                 ctl.recordType = data;
                 ctl.currentSchema = RecordSchemas.get({ id: ctl.recordType.current_schema });
             });
+        }
+
+        function deleteSchema(key) {
+            if (ctl.currentSchema.schema.definitions[key]) {
+                delete ctl.currentSchema.schema.definitions[key];
+                // TODO: Error handle and revert delete if failure
+                RecordSchemas.create({
+                    record_type: ctl.recordType.uuid,
+                    schema: ctl.currentSchema.schema
+                });
+            }
         }
     }
 

--- a/schema_editor/app/scripts/views/recordtype/detail-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/detail-controller.js
@@ -2,12 +2,12 @@
     'use strict';
 
     /* ngInject */
-    function RTDetailController() {
+    function RTDetailController($stateParams, RecordTypes) {
         var ctl = this;
         initialize();
 
         function initialize() {
-
+            ctl.recordType = RecordTypes.get({ id: $stateParams.uuid });
         }
     }
 

--- a/schema_editor/app/scripts/views/recordtype/detail-edit-directive.js
+++ b/schema_editor/app/scripts/views/recordtype/detail-edit-directive.js
@@ -1,0 +1,55 @@
+
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTDetailEditController($log, $state, $stateParams, RecordSchemas, RecordTypes) {
+        var ctl = this;
+        var currentSchema = null;
+        ctl.submitForm = submitForm;
+        initialize();
+
+        function initialize() {
+            ctl.schemaKey = $stateParams.schema;
+            ctl.definition = {};
+            RecordTypes.get({ id: $stateParams.uuid }).$promise.then(function (data) {
+                ctl.recordType = data;
+                RecordSchemas.get({ id: ctl.recordType.current_schema }).$promise.then(function (recordSchema) {
+                    currentSchema = recordSchema;
+                    ctl.definition = currentSchema.schema.definitions[ctl.schemaKey];
+                });
+            });
+        }
+
+        function submitForm() {
+            var key = ctl.definition.title;
+            currentSchema.schema.definitions[key] = ctl.definition;
+            RecordSchemas.create({
+                schema: currentSchema.schema,
+                record_type: ctl.recordType.uuid
+            }, function (newSchema) {
+                $log.debug(newSchema);
+                $state.go('^.detail', {uuid: ctl.recordType.uuid});
+            }, function (error) {
+                $log.debug('Error saving new schema: ', error);
+            });
+        }
+    }
+
+    /* ngInject */
+    function RTDetailEdit() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/detail-add-edit-partial.html',
+            controller: 'RTDetailEditController',
+            controllerAs: 'rtDetail',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTDetailEditController', RTDetailEditController)
+    .directive('aseRtDetailEdit', RTDetailEdit);
+
+})();

--- a/schema_editor/app/scripts/views/recordtype/detail-partial.html
+++ b/schema_editor/app/scripts/views/recordtype/detail-partial.html
@@ -12,7 +12,7 @@
                         <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
                             <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
                         </svg>
-                        <a ui-sref="rt.detail-edit({uuid: rt.recordType.uuid })"><h4>{{ definition.title }}</h4></a>
+                        <a ui-sref="rt.detail-edit({uuid: rt.recordType.uuid, schema: key})"><h4>{{ definition.title }}</h4></a>
                         <a ng-click="rt.deleteSchema(key)" role="button" class="delete">
                             <p>Trash</p>
                             <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">

--- a/schema_editor/app/scripts/views/recordtype/detail-partial.html
+++ b/schema_editor/app/scripts/views/recordtype/detail-partial.html
@@ -6,13 +6,13 @@
             <div class="content-border"></div>
         </div>
         <div class="form-area-body">
-            <div ng-repeat="(key, definition) in rt.recordType.current_schema.definitions">
+            <div ng-repeat="(key, definition) in rt.currentSchema.schema.definitions">
                 <div class="row">
                     <div class="type">
                         <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
                             <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
                         </svg>
-                        <a ui-sref="rt.schema-edit({uuid: rt.recordType.uuid })"><h4>{{ definition.title }}</h4></a>
+                        <a ui-sref="rt.detail-edit({uuid: rt.recordType.uuid })"><h4>{{ definition.title }}</h4></a>
                         <a ng-click="rt.deleteSchema(key)" role="button" class="delete">
                             <p>Trash</p>
                             <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">

--- a/schema_editor/app/scripts/views/recordtype/detail-partial.html
+++ b/schema_editor/app/scripts/views/recordtype/detail-partial.html
@@ -1,80 +1,35 @@
 <div class="form-area">
     <div class="col-sm-8 col-sm-offset-3">
         <div class="form-area-heading">
-            <h2>Related Content for Accidents</h2>
-            <button type="button" class="btn btn-default">Add new content</button>
+            <h2>Related Content for {{ rt.recordType.plural_label }}</h2>
+            <button type="button" class="btn btn-default" ui-sref="rt.detail-add({uuid: rt.recordType.uuid })">Add new content</button>
             <div class="content-border"></div>
         </div>
         <div class="form-area-body">
-
-            <div class="row">
-                <div class="type">
-                    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
-                        <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
-                    </svg>
-                    <a ui-sref="rt.schema-edit({uuid: 'abcd', schema: 'vehicle'})"><h4>Vehicles</h4></a>
-                    <a href="" role="button" class="delete">
-                        <p>Trash</p>
-                        <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">
-                            <path d="M6.1,39l5.5,48.5c0.3,2.3,11.4,9.9,27.5,9.9c16.1,0,27.3-7.6,27.6-9.9L72.2,39c-8.4,4.7-21,6.9-33.1,6.9 C27.1,46,14.5,43.7,6.1,39z M55,9l-4.3-4.8c-1.7-2.4-3.5-2.8-7-2.8h-9.2c-3.5,0-5.3,0.4-7,2.8L23.4,9C10.5,11.3,1.2,17.2,1.2,21.6 v0.9c0,7.7,17,14,38,14c21,0,38-6.3,38-14v-0.9C77.2,17.2,67.9,11.3,55,9z M49.5,20.2l-6.3-6.7h-8.2l-6.3,6.7h-8.5 c0,0,9.3-11.1,10.6-12.6c1-1.2,1.9-1.6,3.2-1.6h10.2c1.3,0,2.2,0.4,3.2,1.6C48.7,9.1,58,20.2,58,20.2H49.5z"/>
+            <div ng-repeat="(key, definition) in rt.recordType.current_schema.definitions">
+                <div class="row">
+                    <div class="type">
+                        <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
+                            <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
                         </svg>
-                    </a>
-                    <a href="" role="button" class="edit">
-                        <p>Edit</p>
-                        <svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-                        viewBox="0 0 80 80" enable-background="new 0 0 80 80" xml:space="preserve">
-                            <g><path d="M71.8,8.2C64.6,1,59.2,2.1,59.2,2.1L33.9,27.3L5,56.2L0,80l23.8-5.1l28.9-28.9l25.3-25.3C77.9,20.8,79,15.4,71.8,8.2z M22.4,72.1l-8.1,1.7c-0.8-1.5-1.7-2.9-3.5-4.7c-1.7-1.7-3.2-2.7-4.7-3.5l1.8-8.1l2.3-2.3c0,0,4.4,0.1,9.4,5.1c5,5,5.1,9.4,5.1,9.4 L22.4,72.1z"/></g>
-                        </svg>
-                    </a>
+                        <a ui-sref="rt.schema-edit({uuid: rt.recordType.uuid })"><h4>{{ definition.title }}</h4></a>
+                        <a ng-click="rt.deleteSchema(key)" role="button" class="delete">
+                            <p>Trash</p>
+                            <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">
+                                <path d="M6.1,39l5.5,48.5c0.3,2.3,11.4,9.9,27.5,9.9c16.1,0,27.3-7.6,27.6-9.9L72.2,39c-8.4,4.7-21,6.9-33.1,6.9 C27.1,46,14.5,43.7,6.1,39z M55,9l-4.3-4.8c-1.7-2.4-3.5-2.8-7-2.8h-9.2c-3.5,0-5.3,0.4-7,2.8L23.4,9C10.5,11.3,1.2,17.2,1.2,21.6 v0.9c0,7.7,17,14,38,14c21,0,38-6.3,38-14v-0.9C77.2,17.2,67.9,11.3,55,9z M49.5,20.2l-6.3-6.7h-8.2l-6.3,6.7h-8.5 c0,0,9.3-11.1,10.6-12.6c1-1.2,1.9-1.6,3.2-1.6h10.2c1.3,0,2.2,0.4,3.2,1.6C48.7,9.1,58,20.2,58,20.2H49.5z"/>
+                            </svg>
+                        </a>
+                        <a ui-sref="rt.schema-edit({uuid: rt.recordType.uuid, schema: key})" role="button" class="edit">
+                            <p>Edit</p>
+                            <svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                            viewBox="0 0 80 80" enable-background="new 0 0 80 80" xml:space="preserve">
+                                <g><path d="M71.8,8.2C64.6,1,59.2,2.1,59.2,2.1L33.9,27.3L5,56.2L0,80l23.8-5.1l28.9-28.9l25.3-25.3C77.9,20.8,79,15.4,71.8,8.2z M22.4,72.1l-8.1,1.7c-0.8-1.5-1.7-2.9-3.5-4.7c-1.7-1.7-3.2-2.7-4.7-3.5l1.8-8.1l2.3-2.3c0,0,4.4,0.1,9.4,5.1c5,5,5.1,9.4,5.1,9.4 L22.4,72.1z"/></g>
+                            </svg>
+                        </a>
+                    </div>
                 </div>
+                <div class="dark-border"></div>
             </div>
-            <div class="dark-border"></div>
-
-            <div class="row">
-                <div class="type">
-                    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
-                        <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
-                    </svg>
-                    <a ui-sref="rt.schema-edit({uuid: 'abcd', schema: 'people'})"><h4>People</h4></a>
-                    <a href="" role="button" class="delete">
-                        <p>Trash</p>
-                        <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">
-                            <path d="M6.1,39l5.5,48.5c0.3,2.3,11.4,9.9,27.5,9.9c16.1,0,27.3-7.6,27.6-9.9L72.2,39c-8.4,4.7-21,6.9-33.1,6.9 C27.1,46,14.5,43.7,6.1,39z M55,9l-4.3-4.8c-1.7-2.4-3.5-2.8-7-2.8h-9.2c-3.5,0-5.3,0.4-7,2.8L23.4,9C10.5,11.3,1.2,17.2,1.2,21.6 v0.9c0,7.7,17,14,38,14c21,0,38-6.3,38-14v-0.9C77.2,17.2,67.9,11.3,55,9z M49.5,20.2l-6.3-6.7h-8.2l-6.3,6.7h-8.5 c0,0,9.3-11.1,10.6-12.6c1-1.2,1.9-1.6,3.2-1.6h10.2c1.3,0,2.2,0.4,3.2,1.6C48.7,9.1,58,20.2,58,20.2H49.5z"/>
-                        </svg>
-                    </a>
-                    <a href="" role="button" class="edit">
-                        <p>Edit</p>
-                        <svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-                        viewBox="0 0 80 80" enable-background="new 0 0 80 80" xml:space="preserve">
-                            <g><path d="M71.8,8.2C64.6,1,59.2,2.1,59.2,2.1L33.9,27.3L5,56.2L0,80l23.8-5.1l28.9-28.9l25.3-25.3C77.9,20.8,79,15.4,71.8,8.2z M22.4,72.1l-8.1,1.7c-0.8-1.5-1.7-2.9-3.5-4.7c-1.7-1.7-3.2-2.7-4.7-3.5l1.8-8.1l2.3-2.3c0,0,4.4,0.1,9.4,5.1c5,5,5.1,9.4,5.1,9.4 L22.4,72.1z"/></g>
-                        </svg>
-                    </a>
-                </div>
-            </div>
-            <div class="dark-border"></div>
-
-            <div class="row">
-                <div class="type">
-                    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
-                        <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
-                    </svg>
-                    <a ui-sref="rt.schema-edit({uuid: 'abcd', schema: 'road'})"><h4>Road Conditions</h4></a>
-                    <a href="" role="button" class="delete">
-                        <p>Trash</p>
-                        <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">
-                            <path d="M6.1,39l5.5,48.5c0.3,2.3,11.4,9.9,27.5,9.9c16.1,0,27.3-7.6,27.6-9.9L72.2,39c-8.4,4.7-21,6.9-33.1,6.9 C27.1,46,14.5,43.7,6.1,39z M55,9l-4.3-4.8c-1.7-2.4-3.5-2.8-7-2.8h-9.2c-3.5,0-5.3,0.4-7,2.8L23.4,9C10.5,11.3,1.2,17.2,1.2,21.6 v0.9c0,7.7,17,14,38,14c21,0,38-6.3,38-14v-0.9C77.2,17.2,67.9,11.3,55,9z M49.5,20.2l-6.3-6.7h-8.2l-6.3,6.7h-8.5 c0,0,9.3-11.1,10.6-12.6c1-1.2,1.9-1.6,3.2-1.6h10.2c1.3,0,2.2,0.4,3.2,1.6C48.7,9.1,58,20.2,58,20.2H49.5z"/>
-                        </svg>
-                    </a>
-                    <a href="" role="button" class="edit">
-                        <p>Edit</p>
-                        <svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-                        viewBox="0 0 80 80" enable-background="new 0 0 80 80" xml:space="preserve">
-                            <g><path d="M71.8,8.2C64.6,1,59.2,2.1,59.2,2.1L33.9,27.3L5,56.2L0,80l23.8-5.1l28.9-28.9l25.3-25.3C77.9,20.8,79,15.4,71.8,8.2z M22.4,72.1l-8.1,1.7c-0.8-1.5-1.7-2.9-3.5-4.7c-1.7-1.7-3.2-2.7-4.7-3.5l1.8-8.1l2.3-2.3c0,0,4.4,0.1,9.4,5.1c5,5,5.1,9.4,5.1,9.4 L22.4,72.1z"/></g>
-                        </svg>
-                    </a>
-                </div>
-            </div>
-            <div class="dark-border"></div>
         </div>
     </div>
 </div>

--- a/schema_editor/app/scripts/views/recordtype/module.js
+++ b/schema_editor/app/scripts/views/recordtype/module.js
@@ -26,7 +26,7 @@
             template: '<ase-rt-detail></ase-rt-detail>'
         });
         $stateProvider.state('rt.detail-edit', {
-            url: '/detail/:uuid/edit',
+            url: '/detail/:uuid/edit/:schema',
             template: '<ase-rt-detail-edit></ase-rt-detail-edit>'
         });
         $stateProvider.state('rt.detail-add', {

--- a/schema_editor/app/scripts/views/recordtype/module.js
+++ b/schema_editor/app/scripts/views/recordtype/module.js
@@ -25,6 +25,14 @@
             url: '/detail/:uuid',
             template: '<ase-rt-detail></ase-rt-detail>'
         });
+        $stateProvider.state('rt.detail-edit', {
+            url: '/detail/:uuid/edit',
+            template: '<ase-rt-detail-edit></ase-rt-detail-edit>'
+        });
+        $stateProvider.state('rt.detail-add', {
+            url: '/detail/:uuid/add',
+            template: '<ase-rt-detail-add></ase-rt-detail-add>'
+        });
         $stateProvider.state('rt.schema-add', {
             url: '/detail/:uuid/schema/add',
             template: '<ase-rt-schema-add></ase-rt-schema-add>'

--- a/schema_editor/app/scripts/views/recordtype/module.js
+++ b/schema_editor/app/scripts/views/recordtype/module.js
@@ -46,6 +46,7 @@
     angular.module('ase.views.recordtype', [
         'ui.router',
         'ase.config',
+        'ase.schemas',
         'ase.resources'
     ]).config(StateConfig);
 


### PR DESCRIPTION
Add/Edit/Delete related content views

Currently no way to access the `/recordtype/detail/:uuid` view from the UI, pending sidebar implementation. Can be navigated to directly via url bar if you create a recordtype and paste the proper UUID.

The related controllers feel kind of messy already, since the page technically isn't ready until both the RecordTypes and RecordSchemas promises resolve and there's nested function calls. All ears if you have ideas on a relatively easy way to refactor.