### PR TITLE
Relationship field

### DIFF
--- a/schema_editor/app/builder-schemas/related.json
+++ b/schema_editor/app/builder-schemas/related.json
@@ -8,7 +8,8 @@
         "oneOf": [
             { "$ref": "#/definitions/textField" },
             { "$ref": "#/definitions/selectList" },
-            { "$ref": "#/definitions/imageUploader" }
+            { "$ref": "#/definitions/imageUploader" },
+            { "$ref": "#/definitions/localReference" }
         ]
     },
     "definitions": {
@@ -148,6 +149,33 @@
                     },
                     "type": "string",
                     "enum": ["image"]
+                }
+            }
+        },
+        "localReference": {
+            "allOf": [
+                { "$ref": "#/definitions/abstractBaseField" },
+                { "$ref": "#/definitions/abstractRequirableField" }
+            ],
+            "title": "Local Reference",
+            "properties": {
+                "fieldTitle": {
+                    "title": "Reference Title",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "referenceTarget": {
+                    "title": "Type of related info to reference",
+                    "type": "string",
+                    "format": "select",
+                    "enumSource": [["Choice one", "choice 2", "choice 3"]]
+                },
+                "fieldType": {
+                    "options": {
+                        "hidden": true
+                    },
+                    "type": "string",
+                    "enum": ["reference"]
                 }
             }
         }

--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -15,6 +15,9 @@
 
     /* ngInject */
     function Schemas() {
+        // Static properties which cannot be changed when editing a schema
+        var systemOnlyProperties = { _localId: true };
+
         var module = {
             JsonObject: jsonObject,
             FieldTypes: {
@@ -29,9 +32,14 @@
                 'image': {
                     label: 'Image Uploader',
                     jsonType: 'string'
+                },
+                'reference': {
+                    label: 'Local Reference',
+                    jsonType: 'string'
                 }
             },
             addVersion4Declaration: addVersion4Declaration,
+            addRelatedContentFields: addRelatedContentFields,
             validateSchemaFormData: validateSchemaFormData,
             definitionFromSchemaFormData: definitionFromSchemaFormData,
             schemaFormDataFromDefinition: schemaFormDataFromDefinition,
@@ -47,9 +55,10 @@
          * @return {string} Currently just returns encodeURIComponent(string)
          */
         function encodeJSONPointer(str) {
-            // TODO: Technically, we should be doing this:
+            // TODO: This can probably be switched after upgrading json-editor:
+            // https://github.com/jdorn/json-editor/issues/402
             // return encodeURIComponent(str);
-            // But json-editor doesn't seem to support that properly.
+            // But the current version of json-editor doesn't support this properly.
             return str;
         }
 
@@ -106,10 +115,10 @@
          */
         function definitionFromSchemaFormData(formData) {
             var definition = {
-                type: 'object',
-                properties: {}
+                properties: {},
+                type: 'object'
             };
-
+            definition = addRelatedContentFields(definition);
             // properties
             _.each(formData, function(fieldData, index) {
                 definition.properties[fieldData.fieldTitle] = _propertyFromSchemaFieldData(
@@ -125,12 +134,8 @@
                     return fieldData.isRequired;
                 }), 'fieldTitle');
 
-            // The schema doesn't validate on save if required is an empty array:
-            // "Invalid schema: [] is too short"
-            // so only set it if there are required fields.
-            if (required.length) {
-                definition.required = required;
-            }
+            // All definitions start with a required "_localId" property
+            definition.required = definition.required.concat(required);
 
             return definition;
         }
@@ -144,38 +149,42 @@
         function schemaFormDataFromDefinition(definition) {
             var formData = [];
             _.each(definition.properties, function(schemaField, title) {
-                var fieldData = {
-                    fieldTitle: title
-                };
-                // Iterate over schema keys and take the appropriate action
-                _.each(schemaField, function(value, key) {
-                    switch(key) {
-                        case 'enum':
-                            fieldData.fieldOptions = value;
-                            break;
-                        case 'format':
-                            fieldData.textOptions = value;
-                            break;
-                        case 'type': // This is the JSON-Schema 'type', which is not used here.
-                            break;
-                        case 'media': // Also not used
-                            break;
-                        default:
-                            fieldData[key] = value;
-                    }
-                });
-
-                // Handle required fields, which are stored outside the field info
-                var indexInRequired = _.findIndex(definition.required, function(item) {
-                    return item === title;
-                });
-                if (indexInRequired >= 0) { // I.e., found title in required: [...]
-                    fieldData.isRequired = true;
+                if (systemOnlyProperties[title]) {
+                    // Don't include in schema editor form
                 } else {
-                    fieldData.isRequired = false;
-                }
+                    var fieldData = {
+                        fieldTitle: title
+                    };
+                    // Iterate over schema keys and take the appropriate action
+                    _.each(schemaField, function(value, key) {
+                        switch(key) {
+                            case 'enum':
+                                fieldData.fieldOptions = value;
+                                break;
+                            case 'format':
+                                fieldData.textOptions = value;
+                                break;
+                            case 'type': // This is the JSON-Schema 'type', which is not used here.
+                                break;
+                            case 'media': // Also not used
+                                break;
+                            default:
+                                fieldData[key] = value;
+                        }
+                    });
 
-                formData.push(fieldData);
+                    // Handle required fields, which are stored outside the field info
+                    var indexInRequired = _.findIndex(definition.required, function(item) {
+                        return item === title;
+                    });
+                    if (indexInRequired >= 0) { // I.e., found title in required: [...]
+                        fieldData.isRequired = true;
+                    } else {
+                        fieldData.isRequired = false;
+                    }
+
+                    formData.push(fieldData);
+                }
             });
             // Order the resulting array by the propertyOrder field so that fields appear in
             // the same order in which they'll appear during data entry. JSON-Editor only applies
@@ -200,6 +209,9 @@
          * be used to determine uniqueness).
          * @param {object} formData The values in a Schema Form
          * @return {array} List of errors, if any
+         *
+         * TODO: JSON-Editor supports custom validators which are applied recursively from the root
+         * -- these should probably be used instead of this function.
          */
         function validateSchemaFormData(formData) {
             var errors = [];
@@ -225,6 +237,30 @@
             return angular.extend(schema, { $schema: 'http://json-schema.org/draft-04/schema#' });
         }
 
+        // TODO Docs
+        function addRelatedContentFields(schema) {
+            schema.properties = angular.extend(schema.properties, {
+                _localId: { // A special field allowing relationships between objects within a record
+                    // A pattern for a UUID field is helpfully supplied at
+                    // http://json-schema.org/example2.html
+                    type: 'string',
+                    pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$',
+                    hidden: true
+                }
+            });
+            if (schema.required) {
+                schema.required = schema.required.concat(['_localId']);
+            } else {
+                schema.required = ['_localId'];
+            }
+            return schema;
+        }
+
+        /**
+         * Creates a new blank object for use in a JSON-Schema
+         * @param {object} Object to extend; default {}
+         * @return {object} A blank object for use in a JSON-Schema
+         */
         function jsonObject(newObject) {
             newObject = newObject || {};
             return angular.extend({}, {
@@ -238,6 +274,8 @@
                 /* jshint camelcase: true */
             }, newObject);
         }
+
+
     }
 
     angular.module('ase.schemas')

--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -266,7 +266,11 @@
             return angular.extend(schema, { $schema: 'http://json-schema.org/draft-04/schema#' });
         }
 
-        // TODO Docs
+        /**
+         * Adds a _localId field to a schema's properties that can store a UUID
+         * @param {object} schema Object to which the declaration should be added
+         * @return {object} The schema with a _localId property added
+         */
         function addRelatedContentFields(schema) {
             schema.properties = angular.extend(schema.properties, {
                 _localId: { // A special field allowing relationships between objects within a record
@@ -274,7 +278,9 @@
                     // http://json-schema.org/example2.html
                     type: 'string',
                     pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$',
-                    hidden: true
+                    options: {
+                        hidden: true
+                    }
                 }
             });
             if (schema.required) {

--- a/schema_editor/app/scripts/views/recordtype/related-add-directive.js
+++ b/schema_editor/app/scripts/views/recordtype/related-add-directive.js
@@ -10,6 +10,7 @@
 
         function initialize() {
             ctl.definition = Schemas.JsonObject();
+            ctl.definition = Schemas.addRelatedContentFields(ctl.definition);
             RecordTypes.get({ id: $stateParams.uuid }).$promise.then(function (data) {
                 ctl.recordType = data;
                 /* jshint camelcase:false */

--- a/schema_editor/app/scripts/views/recordtype/schema/edit-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/schema/edit-controller.js
@@ -6,6 +6,7 @@
                                     RecordSchemas, Schemas, Notifications) {
         var ctl = this;
         var editorData = null;
+
         initialize();
 
         function initialize() {
@@ -48,12 +49,21 @@
 
         // Called after all prerequesite data has been loaded
         function onSchemaReady() {
+            // Get a list of the titles of all relatedContentTypes which have '_localId' as
+            // a property.
+            var referable = _.pluck(
+                _.filter(ctl.recordSchema.schema.definitions, function(definition) {
+                    return !!definition.properties._localId;
+                }), 'title');
+            // Modify the relatedBuilderSchema in-place in order to allow selecting a related content type
+            // as the target of an internal reference.
+            ctl.relatedBuilderSchema.definitions.localReference.properties.referenceTarget.enumSource = [referable];
+
             // Need to call toJSON here in order to strip the additional angular
             // resource properties, as they don't play well with json-editor.
             var schema = ctl.relatedBuilderSchema.toJSON();
 
             // Populate saved properties
-            // TODO: Schema deserialization here, probably
             var definition = ctl.recordSchema.schema.definitions[ctl.schemaKey];
             schema.description = definition.description;
             schema.title = definition.title;

--- a/schema_editor/app/scripts/views/recordtype/schema/edit-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/schema/edit-controller.js
@@ -55,8 +55,8 @@
                 _.filter(ctl.recordSchema.schema.definitions, function(definition) {
                     return !!definition.properties._localId;
                 }), 'title');
-            // Modify the relatedBuilderSchema in-place in order to allow selecting a related content type
-            // as the target of an internal reference.
+            // Modify the relatedBuilderSchema in-place in order to allow selecting a related
+            // content type as the target of an internal reference.
             ctl.relatedBuilderSchema.definitions.localReference.properties.referenceTarget.enumSource = [referable];
 
             // Need to call toJSON here in order to strip the additional angular

--- a/schema_editor/test/spec/schemas/schemas-service.spec.js
+++ b/schema_editor/test/spec/schemas/schemas-service.spec.js
@@ -91,10 +91,22 @@ describe('ase.schemas:Schemas', function () {
             fieldTitle: 'Photo'
         }];
         var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
-        expect(dataFormSchemaDef.properties.Photo.media).toEqual(jasmine.anything());
+        expect(dataFormSchemaDef.properties.Photo.media).toBeDefined();
     });
 
-    it('should set the "required" key when fields have isRequired: true', function () {
+    it('should serialize watch and enumSource keys into reference fields', function () {
+        var schemaFormData = [{
+            fieldType: 'reference',
+            isRequired: false,
+            fieldTitle: 'Reference',
+            referenceTarget: 'Other type'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Reference.watch).toBeDefined();
+        expect(dataFormSchemaDef.properties.Reference.enumSource).toBeDefined();
+    });
+
+    it('should add to the "required" key when fields have isRequired: true', function () {
         var schemaFormData = [{
             fieldType: 'selectlist',
             isRequired: false,
@@ -106,11 +118,11 @@ describe('ase.schemas:Schemas', function () {
             fieldTitle: 'Photo'
         }];
         var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
-        expect(dataFormSchemaDef.required.length).toEqual(1);
-        expect(dataFormSchemaDef.required[0]).toEqual('Photo');
+        expect(dataFormSchemaDef.required.length).toEqual(2); // Everything has required: ['_localId']
+        expect(dataFormSchemaDef.required).toContain('Photo');
     });
 
-    it('should not set the "required" key when there are no required fields', function () {
+    it('should create a required "_localId" field on all definitions', function () {
         var schemaFormData = [{
             fieldType: 'selectlist',
             isRequired: false,
@@ -122,7 +134,9 @@ describe('ase.schemas:Schemas', function () {
             fieldTitle: 'Photo'
         }];
         var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
-        expect(dataFormSchemaDef.required).toBeUndefined();
+        expect(dataFormSchemaDef.required).toBeDefined();
+        expect(dataFormSchemaDef.required.length).toBe(1);
+        expect(dataFormSchemaDef.required).toContain('_localId');
     });
 
     it('should calculate and set propertyOrder based on the ordering of fields', function () {
@@ -210,6 +224,13 @@ describe('ase.schemas:Schemas', function () {
             fieldTitle: 'Text',
             textOptions: 'datetime',
             propertyOrder: 2
+        },{
+            fieldType: 'reference',
+            isRequired: false,
+            isSearchable: false,
+            fieldTitle: 'Local reference',
+            referenceTarget: 'Other Type',
+            propertyOrder: 3
         }];
 
         // Transform back and forth a few times


### PR DESCRIPTION
Adds a relationship field that allows local references to another related content type within the same record.

Also creates a system-only `_localId` field that is added to all related types (except the initial default Details type since it doesn't really make sense there). The editor portion will need to auto-populate these fields with UUIDs.

I had to punt on auto-generating a human-readable name for the related content in the dropdown menu because it would have taken a while and I'm already a bit over time for this card, but I put in a to-do with reasonably detailed instructions, and I don't think it'll be too difficult to implement.