### PR TITLE
Increase max upload size to 10MB

### DIFF
--- a/deployment/ansible/roles/driver.app/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/nginx-app.conf.j2
@@ -7,6 +7,8 @@ server {
 
     access_log /var/log/nginx/driver-app.access.log logstash_json;
 
+    client_max_body_size 10m;
+
     location / {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
This is a more reasonable size for most shapefiles. This allows importing the Philippines administrative regions shapefile.