### PR TITLE
Use node:0.10-slim base image for Windshaft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: app editor web
+all: app editor web windshaft
 
 app:
 	docker build -f ./app/Dockerfile.base -t driver/app:latest ./app
@@ -10,4 +10,7 @@ editor:
 web:
 	docker build -f ./web/Dockerfile -t driver/web:latest ./web
 
-.PHONY: all app editor web
+windshaft:
+	docker build -f ./windshaft/Dockerfile -t driver/windshaft:latest ./windshaft
+
+.PHONY: all app editor web windshaft

--- a/windshaft/Dockerfile
+++ b/windshaft/Dockerfile
@@ -1,31 +1,25 @@
-# Windshaft dependencies are for Ubuntu
-FROM ubuntu:vivid
+FROM node:0.10-slim
 
-MAINTAINER Azavea
+MAINTAINER Azavea <systems@azavea.com>
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    nodejs \
-    npm \
     git-core \
     libcairo2-dev \
     libpango1.0-dev \
-    libjpeg8-dev \
+    libjpeg62-turbo-dev \
     libgif-dev \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
-
-# link nodejs command to node
-RUN update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
 
 RUN mkdir -p /opt/windshaft
 WORKDIR /opt/windshaft
 COPY . /opt/windshaft
 
 # NB: the most recent versions do not work with the provided configurations
-RUN npm install windshaft@0.36.0
+RUN npm install --unsafe-perm windshaft@0.36.0
 
 EXPOSE 5000
 
-ENTRYPOINT ["/usr/bin/node"]
+ENTRYPOINT ["node"]
 CMD ["server.js"]


### PR DESCRIPTION
Make use of the `node:0.10-slim` base image to avoid having to install Node.js and NPM properly. Also, add image creation command to `Makefile` for faster rebuilding.

At some point it may make sense to break this image definition out into its own Azavea repository.