### PR TITLE
Notification Module

### DIFF
--- a/schema_editor/app/index.html
+++ b/schema_editor/app/index.html
@@ -69,6 +69,10 @@
         <script src="scripts/resources/recordtypes-service.js"></script>
         <script src="scripts/json-editor/module.js"></script>
         <script src="scripts/json-editor/json-editor-directive.js"></script>
+        <script src="scripts/notifications/module.js"></script>
+        <script src="scripts/notifications/notifications-service.js"></script>
+        <script src="scripts/notifications/notifications-directive.js"></script>
+        <script src="scripts/notifications/notifications-controller.js"></script>
         <script src="scripts/resources/geography-service.js"></script>
         <script src="scripts/views/sidebar/module.js"></script>
         <script src="scripts/views/sidebar/cancel-bubble-directive.js"></script>

--- a/schema_editor/app/scripts/app.js
+++ b/schema_editor/app/scripts/app.js
@@ -24,6 +24,7 @@
      */
     angular.module('ase', [
         'ase.config',
+        'ase.notifications',
         'ase.views.geography',
         'ase.views.recordtype',
         'ase.resources'

--- a/schema_editor/app/scripts/notifications/README.md
+++ b/schema_editor/app/scripts/notifications/README.md
@@ -1,0 +1,18 @@
+# Notifications module
+
+Allows the broadcast and display of global notifications.
+
+## Usage
+
+1. Place a `<ase-notifications></ase-notifications` tag wherever you want notifications
+to appear. Remember that all notifications are global so this tag may display notifications
+from other parts of the app.
+2. Require the `Notifications` module and then call `Notifications.show(opts)` where opts
+is an Object with options for the new alert (info / warning / error status, timeout, etc.).
+Default values are generated in notifications-service.js for any missing options.
+
+## Limitations
+
+- Only one notification may be active at a time; subsequent notifications will override it.
+- Different notifications may not be sent to different instances of the directive; all
+notifications are global.

--- a/schema_editor/app/scripts/notifications/module.js
+++ b/schema_editor/app/scripts/notifications/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('ase.notifications', []);
+})();

--- a/schema_editor/app/scripts/notifications/notifications-controller.js
+++ b/schema_editor/app/scripts/notifications/notifications-controller.js
@@ -1,0 +1,44 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function NotificationsController($scope, $timeout, Notifications) {
+        var ctl = this;
+        var alertTimeout = null;
+        initialize();
+
+        function initialize() {
+            ctl.active = false;
+            ctl.alert = {};
+            ctl.alertHeight = 0;
+            ctl.hideAlert = hideAlert;
+
+            $scope.$on('ase.notifications.hide', hideAlert);
+            $scope.$on('ase.notifications.show', showAlert);
+
+            function showAlert(event, alert) {
+                ctl.alert = alert;
+                ctl.active = true;
+                if (alert.timeout) {
+                    alertTimeout = $timeout(hideAlert, alert.timeout);
+                }
+            }
+
+            function hideAlert() {
+                ctl.active = false;
+                if (alertTimeout) {
+                    $timeout.cancel(alertTimeout);
+                    alertTimeout = null;
+                }
+            }
+
+            if (Notifications.activeAlert()) {
+                showAlert(null, Notifications.activeAlert());
+            }
+        }
+    }
+
+    angular.module('ase.notifications')
+    .controller('NotificationsController', NotificationsController);
+
+})();

--- a/schema_editor/app/scripts/notifications/notifications-directive.js
+++ b/schema_editor/app/scripts/notifications/notifications-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Notifications() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/notifications/notifications-partial.html',
+            controller: 'NotificationsController',
+            controllerAs: 'ntf',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.notifications')
+    .directive('aseNotifications', Notifications);
+
+})();

--- a/schema_editor/app/scripts/notifications/notifications-partial.html
+++ b/schema_editor/app/scripts/notifications/notifications-partial.html
@@ -1,0 +1,13 @@
+<div class="notifications alert" ng-hide="!ntf.active" ng-class="ntf.alert.displayClass">
+  <table>
+    <tr>
+      <td><span class="glyphicon"
+          ng-class="ntf.alert.imageClass"
+          ng-if="ntf.alert.imageClass"></span></td>
+      <td>{{ ntf.alert.text }}</td>
+      <td><span class="glyphicon glyphicon-remove pull-right"
+          ng-if="ntf.alert.closeButton"
+          ng-click="ntf.hideAlert()"></span></td>
+    </tr>
+  </table>
+</div>

--- a/schema_editor/app/scripts/notifications/notifications-service.js
+++ b/schema_editor/app/scripts/notifications/notifications-service.js
@@ -52,9 +52,7 @@
             };
             var opts = angular.extend({}, defaults, options);
             active = opts;
-            timeoutId = $timeout(function () {
-                $rootScope.$broadcast('ase.notifications.show', opts);
-            });
+            $rootScope.$broadcast('ase.notifications.show', opts);
         }
     }
 

--- a/schema_editor/app/scripts/notifications/notifications-service.js
+++ b/schema_editor/app/scripts/notifications/notifications-service.js
@@ -1,0 +1,64 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Notifications($rootScope, $timeout) {
+
+        var timeoutId = null;
+        var active = null;
+
+        var module = {
+            hide: hide,
+            show: show,
+            activeAlert: activeAlert
+        };
+
+        return module;
+
+        /**
+         * Provide the currently active alert.
+         * Allows directives to display the active alert even if they miss the relevant event
+         * @return the currently active alert
+         */
+        function activeAlert() {
+            return active;
+        }
+
+        /**
+         * Hide a global notification
+         * @return Broadcasts ase.notifications.hide on $rootScope
+         */
+        function hide() {
+            if (timeoutId) {
+                $timeout.cancel(timeoutId);
+                timeoutId = null;
+            }
+            active = null;
+            $rootScope.$broadcast('ase.notifications.hide');
+        }
+
+        /**
+         * Show a global notification, overridding the defaults defined in the function
+         * @param  {object} options Override the defaults with this config
+         * @return Broadcasts ase.notifications.show on $rootScope
+         */
+        function show(options) {
+            var defaults = {
+                timeout: 0,
+                closeButton: true,
+                text: '',
+                imageClass: 'glyphicon-warning-sign',
+                displayClass: 'alert-info'
+            };
+            var opts = angular.extend({}, defaults, options);
+            active = opts;
+            timeoutId = $timeout(function () {
+                $rootScope.$broadcast('ase.notifications.show', opts);
+            });
+        }
+    }
+
+    angular.module('ase.notifications')
+    .factory('Notifications', Notifications);
+
+})();

--- a/schema_editor/app/scripts/views/geography/add-controller.js
+++ b/schema_editor/app/scripts/views/geography/add-controller.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /* ngInject */
-    function GeographyAddController($state, Geography) {
+    function GeographyAddController($state, Geography, Notifications) {
         var ctl = this;
         initialize();
 
@@ -11,7 +11,8 @@
          */
         function geoUploadErrorCB(data, status) {
             ctl.uploadState = 'upload-error';
-            ctl.errorMessage = Geography.errorMessage(status);
+            Notifications.show({text: Geography.errorMessage(status),
+                                displayClass: 'alert-danger'});
         }
 
         /**
@@ -24,20 +25,24 @@
                     ctl.serverGeoFields = data;
                     ctl.fileUploaded = true;
                     ctl.uploadState = 'upload-success';
+                    Notifications.show({text: 'Geography upload successful! Select a primary field below.',
+                                        displayClass: 'alert-success'});
                     /* jshint camelcase: false */
                     ctl.fields = data.data_fields;
                     /* jshint camelcase: true */
                 } else if (data.status === 'ERROR') {
                     ctl.uploadState = 'upload-error';
-                    ctl.errorMessage = 'Error - check that your upload is a valid shapefile';
+                    Notifications.show({text: 'Error - check that your upload is a valid shapefile',
+                                        displayClass: 'alert-danger'});
                 }
             }
             ctl.uploadState = 'requesting';
+            Notifications.show({text: 'Loading...'});
             Geography.create(ctl.files,
-                              ctl.geoFields.label,
-                              ctl.geoFields.color,
-                              successCB,
-                              geoUploadErrorCB);
+                             ctl.geoFields.label,
+                             ctl.geoFields.color,
+                             successCB,
+                             geoUploadErrorCB);
         };
 
         /**
@@ -51,8 +56,11 @@
             /* jshint camelcase: true */
             var updateRequest = geo.$update();
             ctl.uploadState = 'requesting';
+            Notifications.show({text: 'Loading...'});
             updateRequest.then(function(res) {
                 ctl.uploadState = 'update-success';
+                Notifications.show({text: 'Geography update successful!',
+                                    displayClass: 'alert-success'});
                 ctl.serverSays = res;
             }, geoUploadErrorCB);
         };
@@ -78,6 +86,9 @@
         function initialize() {
             ctl.fileUploaded = false;
             ctl.uploadState = '';
+            Notifications.show({text: 'Upload your zipped shapefile; once uploaded, ' +
+                                      'select a primary field for display',
+                                displayClass: 'alert-info'});
             ctl.files = [];
             ctl.colors = ['Red', 'Blue', 'Green'];
         }

--- a/schema_editor/app/scripts/views/geography/add-partial.html
+++ b/schema_editor/app/scripts/views/geography/add-partial.html
@@ -1,33 +1,9 @@
 <div class="form-area">
     <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
         <div class="form-area-heading">
             <h2>Add New Geography</h2>
             <div class="content-border"></div>
-        </div>
-        <div ng-switch="geoAdd.uploadState">
-            <div class="alert alert-info" role="alert" ng-switch-default>
-                <span class="sr-only">Info:</span>
-                Upload your zipped shapefile; once uploaded, select a primary field for display
-            </div>
-            <div class="alert alert-info" ng-switch-when="requesting">
-                <span class="sr-only">Loading...:</span>
-                Loading...
-            </div>
-            <div class="alert alert-danger" role="alert" ng-switch-when="upload-error">
-                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-                <span class="sr-only">Error:</span>
-                {{ geoAdd.errorMessage }}
-            </div>
-            <div class="alert alert-success" role="alert" ng-switch-when="upload-success">
-                <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-                <span class="sr-only">Success:</span>
-                Geography upload successful! Select a primary field below.
-            </div>
-            <div class="alert alert-success" role="alert" ng-switch-when="update-success">
-                <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-                <span class="sr-only">Success:</span>
-                Geography update successful!
-            </div>
         </div>
         <form name="geoAddForm" ng-submit="" novalidate>
             <div class="form-group col-sm-12">

--- a/schema_editor/app/scripts/views/geography/edit-partial.html
+++ b/schema_editor/app/scripts/views/geography/edit-partial.html
@@ -1,5 +1,6 @@
 <div class="form-area">
     <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
         <div class="form-area-heading">
             <h2>Edit Geography</h2>
             <div class="content-border"></div>

--- a/schema_editor/app/scripts/views/geography/list-partial.html
+++ b/schema_editor/app/scripts/views/geography/list-partial.html
@@ -1,5 +1,6 @@
 <div class="form-area">
     <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
         <div class="form-area-heading">
             <h2>Geography Files</h2>
             <button type="button" class="btn btn-default" ui-sref="geo.add">Add new Shapefile</button>

--- a/schema_editor/app/scripts/views/geography/module.js
+++ b/schema_editor/app/scripts/views/geography/module.js
@@ -27,6 +27,7 @@
         'ui.router',
         'ase.config',
         'ngFileUpload',
+        'ase.notifications',
         'ase.views.sidebar',
         'ase.resources'
     ]).config(StateConfig);

--- a/schema_editor/app/scripts/views/recordtype/module.js
+++ b/schema_editor/app/scripts/views/recordtype/module.js
@@ -44,6 +44,7 @@
         'ui.bootstrap',
         'json-editor',
         'ase.config',
+        'ase.notifications',
         'ase.utils',
         'ase.schemas',
         'ase.resources'

--- a/schema_editor/app/styles/main.scss
+++ b/schema_editor/app/styles/main.scss
@@ -10,3 +10,4 @@ $icon-font-path: "../bower_components/bootstrap-sass-official/assets/fonts/boots
 @import "partials/field";
 @import "partials/types";
 @import "partials/add-new";
+@import "partials/notifications";

--- a/schema_editor/app/styles/partials/_notifications.scss
+++ b/schema_editor/app/styles/partials/_notifications.scss
@@ -1,0 +1,3 @@
+.glyphicon-remove {
+	cursor: pointer;
+}

--- a/schema_editor/test/karma.conf.js
+++ b/schema_editor/test/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function(config) {
     ],
 
     preprocessors: {
-      "**/*.html": 'ng-html2js'
+      '**/*.html': 'ng-html2js'
     },
 
     // list of files / patterns to load in the browser
@@ -52,10 +52,12 @@ module.exports = function(config) {
       'app/scripts/resources/**.js',
       'app/scripts/json-editor/module.js',
       'app/scripts/json-editor/**.js',
+      'app/scripts/notifications/module.js',
+      'app/scripts/notifications/**.js',
       'app/scripts/views/sidebar/module.js',
       'app/scripts/views/sidebar/**.js',
-      "app/scripts/views/geography/module.js",
-      "app/scripts/views/geography/**.js",
+      'app/scripts/views/geography/module.js',
+      'app/scripts/views/geography/**.js',
       'app/scripts/views/recordtype/module.js',
       'app/scripts/views/recordtype/**.js',
       'test/mock/**/*.js',
@@ -92,8 +94,8 @@ module.exports = function(config) {
     // Load all templates into $templateCache. They can be imported with:
     //   beforeEach(module('ase.templates'));
     ngHtml2JsPreprocessor: {
-      stripPrefix: "app/",
-      moduleName: "ase.templates"
+      stripPrefix: 'app/',
+      moduleName: 'ase.templates'
     },
 
     // Continuous Integration mode

--- a/schema_editor/test/spec/notifications/notifications-controller.spec.js
+++ b/schema_editor/test/spec/notifications/notifications-controller.spec.js
@@ -1,0 +1,64 @@
+'use strict';
+
+describe('ase.notifications: NotificationsController', function () {
+    beforeEach(module('ase.notifications'));
+
+    var $controller;
+    var $rootScope;
+    var $scope;
+    var $timeout;
+    var Controller;
+
+    // Initialize the controller and a mock scope
+    beforeEach(inject(function (_$controller_, _$rootScope_, _$timeout_) {
+        $controller = _$controller_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        $timeout = _$timeout_;
+    }));
+
+    it('should set active to true when ase.notifications.show is broadcast', function () {
+        Controller = $controller('NotificationsController', {
+            $scope: $scope
+        });
+        $scope.$apply();
+        expect(Controller.active).toBe(false);
+        $rootScope.$broadcast('ase.notifications.show', {});
+        expect(Controller.active).toBe(true);
+    });
+
+    it('should set active to false when ase.notifications.hide is broadcast', function () {
+        Controller = $controller('NotificationsController', {
+            $scope: $scope
+        });
+        $scope.$apply();
+        expect(Controller.active).toBe(false);
+        Controller.active = true;
+        expect(Controller.active).toBe(true);
+        $rootScope.$broadcast('ase.notifications.hide', {});
+        expect(Controller.active).toBe(false);
+    });
+
+    it('should save the alert options sent to it', function () {
+        Controller = $controller('NotificationsController', {
+            $scope: $scope
+        });
+        $scope.$apply();
+        $rootScope.$broadcast('ase.notifications.show', {customAttribute: 'Borgle'});
+        expect(Controller.alert).toBeDefined();
+        expect(Controller.alert.customAttribute).toBeDefined();
+        expect(Controller.alert.customAttribute).toBe('Borgle');
+    });
+
+    it('The alert should be hidden after a timeout if the timeout parameter is set', function () {
+        Controller = $controller('NotificationsController', {
+            $scope: $scope
+        });
+        $scope.$apply();
+        $rootScope.$broadcast('ase.notifications.show', { timeout: 1000 });
+        expect(Controller.active).toBe(true);
+        $timeout(function() {
+            expect(Controller.active).toBe(false);
+        }, 2000);
+    });
+});

--- a/schema_editor/test/spec/notifications/notifications-directive.spec.js
+++ b/schema_editor/test/spec/notifications/notifications-directive.spec.js
@@ -1,0 +1,23 @@
+'use strict';
+
+describe('ase.notifications: Directive', function () {
+    beforeEach(module('ase.templates'));
+    beforeEach(module('ase.notifications'));
+
+    var $compile;
+    var $rootScope;
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+    }));
+
+    it('should load directive', function () {
+        var scope = $rootScope.$new();
+        var element = $compile('<ase-notifications></ase-notifications>')(scope);
+        $rootScope.$apply();
+
+        expect(element.find('table').length).toEqual(1);
+    });
+
+});

--- a/schema_editor/test/spec/notifications/notifications-service.spec.js
+++ b/schema_editor/test/spec/notifications/notifications-service.spec.js
@@ -1,0 +1,47 @@
+'use strict';
+
+describe('ase.notifications: Notifications', function () {
+
+    beforeEach(module('ase.notifications'));
+
+    var Notifications;
+    var $rootScope;
+
+    beforeEach(inject(function (_$rootScope_, _Notifications_) {
+        $rootScope = _$rootScope_;
+        Notifications = _Notifications_;
+    }));
+
+    it('should store and clear the most recently created alert', function () {
+        expect(Notifications.activeAlert()).toBeNull();
+        Notifications.show({customAttribute: 'Borgle'});
+        var activeAlert = Notifications.activeAlert();
+        expect(activeAlert).toBeDefined();
+        expect(activeAlert).not.toBeNull();
+        expect(activeAlert.customAttribute).toBeDefined();
+        expect(activeAlert.customAttribute).toBe('Borgle');
+        Notifications.hide();
+        expect(Notifications.activeAlert()).toBeNull();
+    });
+
+    it('should emit the correct events when show / hide is called', function () {
+        spyOn($rootScope, '$broadcast');
+        Notifications.show({});
+        expect($rootScope.$broadcast).toHaveBeenCalledWith('ase.notifications.show',
+            jasmine.any(Object) // Don't check the default values here.
+        );
+        Notifications.hide();
+        expect($rootScope.$broadcast).toHaveBeenCalledWith('ase.notifications.hide');
+    });
+
+    it('should set sane defaults on newly created alerts', function () {
+        Notifications.show({});
+        var created = Notifications.activeAlert();
+        expect(created.timeout).toBe(0);
+        expect(created.closeButton).toBe(true);
+        expect(created.text).toBe('');
+        expect(created.imageClass).toBe('glyphicon-warning-sign');
+        expect(created.displayClass).toBe('alert-info');
+    });
+});
+


### PR DESCRIPTION
Creates a module for broadcasting global notifications, and updates the Geography page to use these notifications.

Currently, there is no notifications directive in the root partial because I had trouble with positioning and styling, so I added it into the Geography partial instead. However, we will likely want to create one so we don't have to put `<ase-notifications></ase-notifications>` every time we want to show notifications.