### PR TITLE
Fix form reinitialization from a destroyed editor instance

### DIFF
--- a/schema_editor/app/scripts/json-editor/json-editor-directive.js
+++ b/schema_editor/app/scripts/json-editor/json-editor-directive.js
@@ -20,8 +20,6 @@
 
     function JsonEditor() {
 
-        var editor = null;
-
         var module = {
             restrict: 'E',
             scope: {
@@ -34,6 +32,7 @@
         return module;
 
         function link(scope, element) {
+            var editor = null;
             var htmlElement = element[0];
             var changeRef = null;
 


### PR DESCRIPTION
The editor var was one scope too high. If a json-editor
directive instance was destroyed, the editor object was not.

Moving the editor var inside the link function ensures
it gets destroyed with everything else when a json-editor
directive instance goes out of scope.