### PR TITLE
Add multiple property for related content + more tests

### DIFF
--- a/schema_editor/app/scripts/views/recordtype/add-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/add-controller.js
@@ -31,6 +31,7 @@
             var schema = Schemas.JsonObject();
             var definition = Schemas.JsonObject();
             definition.description = 'Details for ' + recordType.label;
+            definition.multiple = false;
             /* jshint camelcase: false */
             definition.title = definition.plural_title = recordType.label + ' Details';
             /* jshint camelcase: true */

--- a/schema_editor/app/scripts/views/recordtype/related-add-edit-partial.html
+++ b/schema_editor/app/scripts/views/recordtype/related-add-edit-partial.html
@@ -43,6 +43,13 @@
                 <p ng-show="rtForm.description.$error.maxlength" class="help-block">Description too long</p>
             </div>
 
+            <div class="form-group col-sm-12">
+                <label for="multiple">Allow multiple?</label>
+                <input type="checkbox" name="multiple"
+                       ng-model="rtRelated.definition.multiple" id="multiple">
+                </input>
+            </div>
+
             <div class="save-area">
                 <button type="submit" class="btn btn-default" ng-disabled="rtForm.$invalid">
                     Save

--- a/schema_editor/app/scripts/views/recordtype/related-partial.html
+++ b/schema_editor/app/scripts/views/recordtype/related-partial.html
@@ -7,12 +7,18 @@
         </div>
         <div class="form-area-body">
             <div ng-repeat="(key, definition) in rt.currentSchema.schema.definitions">
-                <div class="row">
+                <div class="row" ng-class="{ 'multiple': definition.multiple }">
                     <div class="type">
                         <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
                             <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
                         </svg>
                         <a ui-sref="rt.related-edit({uuid: rt.recordType.uuid, schema: key})"><h4>{{ definition.title }}</h4></a>
+
+                        <!--Placeholder styling for denoting 'multiple'. A 'multiple' class has been added
+                            to the row for future styling work.
+                          -->
+                        <h5 ng-if="definition.multiple">[MULTIPLE]</h5>
+
                         <a ng-click="rt.deleteSchema(key)" role="button" class="delete">
                             <p>Trash</p>
                             <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">

--- a/schema_editor/test/mock/resources/resources-mocks.js
+++ b/schema_editor/test/mock/resources/resources-mocks.js
@@ -90,7 +90,8 @@
                     type: 'object',
                     title: 'Accident Details',
                     plural_title: 'Accident Details',
-                    description: 'Details for Accident'
+                    description: 'Details for Accident',
+                    multiple: false
                 }
             }
         });

--- a/schema_editor/test/mock/resources/resources-mocks.js
+++ b/schema_editor/test/mock/resources/resources-mocks.js
@@ -98,6 +98,7 @@
 
         var module = {
             GeographyResponse: GeographyResponse,
+            RecordSchema: RecordSchemaResponse.results[0],
             RecordSchemaResponse: RecordSchemaResponse,
             RecordSchemaRequest: RecordSchemaRequest,
             RecordType: RecordType,

--- a/schema_editor/test/spec/views/recordtype/add-controller.spec.js
+++ b/schema_editor/test/spec/views/recordtype/add-controller.spec.js
@@ -54,6 +54,7 @@ describe('ase.views.recordtype: AddController', function () {
                         title: 'Accident Details',
                         plural_title: 'Accident Details',
                         description: 'Details for Accident',
+                        multiple: false,
                         properties: {},
                         definitions: {}
                     }

--- a/schema_editor/test/spec/views/recordtype/related-add-controller.spec.js
+++ b/schema_editor/test/spec/views/recordtype/related-add-controller.spec.js
@@ -26,13 +26,12 @@ describe('ase.views.recordtype: RelatedAddController', function () {
     }));
 
     it('should add related content and switch view', function () {
-        /* jshint camelcase: false */
-        var recordType = {
-            label: 'Accident',
-            plural_label: 'Accidents',
-            description: 'An Accident'
-        };
+        var recordType = ResourcesMock.RecordType;
+        var recordTypeId = recordType.uuid;
+        var recordTypeIdUrl = new RegExp('api\/recordtypes\/' + recordTypeId);
+        $httpBackend.expectGET(recordTypeIdUrl).respond(200, recordType);
 
+        /* jshint camelcase: false */
         var recordSchema = {
             schema: {
                 type: 'object',
@@ -50,31 +49,34 @@ describe('ase.views.recordtype: RelatedAddController', function () {
                         properties: {},
                         definitions: {}
                     }
-                }
+                },
+                recordType: recordType.uuid
             }
         };
         /* jshint camelcase: true */
 
-        var recordTypeUrl = /\/api\/recordtypes/;
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordType);
-
         var recordSchemaUrl = /\/api\/recordschemas\//;
         $httpBackend.expectPOST(recordSchemaUrl, recordSchema).respond(201);
 
-        var recordSchemaByIdUrl = /\/api\/recordschemas\/.*\//;
-        $httpBackend.expectGET(recordSchemaByIdUrl).respond(200, ResourcesMock.RecordType);
+        var recordSchemaId = ResourcesMock.RecordSchema.uuid;
+        var recordSchemaIdUrl = new RegExp('api\/recordschemas\/' + recordSchemaId);
+        $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 
         spyOn(StateMock, 'go');
 
         Controller = $controller('RTRelatedAddController', {
             $scope: $scope,
+            $stateParams: { uuid: recordTypeId },
             $state: StateMock
         });
+
         $scope.$apply();
 
-        Controller.recordType = recordType;
+        Controller.recordType = recordType.uuid;
         Controller.currentSchema = recordSchema;
         Controller.submitForm();
+
+        $scope.$apply();
 
         $httpBackend.flush();
         $httpBackend.verifyNoOutstandingRequest();

--- a/schema_editor/test/spec/views/recordtype/related-add-controller.spec.js
+++ b/schema_editor/test/spec/views/recordtype/related-add-controller.spec.js
@@ -11,6 +11,13 @@ describe('ase.views.recordtype: RelatedAddController', function () {
     var $scope;
     var Controller;
     var ResourcesMock;
+    var recordSchema;
+    var recordSchemaId;
+    var recordSchemaIdUrl;
+    var recordSchemaUrl;
+    var recordType;
+    var recordTypeId;
+    var recordTypeIdUrl;
     var StateMock = {
         go: angular.noop
     };
@@ -23,16 +30,9 @@ describe('ase.views.recordtype: RelatedAddController', function () {
         $rootScope = _$rootScope_;
         $scope = $rootScope.$new();
         ResourcesMock = _ResourcesMock_;
-    }));
-
-    it('should add related content and switch view', function () {
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
-        var recordTypeIdUrl = new RegExp('api\/recordtypes\/' + recordTypeId);
-        $httpBackend.expectGET(recordTypeIdUrl).respond(200, recordType);
 
         /* jshint camelcase: false */
-        var recordSchema = {
+        recordSchema = {
             schema: {
                 type: 'object',
                 title: '',
@@ -50,16 +50,45 @@ describe('ase.views.recordtype: RelatedAddController', function () {
                         definitions: {}
                     }
                 },
-                recordType: recordType.uuid
+                recordType: ResourcesMock.RecordType.uuid
             }
         };
         /* jshint camelcase: true */
 
-        var recordSchemaUrl = /\/api\/recordschemas\//;
-        $httpBackend.expectPOST(recordSchemaUrl, recordSchema).respond(201);
+        recordType = ResourcesMock.RecordType;
+        recordTypeId = recordType.uuid;
+        recordTypeIdUrl = new RegExp('api\/recordtypes\/' + recordTypeId);
+        recordSchemaId = ResourcesMock.RecordSchema.uuid;
+        recordSchemaIdUrl = new RegExp('api\/recordschemas\/' + recordSchemaId);
+        recordSchemaUrl = /\/api\/recordschemas\//;
+    }));
 
-        var recordSchemaId = ResourcesMock.RecordSchema.uuid;
-        var recordSchemaIdUrl = new RegExp('api\/recordschemas\/' + recordSchemaId);
+    it('should add related content', function () {
+        $httpBackend.expectGET(recordTypeIdUrl).respond(200, recordType);
+        $httpBackend.expectPOST(recordSchemaUrl, recordSchema).respond(201);
+        $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
+
+        Controller = $controller('RTRelatedAddController', {
+            $scope: $scope,
+            $stateParams: { uuid: recordTypeId },
+            $state: StateMock
+        });
+
+        $scope.$apply();
+
+        Controller.recordType = recordType.uuid;
+        Controller.currentSchema = recordSchema;
+        Controller.submitForm();
+
+        $scope.$apply();
+
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('should switch view', function () {
+        $httpBackend.expectGET(recordTypeIdUrl).respond(200, recordType);
+        $httpBackend.expectPOST(recordSchemaUrl, recordSchema).respond(201);
         $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 
         spyOn(StateMock, 'go');

--- a/schema_editor/test/spec/views/recordtype/related-add-controller.spec.js
+++ b/schema_editor/test/spec/views/recordtype/related-add-controller.spec.js
@@ -1,0 +1,84 @@
+'use strict';
+
+describe('ase.views.recordtype: RelatedAddController', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('ase.views.recordtype'));
+
+    var $controller;
+    var $httpBackend;
+    var $rootScope;
+    var $scope;
+    var Controller;
+    var ResourcesMock;
+    var StateMock = {
+        go: angular.noop
+    };
+
+    // Initialize the controller and a mock scope
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_,
+                                _ResourcesMock_) {
+        $controller = _$controller_;
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        ResourcesMock = _ResourcesMock_;
+    }));
+
+    it('should add related content and switch view', function () {
+        /* jshint camelcase: false */
+        var recordType = {
+            label: 'Accident',
+            plural_label: 'Accidents',
+            description: 'An Accident'
+        };
+
+        var recordSchema = {
+            schema: {
+                type: 'object',
+                title: '',
+                plural_title: '',
+                description: '',
+                properties: {},
+                definitions: {
+                    'Accident Details': {
+                        type: 'object',
+                        title: 'Accident Details',
+                        plural_title: 'Accident Details',
+                        description: 'Details for Accident',
+                        multiple: false,
+                        properties: {},
+                        definitions: {}
+                    }
+                }
+            }
+        };
+        /* jshint camelcase: true */
+
+        var recordTypeUrl = /\/api\/recordtypes/;
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordType);
+
+        var recordSchemaUrl = /\/api\/recordschemas\//;
+        $httpBackend.expectPOST(recordSchemaUrl, recordSchema).respond(201);
+
+        var recordSchemaByIdUrl = /\/api\/recordschemas\/.*\//;
+        $httpBackend.expectGET(recordSchemaByIdUrl).respond(200, ResourcesMock.RecordType);
+
+        spyOn(StateMock, 'go');
+
+        Controller = $controller('RTRelatedAddController', {
+            $scope: $scope,
+            $state: StateMock
+        });
+        $scope.$apply();
+
+        Controller.recordType = recordType;
+        Controller.currentSchema = recordSchema;
+        Controller.submitForm();
+
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+
+        expect(StateMock.go).toHaveBeenCalled();
+    });
+});

--- a/schema_editor/test/spec/views/recordtype/related-add-directive.spec.js
+++ b/schema_editor/test/spec/views/recordtype/related-add-directive.spec.js
@@ -2,6 +2,12 @@
 
 describe('ase.views.recordtype: RTRelatedAdd', function () {
 
+    // Need to override the controller, mostly because it relies on $stateParams being set,
+    // but also because we already have tests for the controller, and don't need extra logic here
+    beforeEach(module('ase', function ($controllerProvider) {
+        $controllerProvider.register('RTRelatedAddController', angular.noop);
+    }));
+
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('ase.templates'));
     beforeEach(module('ase.views.recordtype'));
@@ -19,17 +25,30 @@ describe('ase.views.recordtype: RTRelatedAdd', function () {
         $rootScope = _$rootScope_;
         RecordTypes = _RecordTypes_;
         ResourcesMock = _ResourcesMock_;
+
     }));
 
-    it('should load directive', function () {
-        var requestUrl = /\/api\/recordtypes/;
-        $httpBackend.expectGET(requestUrl).respond(200, ResourcesMock.RecordTypeResponse);
-
+    it('should allow adding new related type', function () {
         var scope = $rootScope.$new();
         var element = $compile('<ase-rt-related-add></ase-rt-related-add>')(scope);
         $rootScope.$apply();
 
-        // 'Save' and 'Cancel' buttons
+        // Check for existence of 'Save' and 'Cancel' buttons
         expect(element.find('button').length).toEqual(2);
+        var saveButton = element.find('button:submit');
+
+        // Helper for testing whether or not the save button is disabled
+        var checkSaveButtonDisabled = function(disabled) {
+            expect(saveButton.prop('disabled')).toBe(disabled);
+        };
+
+        // Save button should be disabled until all the required fields are entered
+        checkSaveButtonDisabled(true);
+        element.find('#single-title').val('Vehicle').change();
+        checkSaveButtonDisabled(true);
+        element.find('#plural-title').val('Vehicles').change();
+        checkSaveButtonDisabled(true);
+        element.find('#description').val('A vehicle').change();
+        checkSaveButtonDisabled(false);
     });
 });

--- a/schema_editor/test/spec/views/recordtype/related-controller.spec.js
+++ b/schema_editor/test/spec/views/recordtype/related-controller.spec.js
@@ -1,0 +1,46 @@
+'use strict';
+
+describe('ase.views.recordtype: RelatedController', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('ase.views.recordtype'));
+
+    var $controller;
+    var $httpBackend;
+    var $rootScope;
+    var $scope;
+    var Controller;
+    var ResourcesMock;
+
+    // Initialize the controller and a mock scope
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_,
+                                _ResourcesMock_) {
+        $controller = _$controller_;
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        ResourcesMock = _ResourcesMock_;
+    }));
+
+    it('should request proper record type and record schema', function () {
+        var recordType = ResourcesMock.RecordType;
+        var recordTypeId = recordType.uuid;
+        var recordTypeIdUrl = new RegExp('api\/recordtypes\/' + recordTypeId);
+        $httpBackend.expectGET(recordTypeIdUrl).respond(200, recordType);
+
+        var recordSchema = ResourcesMock.RecordSchema;
+        var recordSchemaId = recordSchema.uuid;
+        var recordSchemaIdUrl = new RegExp('api\/recordschemas\/' + recordSchemaId);
+        $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
+
+        Controller = $controller('RTRelatedController', {
+            $scope: $scope,
+            $stateParams: { uuid: recordTypeId }
+        });
+
+        $scope.$apply();
+
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+});

--- a/schema_editor/test/spec/views/recordtype/related-directive.spec.js
+++ b/schema_editor/test/spec/views/recordtype/related-directive.spec.js
@@ -1,6 +1,10 @@
 'use strict';
 
-describe('ase.views.recordtype: RTRelated', function () {
+describe('ase.views.recordtype: RTRelatedAdd', function () {
+
+    beforeEach(module('ase', function ($controllerProvider) {
+        $controllerProvider.register('RTRelatedController', angular.noop);
+    }));
 
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('ase.templates'));
@@ -9,27 +13,39 @@ describe('ase.views.recordtype: RTRelated', function () {
     var $compile;
     var $httpBackend;
     var $rootScope;
-    var RecordTypes;
     var ResourcesMock;
 
     beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_,
-                                _RecordTypes_, _ResourcesMock_) {
+                                _ResourcesMock_) {
         $compile = _$compile_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
-        RecordTypes = _RecordTypes_;
         ResourcesMock = _ResourcesMock_;
+
     }));
 
-    it('should load directive', function () {
-        var requestUrl = /\/api\/recordtypes/;
-        $httpBackend.expectGET(requestUrl).respond(200, ResourcesMock.RecordTypeResponse);
-
+    it('should load directive and reflect multiple rows', function () {
         var scope = $rootScope.$new();
+
         var element = $compile('<ase-rt-related></ase-rt-related>')(scope);
         $rootScope.$apply();
 
-        // 'Add new content' button
+        angular.extend(scope, {
+            rt: {
+                currentSchema: ResourcesMock.RecordSchema
+            }
+        });
+        $rootScope.$apply();
+
+        // Check for existence of 'Add new content' button
         expect(element.find('button').length).toEqual(1);
+
+        // There shouldn't be any rows denoted as 'multiple'
+        expect(element.find('.multiple').length).toEqual(0);
+
+        // Setting a related type as multiple should be reflected in the html
+        scope.rt.currentSchema.schema.definitions.Firearm.multiple = true;
+        $rootScope.$apply();
+        expect(element.find('.multiple').length).toEqual(1);
     });
 });

--- a/schema_editor/test/spec/views/recordtype/related-directive.spec.js
+++ b/schema_editor/test/spec/views/recordtype/related-directive.spec.js
@@ -24,7 +24,7 @@ describe('ase.views.recordtype: RTRelatedAdd', function () {
 
     }));
 
-    it('should load directive and reflect multiple rows', function () {
+    it('should load directive', function () {
         var scope = $rootScope.$new();
 
         var element = $compile('<ase-rt-related></ase-rt-related>')(scope);
@@ -39,6 +39,20 @@ describe('ase.views.recordtype: RTRelatedAdd', function () {
 
         // Check for existence of 'Add new content' button
         expect(element.find('button').length).toEqual(1);
+    });
+
+    it('should reflect multiple rows', function () {
+        var scope = $rootScope.$new();
+
+        var element = $compile('<ase-rt-related></ase-rt-related>')(scope);
+        $rootScope.$apply();
+
+        angular.extend(scope, {
+            rt: {
+                currentSchema: ResourcesMock.RecordSchema
+            }
+        });
+        $rootScope.$apply();
 
         // There shouldn't be any rows denoted as 'multiple'
         expect(element.find('.multiple').length).toEqual(0);


### PR DESCRIPTION
This doesn't modify the schema to use an array vs. object; there is a separate task for that. This just allows setting a related type as multiple and having it reflected in the list view. Also fleshed out some tests a bit more.