### PR TITLE
Deserialize related type schemas to form

### DIFF
--- a/schema_editor/app/builder-schemas/related.json
+++ b/schema_editor/app/builder-schemas/related.json
@@ -14,7 +14,15 @@
     "definitions": {
         "abstractBaseField": {
             "type": "object",
-            "required": ["fieldTitle", "fieldType"]
+            "required": ["fieldTitle", "fieldType"],
+            "properties": {
+                "propertyOrder": {
+                    "type": "number",
+                    "options": {
+                        "hidden": true
+                    }
+                }
+            }
         },
         "abstractSearchableField": {
             "properties": {
@@ -99,13 +107,15 @@
                     "enum": [
                         "select",
                         "checkbox"
-                    ]
+                    ],
+                    "default": "select"
                 },
                 "fieldOptions": {
                     "title": "Field Options",
                     "type": "array",
                     "format": "table",
                     "uniqueItems": true,
+                    "minItems": 1,
                     "items": {
                         "title": "Option value",
                         "type": "string"

--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -34,6 +34,7 @@
             addVersion4Declaration: addVersion4Declaration,
             validateSchemaFormData: validateSchemaFormData,
             definitionFromSchemaFormData: definitionFromSchemaFormData,
+            schemaFormDataFromDefinition: schemaFormDataFromDefinition,
             encodeJSONPointer: encodeJSONPointer
         };
         return module;
@@ -58,16 +59,19 @@
          * which would be used for data entry / editing. Does not perform validation.
          * @param {object} fieldData The value of one Schema Entry Form field, specifying required,
          *      searchable, possible values, etc.
+         * @param {number} index The index of this field in its form
          * @return {object} A snippet designed to be inserted into the 'properties' of a Data Form
          *      Schema
          */
         // TODO: This monolithic function isn't great; investigate more modular options
-        function _propertyFromSchemaFieldData(fieldData) {
+        // (likewise in the deserializing function below)
+        function _propertyFromSchemaFieldData(fieldData, index) {
             var propertyDefinition = {};
             propertyDefinition.type = module.FieldTypes[fieldData.fieldType].jsonType;
 
             if (fieldData.fieldType === 'selectlist') {
                 propertyDefinition.enum = fieldData.fieldOptions;
+                propertyDefinition.displayType = fieldData.displayType;
             } else if (fieldData.fieldType === 'image') {
                 propertyDefinition.media = {
                     binaryEncoding: 'base64',
@@ -80,11 +84,20 @@
             // Set the common properties
             propertyDefinition.isSearchable = fieldData.isSearchable;
 
+            // Include the fieldType to make deserialization easier; without this we have to guess
+            // based on other properties.
+            propertyDefinition.fieldType = fieldData.fieldType;
+
+            // Insert the array index into the 'propertyOrder' key; this is a custom key
+            // defined by JSON-Editor to allow specification of property ordering, which is not
+            // supported by JSON-Schema (yet)
+            propertyDefinition.propertyOrder = index;
+
             return propertyDefinition;
         }
 
         /**
-         * Converts the outut of a Schema Entry Form into a sub-schema designed to be
+         * Converts the output of a Schema Entry Form into a sub-schema designed to be
          * inserted into the 'definitions' key of a Data Form Schema. Does not perform
          * validation.
          * @param {array} formData The values in the Schema Form, defining the fields in
@@ -98,8 +111,11 @@
             };
 
             // properties
-            _.each(formData, function(fieldData) {
-                definition.properties[fieldData.fieldTitle] = _propertyFromSchemaFieldData(fieldData);
+            _.each(formData, function(fieldData, index) {
+                definition.properties[fieldData.fieldTitle] = _propertyFromSchemaFieldData(
+                    fieldData,
+                    index
+                );
             });
 
             // required
@@ -117,6 +133,61 @@
             }
 
             return definition;
+        }
+
+        /**
+         * Inverse of the above; converts a sub-schema into a JSON-Schema that will allow
+         * JSON-Editor to generate the correct form elements for editing the fields in the schema.
+         * @param {object} definition The sub-schema to convert into fields
+         * @return {array} Form schema to allow editing the fields in definition
+         */
+        function schemaFormDataFromDefinition(definition) {
+            var formData = [];
+            _.each(definition.properties, function(schemaField, title) {
+                var fieldData = {
+                    fieldTitle: title
+                };
+                // Iterate over schema keys and take the appropriate action
+                _.each(schemaField, function(value, key) {
+                    switch(key) {
+                        case 'enum':
+                            fieldData.fieldOptions = value;
+                            break;
+                        case 'type': // This is the JSON-Schema 'type', which is not used here.
+                            break;
+                        case 'media': // Also not used
+                            break;
+                        default:
+                            fieldData[key] = value;
+                    }
+                });
+
+                // Handle required fields, which are stored outside the field info
+                var indexInRequired = _.findIndex(definition.required, function(item) {
+                    return item === title;
+                });
+                if (indexInRequired >= 0) { // I.e., found title in required: [...]
+                    fieldData.isRequired = true;
+                } else {
+                    fieldData.isRequired = false;
+                }
+
+                formData.push(fieldData);
+            });
+            // Order the resulting array by the propertyOrder field so that fields appear in
+            // the same order in which they'll appear during data entry. JSON-Editor only applies
+            // the propertyOrder keyword if it appears *inside* a property. If it appears *as* a
+            // property, it won't have any effect, so we need to do the sorting ourselves.
+            formData.sort(function(a, b) {
+                if (a.propertyOrder < b.propertyOrder) {
+                    return -1;
+                }
+                if (a.propertyOrder > b.propertyOrder) {
+                    return 1;
+                }
+                return 0;
+            });
+            return formData;
         }
 
         /**

--- a/schema_editor/app/scripts/views/recordtype/schema/edit-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/schema/edit-controller.js
@@ -57,6 +57,8 @@
             var definition = ctl.recordSchema.schema.definitions[ctl.schemaKey];
             schema.description = definition.description;
             schema.title = definition.title;
+            var initialData = Schemas.schemaFormDataFromDefinition(definition);
+            $log.debug('Initializing form with startval', initialData);
 
             // Configure the json-editor
             ctl.editor = {
@@ -69,7 +71,8 @@
                     disable_array_add: false,
                     theme: 'bootstrap3',
                     show_errors: 'change',
-                    no_additional_properties: true
+                    no_additional_properties: true,
+                    startval: initialData
                     /* jshint camelcase: true */
                 },
                 errors: []

--- a/schema_editor/test/spec/schemas/schemas-service.spec.js
+++ b/schema_editor/test/spec/schemas/schemas-service.spec.js
@@ -72,6 +72,18 @@ describe('ase.schemas:Schemas', function () {
         expect(dataFormSchemaDef.properties.Text['enum']).toEqual(schemaFormData[0].fieldOptions);
     });
 
+    it('should serialize a displayType key in selectlist fields', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            displayType: 'select',
+            isRequired: false,
+            fieldTitle: 'Text',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Text.displayType).toEqual(schemaFormData[0].displayType);
+    });
+
     it('should serialize a media key in image fields', function () {
         var schemaFormData = [{
             fieldType: 'image',
@@ -98,7 +110,7 @@ describe('ase.schemas:Schemas', function () {
         expect(dataFormSchemaDef.required[0]).toEqual('Photo');
     });
 
-    it('should net set the "required" key when there are no required fields', function () {
+    it('should not set the "required" key when there are no required fields', function () {
         var schemaFormData = [{
             fieldType: 'selectlist',
             isRequired: false,
@@ -111,6 +123,22 @@ describe('ase.schemas:Schemas', function () {
         }];
         var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
         expect(dataFormSchemaDef.required).toBeUndefined();
+    });
+
+    it('should calculate and set propertyOrder based on the ordering of fields', function () {
+        var schemaFormData = [];
+        for (var i in [0,1,2,3,4]) {
+            schemaFormData.push({
+                fieldType: 'text',
+                fieldTitle: 'Title' + i,
+                indexShouldBe: i
+            });
+        }
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        for (var j in [0,1,2,3,4]) {
+            var field = dataFormSchemaDef.properties['Title' + j];
+            expect(field.propertyOrder.toString()).toEqual(j);
+        }
     });
 
     it('should validate that no two Schema Entry Form fields have the same title', function () {
@@ -148,4 +176,69 @@ describe('ase.schemas:Schemas', function () {
             message: jasmine.stringMatching('Diff')
         }]));
     });
+
+    // NOTE: This test must be updated when new field types are added.
+    it('should preserve all information when serializing and deserializing schemas', function () {
+        // In practice this means that the serialize and deserialize methods are inverses
+        var f = Schemas.definitionFromSchemaFormData;
+        var b = Schemas.schemaFormDataFromDefinition;
+
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isSearchable: false,
+            displayType: 'checkbox',
+            isRequired: false,
+            fieldTitle: 'Select',
+            fieldOptions: ['opt1', 'opt2'],
+            propertyOrder: 0 // The serializer uses the ordering of the incoming form data to
+                             // determine and set the propertyOrder value, since this is how
+                             // JSON-Editor expresses the value. Therefore this value must match
+                             // the ordering of the array in order to ensure that the output
+                             // matches the input, otherwise the serializer will assume that the
+                             // ordering has changed and update the propertyOrder field, causing
+                             // the test to fail.
+        },{
+            fieldType: 'image',
+            isSearchable: false,
+            isRequired: true,
+            fieldTitle: 'Image',
+            propertyOrder: 1
+        },{
+            fieldType: 'text',
+            isSearchable: false,
+            isRequired: false,
+            fieldTitle: 'Text',
+            textOptions: 'datetime',
+            propertyOrder: 2
+        }];
+
+        // Transform back and forth a few times
+        var output = b(f(b(f(b(f(b(f(b(f(b(f(schemaFormData))))))))))));
+        expect(output).toEqual(schemaFormData);
+    });
+
+    it('should sort by propertyOrder when deserializing schemas', function () {
+        var definition = {
+            properties: {
+                appearsSecond: {
+                    fieldType: 'text',
+                    propertyOrder: 1
+                },
+                appearsThird: {
+                    fieldType: 'text',
+                    propertyOrder: 2
+                },
+                appearsFirst: {
+                    fieldType: 'text',
+                    propertyOrder: 0
+                }
+            }
+        };
+
+        var formData = Schemas.schemaFormDataFromDefinition(definition);
+        for (var i = 1; i < formData.length; i++) {
+            expect(formData[i].propertyOrder).toBeGreaterThan(formData[i-1].propertyOrder);
+        }
+    });
+
 });


### PR DESCRIPTION
Deserializes items from the "definition" key of a schema into initial data for a Schema Entry Form. Also preserves field ordering via the "propertyOrder" attribute, and makes some incremental changes to the Schema Entry Form Schema.

@kshepard should take a look too.