### PR TITLE
Fix Driver application startup when developing

### DIFF
--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -1,6 +1,10 @@
 description "driver-app"
 
-start on filesystem and started docker
+{% if developing_or_testing -%}
+start on (vagrant-mounted and started docker)
+{% else -%}
+start on (filesystem and started docker)
+{% endif -%}
 stop on stopping docker
 
 kill timeout 20


### PR DESCRIPTION
If in development, wait for `vagrant-mounted` and `docker`. Otherwise, just wait for the `filesystem` and `docker.