### PR TITLE
Serialize schema form

### DIFF
--- a/schema_editor/app/scripts/json-editor/json-editor-directive.js
+++ b/schema_editor/app/scripts/json-editor/json-editor-directive.js
@@ -63,7 +63,8 @@
                 }
                 changeRef = editor.on('change', function () {
                     var editorData = editor.getValue();
-                    scope.onDataChange()(editorData);
+                    var errors = editor.validate();
+                    scope.onDataChange()(editorData, errors);
                 });
             });
         }

--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -23,16 +23,30 @@
         var module = {
             JsonObject: jsonObject,
             FieldTypes: {
-                'text': 'Text Field',
-                'selectlist': 'Select List',
-                'image': 'Image Uploader'
+                'text': {
+                    label: 'Text Field',
+                    jsonType: 'string',
+                    create: textField
+                },
+                'selectlist': {
+                    label: 'Select List',
+                    jsonType: 'string',
+                    create: selectList,
+                },
+                'image': {
+                    label: 'Image Uploader',
+                    jsonType: 'string',
+                    create: imageUploader
+                }
             },
             Fields: {
                 TextField: textField,
                 SelectList: selectList,
                 ImageUploader: imageUploader
             },
-            fieldFromKey: fieldFromKey
+            fieldFromKey: fieldFromKey,
+            definitionFromSchemaFormData: definitionFromSchemaFormData,
+            encodeJSONPointer: encodeJSONPointer
         };
         return module;
 
@@ -45,21 +59,76 @@
          */
         function fieldFromKey(fieldKey, fieldOptions) {
             fieldOptions = fieldOptions || {};
-            var field = null;
-            switch (fieldKey) {
-                case 'text':
-                    field = textField(fieldOptions);
-                    break;
-                case 'selectlist':
-                    field = selectList(fieldOptions);
-                    break;
-                case 'image':
-                    field = imageUploader(fieldOptions);
-                    break;
-                default:
-                    throw 'key must be one of Schemas.FieldTypes';
+            if (module.FieldTypes[fieldKey] === undefined) {
+                throw 'key must be one of Schemas.FieldTypes';
             }
-            return field;
+            return module.FieldTypes[fieldKey].create(fieldOptions);
+        }
+
+        /**
+         * Encode a string so that it complies with the JSON Pointer spec
+         * http://tools.ietf.org/html/draft-pbryan-zyp-json-pointer-02
+         * This is what is used in $ref to specify sub-schema paths
+         * @param {string} str
+         * @return {string} Currently just returns encodeURIComponent(string)
+         */
+        function encodeJSONPointer(str) {
+            // TODO: Technically, we should be doing this:
+            // return encodeURIComponent(str);
+            // But json-editor doesn't seem to support that properly.
+            return str;
+        }
+
+        /**
+         * Converts part of the output of a Schema Entry Form (data about fields)
+         * into a snippet designed to be inserted into the 'properties' key of a Data Form Schema
+         * which would be used for data entry / editing. Does not perform validation.
+         * @param {object} fieldData The value of one Schema Entry Form field, specifying required,
+         *      searchable, possible values, etc.
+         * @return {object} A snippet designed to be inserted into the 'properties' of a Data Form
+         *      Schema
+         */
+        // TODO: This monolithic function isn't great; investigate more modular options
+        function _propertyFromSchemaFieldData(fieldData) {
+            var propertyDefinition = {};
+            propertyDefinition.type = module.FieldTypes[fieldData.fieldType].jsonType;
+
+            if (fieldData.fieldType === 'selectlist') {
+                propertyDefinition.enum = fieldData.fieldOptions;
+            } else if (fieldData.fieldType === 'image') {
+                propertyDefinition.media = {
+                    binaryEncoding: 'base64',
+                    type: 'image/jpeg'
+                };
+            }
+            return propertyDefinition;
+        }
+
+        /**
+         * Converts the outut of a Schema Entry Form into a sub-schema designed to be
+         * inserted into the 'definitions' key of a Data Form Schema. Does not perform
+         * validation.
+         * @param {array} formData The values in the Schema Form, defining the fields in
+         *      this Data Form Schema
+         * @return {object} The serialized JSON-Schema snippet
+         */
+        function definitionFromSchemaFormData(formData) {
+            var definition = {
+                type: 'object',
+                properties: {}
+            };
+
+            // properties
+            _.each(formData, function(fieldData) {
+                definition.properties[fieldData.fieldTitle] = _propertyFromSchemaFieldData(fieldData);
+            });
+
+            // required
+            // A list containing the titles of properties which are required.
+            definition.required = _.pluck(_.filter(formData, function(fieldData) {
+                    return fieldData.isRequired;
+                }), 'fieldTitle');
+            return definition;
         }
 
         function jsonObject(newObject) {
@@ -79,12 +148,13 @@
         function textField(newField) {
             newField = newField || {};
             var newTextField = jsonObject(newField);
-            return angular.extend(newTextField, {
+            newTextField = angular.extend(newTextField, {
                 headerTemplate: '{{ self.fieldTitle }}',
                 properties: {
                     fieldTitle: {
                         type: 'string',
-                        title: 'Field Title'
+                        title: 'Field Title',
+                        minLength: 1
                     },
                     isRequired: {
                         type: 'boolean',
@@ -121,23 +191,31 @@
                             ]
                             /* jshint camelcase: true */
                         }
+                    },
+                    fieldType: {
+                        options: {
+                            hidden: true
+                        },
+                        type: 'string'
+                        // Set default: 'text' below since default is a reserved word
                     }
-                },
-                options: {
-                    fieldType: 'text'
                 }
             });
+            newTextField.properties.fieldType['default'] = 'text';
+            return newTextField;
+
         }
 
         function selectList(newList) {
             newList = newList || {};
             var newSelectList = jsonObject(newList);
-            return angular.extend(newSelectList, {
+            newSelectList = angular.extend(newSelectList, {
                 headerTemplate: '{{ self.fieldTitle }}',
                 properties: {
                     fieldTitle: {
                         type: 'string',
-                        title: 'Field Title'
+                        title: 'Field Title',
+                        minLength: 1
                     },
                     isRequired: {
                         type: 'boolean',
@@ -158,36 +236,54 @@
                     },
                     fieldOptions: {
                         title: 'Field Options',
-                        type: 'string',
-                        format: 'textarea'
+                        type: 'array',
+                        format: 'table',
+                        uniqueItems: true,
+                        items: {
+                            type: 'string',
+                            title: 'Option value'
+                        }
+                    },
+                    fieldType: {
+                        options: {
+                            hidden: true
+                        },
+                        type: 'string'
+                        // Set default: 'selectlist' below since default is a reserved word
                     }
-                },
-                options: {
-                    fieldType: 'selectlist'
                 }
             });
+            newSelectList.properties.fieldType['default'] = 'selectlist';
+            return newSelectList;
         }
 
         function imageUploader(newImage) {
             newImage = newImage || {};
             var newImageUploader = jsonObject(newImage);
-            return angular.extend(newImageUploader, {
+            newImageUploader = angular.extend(newImageUploader, {
                 headerTemplate: '{{ self.fieldTitle }}',
                 properties: {
                     fieldTitle: {
                         type: 'string',
-                        title: 'Field Title'
+                        title: 'Field Title',
+                        minLength: 1
                     },
                     isRequired: {
                         type: 'boolean',
                         format: 'checkbox',
                         title: 'Required'
+                    },
+                    fieldType: {
+                        options: {
+                            hidden: true
+                        },
+                        type: 'string'
+                        // Set default: 'image' below since default is a reserved word
                     }
-                },
-                options: {
-                    fieldType: 'image'
                 }
             });
+            newImageUploader.properties.fieldType['default'] = 'image';
+            return newImageUploader;
         }
     }
 

--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -46,6 +46,7 @@
             },
             addVersion4Declaration: addVersion4Declaration,
             fieldFromKey: fieldFromKey,
+            validateSchemaFormData: validateSchemaFormData,
             definitionFromSchemaFormData: definitionFromSchemaFormData,
             encodeJSONPointer: encodeJSONPointer
         };
@@ -130,6 +131,29 @@
                     return fieldData.isRequired;
                 }), 'fieldTitle');
             return definition;
+        }
+
+        /**
+         * Validate that a Schema Entry Form has valid data; currently validates that there are
+         * no duplicate fieldTitles because this is currently not easily done in native
+         * JSON-Schema (the uniqueItems keyword doesn't allow specifying which fields should
+         * be used to determine uniqueness).
+         * @param {object} formData The values in a Schema Form
+         * @return {array} List of errors, if any
+         */
+        function validateSchemaFormData(formData) {
+            var errors = [];
+            var titleCounts = _.countBy(formData, function(fieldData) {
+                return fieldData.fieldTitle;
+            });
+            _.forEach(titleCounts, function(count, title) {
+                if (count > 1) {
+                    errors.push({ 'message': 'Invalid schema: The field title "' + title +
+                        '" is used more than once.'
+                    });
+                }
+            });
+            return errors;
         }
 
         /**

--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -44,6 +44,7 @@
                 SelectList: selectList,
                 ImageUploader: imageUploader
             },
+            addVersion4Declaration: addVersion4Declaration,
             fieldFromKey: fieldFromKey,
             definitionFromSchemaFormData: definitionFromSchemaFormData,
             encodeJSONPointer: encodeJSONPointer
@@ -129,6 +130,15 @@
                     return fieldData.isRequired;
                 }), 'fieldTitle');
             return definition;
+        }
+
+        /**
+         * Adds a $schema keyword to an object; this declares that the object is JSON-Schema v4
+         * @param {object} schema Object to which the declaration should be added
+         * @return {object} The schema with the $schema keyword added, pointing to Draft 4
+         */
+        function addVersion4Declaration(schema) {
+            return angular.extend(schema, { $schema: 'http://json-schema.org/draft-04/schema#' });
         }
 
         function jsonObject(newObject) {

--- a/schema_editor/app/scripts/views/recordtype/add-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/add-controller.js
@@ -35,7 +35,15 @@
             /* jshint camelcase: false */
             definition.title = definition.plural_title = recordType.label + ' Details';
             /* jshint camelcase: true */
+            // TODO: $refs should be stored as JSON Pointers, which use URI encoding for certain
+            // characters, such as spaces. However, json-editor currently does not appear to decode
+            // the URI encoding for JSON pointers properly. Putting in spaces directly works with
+            // json-editor, but is technically not a valid JSON Pointer. If this causes problems
+            // with other libraries, we may need to find a fix.
             schema.definitions[definition.title] = definition;
+            schema.properties[definition.title] = {
+                $ref: '#/definitions/' + Schemas.encodeJSONPointer(definition.title)
+            };
 
             RecordSchemas.create({
                 /* jshint camelcase: false */

--- a/schema_editor/app/scripts/views/recordtype/add-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/add-controller.js
@@ -29,6 +29,7 @@
 
             // Automatically add 'Details' related content type to all record types
             var schema = Schemas.JsonObject();
+            schema = Schemas.addVersion4Declaration(schema); // Make root object a "real" JSON-Schema
             var definition = Schemas.JsonObject();
             definition.description = 'Details for ' + recordType.label;
             definition.multiple = false;

--- a/schema_editor/app/scripts/views/recordtype/schema/edit-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/schema/edit-controller.js
@@ -18,12 +18,16 @@
                     schema: null,
                     disable_edit_json: true,
                     disable_properties: true,
-                    disable_array_add: true,
+                    disable_array_add: false,
                     theme: 'bootstrap3'
                     /* jshint camelcase: true */
                 }
             };
-            ctl.fieldTypes = Schemas.FieldTypes;
+
+            // Pick out just the labels; these will go into the dropdown.
+            ctl.fieldTypes = _.mapValues(Schemas.FieldTypes, function(ft) {
+                return ft.label;
+            });
 
             RecordTypes.get({ id: $stateParams.uuid }).$promise.then(function (recordType) {
                 ctl.recordType = recordType;
@@ -41,17 +45,18 @@
         }
 
         function onSchemaReady(recordSchema) {
+            // TODO: Schema deserialization here, probably
             schema = recordSchema.schema.definitions[ctl.schemaKey];
             extendEditor({ schema: schema });
         }
 
         function onDataChange(newData) {
-            $log.debug('EditController Form Data:', newData);
+            $log.debug('Related type definition from form data:', Schemas.definitionFromSchemaFormData(newData));
             editorData = newData;
         }
 
         function onEditorAddClicked(fieldKey) {
-            var fieldTitle = Schemas.FieldTypes[fieldKey];
+            var fieldTitle = Schemas.FieldTypes[fieldKey].label;
             var fieldOptions = {
                 title: fieldTitle
             };

--- a/schema_editor/app/scripts/views/recordtype/schema/edit-partial.html
+++ b/schema_editor/app/scripts/views/recordtype/schema/edit-partial.html
@@ -1,5 +1,6 @@
 <div class="form-area">
     <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
         <div class="form-area-heading">
             <h2>{{ ::rtSchemaEdit.schemaKey }}</h2>
             <div class="btn-group pull-right" dropdown>
@@ -20,7 +21,8 @@
                      class="form-area-body">
         </json-editor>
         <div class="save-area">
-            <button type="button" class="btn btn-default">Save</button>
+          <button type="button" class="btn btn-default"
+              ng-click="rtSchemaEdit.onSaveClicked()">Save</button>
             <button type="button" class="btn btn-default"
                     ui-sref="rt.related({uuid: rtSchemaEdit.recordType.uuid })">Cancel</button>
             </div>

--- a/schema_editor/test/spec/schemas/schemas-service.spec.js
+++ b/schema_editor/test/spec/schemas/schemas-service.spec.js
@@ -28,7 +28,7 @@ describe('ase.schemas:Schemas', function () {
         expect(schemaEnv.validate('v4', field)).toBe(null);
     });
 
-    it('should add the $schema declaration to schemas', function () {
+    it('should be able to add the $schema declaration to schemas', function () {
         var obj = Schemas.JsonObject();
         obj = Schemas.addVersion4Declaration(obj);
         expect(schemaEnv.validate('v4', obj)).toBe(null);
@@ -48,7 +48,7 @@ describe('ase.schemas:Schemas', function () {
         }));
     });
 
-    it('should include an enum key in selectlist fields', function () {
+    it('should serialize an enum key in selectlist fields', function () {
         var schemaFormData = [{
             fieldType: 'selectlist',
             isRequired: false,
@@ -59,7 +59,7 @@ describe('ase.schemas:Schemas', function () {
         expect(dataFormSchemaDef.properties.Text['enum']).toEqual(schemaFormData[0].fieldOptions);
     });
 
-    it('should include a media key in image fields', function () {
+    it('should serialize a media key in image fields', function () {
         var schemaFormData = [{
             fieldType: 'image',
             isRequired: false,
@@ -83,5 +83,41 @@ describe('ase.schemas:Schemas', function () {
         var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
         expect(dataFormSchemaDef.required.length).toEqual(1);
         expect(dataFormSchemaDef.required[0]).toEqual('Photo');
+    });
+
+    it('should validate that no two Schema Entry Form fields have the same title', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isRequired: false,
+            fieldTitle: 'Same1',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        },{
+            fieldType: 'image',
+            isRequired: true,
+            fieldTitle: 'Same2'
+        },{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Same1'
+        },{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Diff'
+        },{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Same2'
+        }];
+        var errors = Schemas.validateSchemaFormData(schemaFormData);
+        expect(errors.length).toEqual(2);
+        expect(errors).toEqual(jasmine.arrayContaining([{
+            message: jasmine.stringMatching('Same1')
+        }]));
+        expect(errors).toEqual(jasmine.arrayContaining([{
+            message: jasmine.stringMatching('Same2')
+        }]));
+        expect(errors).not.toEqual(jasmine.arrayContaining([{
+            message: jasmine.stringMatching('Diff')
+        }]));
     });
 });

--- a/schema_editor/test/spec/schemas/schemas-service.spec.js
+++ b/schema_editor/test/spec/schemas/schemas-service.spec.js
@@ -27,4 +27,61 @@ describe('ase.schemas:Schemas', function () {
         var field = Schemas.Fields.SelectList();
         expect(schemaEnv.validate('v4', field)).toBe(null);
     });
+
+    it('should add the $schema declaration to schemas', function () {
+        var obj = Schemas.JsonObject();
+        obj = Schemas.addVersion4Declaration(obj);
+        expect(schemaEnv.validate('v4', obj)).toBe(null);
+    });
+
+    it('should serialize schema form outputs to data form schema snippets', function () {
+        var schemaFormData = [{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Text'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef).toEqual(jasmine.objectContaining({
+            required: jasmine.anything(),
+            properties: jasmine.anything(),
+            type: 'object'
+        }));
+    });
+
+    it('should include an enum key in selectlist fields', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isRequired: false,
+            fieldTitle: 'Text',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Text['enum']).toEqual(schemaFormData[0].fieldOptions);
+    });
+
+    it('should include a media key in image fields', function () {
+        var schemaFormData = [{
+            fieldType: 'image',
+            isRequired: false,
+            fieldTitle: 'Photo'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Photo.media).toEqual(jasmine.anything());
+    });
+
+    it('should set the "required" key when fields have isRequired: true', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isRequired: false,
+            fieldTitle: 'Text',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        },{
+            fieldType: 'image',
+            isRequired: true,
+            fieldTitle: 'Photo'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.required.length).toEqual(1);
+        expect(dataFormSchemaDef.required[0]).toEqual('Photo');
+    });
 });

--- a/schema_editor/test/spec/views/recordtype/add-controller.spec.js
+++ b/schema_editor/test/spec/views/recordtype/add-controller.spec.js
@@ -47,7 +47,9 @@ describe('ase.views.recordtype: AddController', function () {
                 title: '',
                 plural_title: '',
                 description: '',
-                properties: {},
+                properties: {
+                    'Accident Details': { $ref: '#/definitions/Accident Details' }
+                },
                 definitions: {
                     'Accident Details': {
                         type: 'object',


### PR DESCRIPTION
This sets up the Schema Entry Form for Related Content so that when the Save button is clicked, the data from the form is serialized into a JSON-Schema snippet designed to be inserted into the `definitions` of the larger JSON-Schema for the Record Type which contains the Related Content type.

Also adds some basic validation that field titles are not duplicated and improves the built-in form schema to validate the existence of field titles.