### PR TITLE
Ensure that development version of Ashlar is used on restart

### DIFF
--- a/app/Dockerfile.development
+++ b/app/Dockerfile.development
@@ -1,5 +1,5 @@
 FROM driver/app:latest
 
-RUN pip install --no-cache-dir -r dev-requirements.txt
+RUN pip install --no-cache-dir -r dev-requirements.txt --src /opt
 
 CMD ["driver.wsgi", "-w1", "-b:4000", "--reload", "-kgevent"]

--- a/app/dev-requirements.txt
+++ b/app/dev-requirements.txt
@@ -1,2 +1,3 @@
 ipython==3.0.0
 ipdb==0.8.1
+-e git+https://github.com/azavea/ashlar.git@develop#egg=ashlar

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,4 +3,4 @@ djangorestframework-gis==0.9.1
 django-extensions==1.5.5
 django-cors-headers==1.0.0
 django-oauth-toolkit==0.8.1
-git+https://github.com/azavea/ashlar.git@develop
+git+https://github.com/azavea/ashlar.git@develop#egg=ashlar

--- a/deployment/ansible/app.yml
+++ b/deployment/ansible/app.yml
@@ -12,4 +12,3 @@
 
   roles:
     - { role: "driver.app" }
-    - { role: "driver.ashlar" }

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -1,6 +1,6 @@
 ---
 ## DOCKER SETTINGS
-docker_options: "-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock"
+docker_options: "-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock --storage-driver=aufs"
 
 ## POSTGRESQL SETTINGS
 postgresql_host: "{{ lookup('env', 'DRIVER_DATABASE_IP') | default('192.168.11.101', true) }}"

--- a/deployment/ansible/roles/driver.app/tasks/main.yml
+++ b/deployment/ansible/roles/driver.app/tasks/main.yml
@@ -19,6 +19,13 @@
       -f {{ root_app_dir }}/Dockerfile.base
       -t driver/app:latest
       {{ root_app_dir }}
+
+- name: Build application Docker image
+  command: >
+    docker build
+      -f {{ root_app_dir }}/Dockerfile.development
+      -t driver/app:latest
+      {{ root_app_dir }}
   when: developing_or_testing
 
 - name: Configure Driver application service definition

--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -16,23 +16,21 @@ pre-start script
   /usr/bin/docker rm driver-app || true
 end script
 
-script
-  /usr/bin/docker run \
-    --name driver-app \
-    --publish 4000:4000 \
-    --volume {{ root_static_dir }}:{{ root_static_dir }} \
-    --volume {{ root_media_dir }}:{{ root_media_dir }} \
-    {% if developing -%}
-    --volume {{ root_app_dir }}:{{ root_app_dir }} \
-    --volume /opt/ashlar:/opt/ashlar \
-    --env "DJANGO_SETTINGS_MODULE=driver.settings_dev" \
-    {% endif -%}
-    {% for k,v in driver_conf.items() -%}
-    --env {{ k }}={{ v }} \
-    {% endfor -%}
-    --log-driver syslog \
-    driver/app:latest
-end script
+exec /usr/bin/docker run \
+  --name driver-app \
+  --publish 4000:4000 \
+  --volume {{ root_static_dir }}:{{ root_static_dir }} \
+  --volume {{ root_media_dir }}:{{ root_media_dir }} \
+  {% if developing -%}
+  --volume {{ root_app_dir }}:{{ root_app_dir }} \
+  --volume /opt/ashlar:/opt/ashlar \
+  --env "DJANGO_SETTINGS_MODULE=driver.settings_dev" \
+  {% endif -%}
+  {% for k,v in driver_conf.items() -%}
+  --env {{ k }}={{ v }} \
+  {% endfor -%}
+  --log-driver syslog \
+  driver/app:latest
 
 post-stop script
   /usr/bin/docker kill driver-app

--- a/deployment/ansible/roles/driver.ashlar/tasks/main.yml
+++ b/deployment/ansible/roles/driver.ashlar/tasks/main.yml
@@ -1,4 +1,0 @@
----
-- name: Install Ashlar
-  command: >
-    /usr/bin/docker exec -ti driver-app pip install -e /opt/ashlar


### PR DESCRIPTION
A version of Ashlar is installed during the Docker image building process, but that version comes from the `develop` branch on GitHub. In order to support local development, an Upstart task definition runs after `driver-app` enters the `started` state to ensure that Ashlar is re-installed inside of the container on each service restart using the contents of `/opt/ashlar`.