### PR TITLE
Consolidate Docker volumes; relocate NPM and Bower directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ python:
 
 cache:
   directories:
-    - schema_editor/node_modules
-    - schema_editor/bower_components
     - $HOME/.cache/pip
 
 addons:
@@ -23,6 +21,7 @@ before_install:
     #   https://github.com/npm/npm/issues/6309
   - nvm install 0.12
   - nvm use 0.12
+  - find . -type l -name "bower_components" -delete -o -name "node_modules" -delete
 
 install:
   - gem install -q sass compass

--- a/deployment/ansible/roles/driver.web/tasks/main.yml
+++ b/deployment/ansible/roles/driver.web/tasks/main.yml
@@ -17,17 +17,8 @@
     /usr/bin/docker run
       --rm
       --name driver-web
-      --volume {{ editor_dir }}/app:{{ editor_dir }}/app
-      --volume {{ editor_dir }}/test:{{ editor_dir }}/test
-      --volume {{ web_build_dir }}:{{ web_build_dir }}
-      --volume {{ web_dir }}/app:{{ web_dir }}/app
-      --volume {{ web_dir }}/test:{{ web_dir }}/test
-      --volume {{ web_dir }}/.bowerrc:{{ web_dir }}/.bowerrc
-      --volume {{ web_dir }}/.editorconfig:{{ web_dir }}/.editorconfig
-      --volume {{ web_dir }}/.jshintrc:{{ web_dir }}/.jshintrc
-      --volume {{ web_dir }}/bower.json:{{ web_dir }}/bower.json
-      --volume {{ web_dir }}/Gruntfile.js:{{ web_dir }}/Gruntfile.js
-      --volume {{ web_dir }}/package.json:{{ web_dir }}/package.json
+      --volume {{ editor_dir }}:{{ editor_dir }}
+      --volume {{ web_dir }}:{{ web_dir }}
       --log-driver syslog
       driver/web:latest
       build
@@ -50,15 +41,7 @@
     /usr/bin/docker run
       --rm
       --name driver-editor
-      --volume {{ editor_build_dir }}:{{ editor_build_dir }}
-      --volume {{ editor_dir }}/app:{{ editor_dir }}/app
-      --volume {{ editor_dir }}/test:{{ editor_dir }}/test
-      --volume {{ editor_dir }}/.bowerrc:{{ editor_dir }}/.bowerrc
-      --volume {{ editor_dir }}/.editorconfig:{{ editor_dir }}/.editorconfig
-      --volume {{ editor_dir }}/.jshintrc:{{ editor_dir }}/.jshintrc
-      --volume {{ editor_dir }}/bower.json:{{ editor_dir }}/bower.json
-      --volume {{ editor_dir }}/Gruntfile.js:{{ editor_dir }}/Gruntfile.js
-      --volume {{ editor_dir }}/package.json:{{ editor_dir }}/package.json
+      --volume {{ editor_dir }}:{{ editor_dir }}
       --log-driver syslog
       driver/editor:latest
       build

--- a/schema_editor/.gitignore
+++ b/schema_editor/.gitignore
@@ -1,5 +1,3 @@
-node_modules
 dist
 .tmp
 .sass-cache
-bower_components

--- a/schema_editor/Dockerfile
+++ b/schema_editor/Dockerfile
@@ -10,15 +10,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN gem install compass
 
-RUN mkdir -p /opt/schema_editor
-WORKDIR /opt/schema_editor
+RUN mkdir -p /opt/schema_editor /npm /bower
 
-COPY package.json /opt/schema_editor/
-RUN npm install --unsafe-perm
+WORKDIR /npm
+COPY package.json /npm/
+RUN npm install
 
-COPY bower.json /opt/schema_editor/
+WORKDIR /bower
+COPY bower.json /bower/
 RUN bower install --allow-root --config.interactive=false --force
 
+WORKDIR /opt/schema_editor
 COPY . /opt/schema_editor
 
 ENTRYPOINT ["grunt"]

--- a/schema_editor/bower_components
+++ b/schema_editor/bower_components
@@ -1,0 +1,1 @@
+/bower/bower_components

--- a/schema_editor/node_modules
+++ b/schema_editor/node_modules
@@ -1,0 +1,1 @@
+/npm/node_modules

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,5 +1,3 @@
-/node_modules
 /dist
 /.tmp
 /.sass-cache
-/bower_components

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,15 +10,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN gem install compass
 
-RUN mkdir -p /opt/web
-WORKDIR /opt/web
+RUN mkdir -p /opt/web /npm /bower
 
-COPY package.json /opt/web/
-RUN npm install --unsafe-perm
+WORKDIR /npm
+COPY package.json /npm/
+RUN npm install
 
-COPY bower.json /opt/web/
+WORKDIR /bower
+COPY bower.json /bower/
 RUN bower install --allow-root --config.interactive=false --force
 
+WORKDIR /opt/web
 COPY . /opt/web
 
 ENTRYPOINT ["grunt"]

--- a/web/bower_components
+++ b/web/bower_components
@@ -1,0 +1,1 @@
+/bower/bower_components

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,0 +1,1 @@
+/npm/node_modules


### PR DESCRIPTION
The approach here is:

- Install NPM & Bower modules in separate directories (/npm and /bower)
- Create a symlinks for each project that points to those directories
- Symlinks are valid inside the container, but invalid outside

This allows us to mount the source directory inside the container without worrying about clobbering any existing NPM or Bower module installations.

Main downside is that adding or removing NPM or Bower modules requires a Docker container rebuild.