### PR TITLE
Add record constants to detail tabbed view

### DIFF
--- a/scripts/load_pnp_accidents_v2.py
+++ b/scripts/load_pnp_accidents_v2.py
@@ -35,7 +35,7 @@ def transform(record, schema_id):
     obj = {
         'data': {
             'Accident Details': dict(),
-            'Vehicle': dict(),
+            'Vehicle': [],
         },
         'schema': str(schema_id),
         'slug': 'removeme',  # TODO: Remove when removed from Record class.

--- a/web/app/index.html
+++ b/web/app/index.html
@@ -99,6 +99,8 @@
     <script src="scripts/leaflet/leaflet-defaults-provider.js"></script>
 
     <script src="scripts/details/module.js"></script>
+    <script src="scripts/details/details-constants-controller.js"></script>
+    <script src="scripts/details/details-constants-directive.js"></script>
     <script src="scripts/details/details-image-controller.js"></script>
     <script src="scripts/details/details-image-directive.js"></script>
     <script src="scripts/details/details-multiple-controller.js"></script>

--- a/web/app/scripts/details/details-constants-controller.js
+++ b/web/app/scripts/details/details-constants-controller.js
@@ -1,0 +1,13 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsConstantsController() {
+        var ctl = this;
+        ctl.dateFormat = 'MMM d, y h:mm:ss a';
+    }
+
+    angular.module('driver.details')
+    .controller('DetailsConstantsController', DetailsConstantsController);
+
+})();

--- a/web/app/scripts/details/details-constants-directive.js
+++ b/web/app/scripts/details/details-constants-directive.js
@@ -1,0 +1,22 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsConstants() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+                record: '='
+            },
+            templateUrl: 'scripts/details/details-constants-partial.html',
+            bindToController: true,
+            controller: 'DetailsConstantsController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('driver.details')
+    .directive('driverDetailsConstants', DetailsConstants);
+
+})();

--- a/web/app/scripts/details/details-constants-partial.html
+++ b/web/app/scripts/details/details-constants-partial.html
@@ -1,0 +1,38 @@
+<div class="col-sm-6">
+    <label>
+        Occurred
+    </label>
+    <div class="value constant date occurred">
+        {{ ::ctl.record.occurred_from | date : ctl.dateFormat }}
+    </div>
+</div>
+<div class="col-sm-6">
+    <label>
+        Created
+    </label>
+    <div class="value constant date created">
+        {{ ::ctl.record.created | date: ctl.dateFormat }}
+    </div>
+</div>
+<div class="col-sm-6">
+    <label>
+        Latitude
+    </label>
+    <div class="value constant float latitude">
+        {{ ::ctl.record.geom.coordinates[1] }}
+    </div>
+</div>
+<div class="col-sm-6">
+    <label>
+        Longitude
+    </label>
+    <div class="value constant float longitude">
+        {{ ::ctl.record.geom.coordinates[0] }}
+    </div>
+</div>
+<div class="col-md-12">
+    <div class="map" leaflet-map driver-embed-map
+        lat="{{ ::ctl.record.geom.coordinates[1] }}"
+        lng="{{ ::ctl.record.geom.coordinates[0] }}">
+    </div>
+</div>

--- a/web/app/scripts/details/details-multiple-directive.js
+++ b/web/app/scripts/details/details-multiple-directive.js
@@ -8,7 +8,8 @@
             scope: {
                 data: '=',
                 properties: '=',
-                record: '='
+                record: '=',
+                definition: '='
             },
             templateUrl: 'scripts/details/details-multiple-partial.html',
             bindToController: true,

--- a/web/app/scripts/details/details-single-directive.js
+++ b/web/app/scripts/details/details-single-directive.js
@@ -8,7 +8,8 @@
             scope: {
                 data: '=',
                 properties: '=',
-                record: '='
+                record: '=',
+                definition: '='
             },
             templateUrl: 'scripts/details/details-single-partial.html',
             bindToController: true,

--- a/web/app/scripts/details/details-single-partial.html
+++ b/web/app/scripts/details/details-single-partial.html
@@ -1,3 +1,7 @@
+<driver-details-constants
+     ng-if="ctl.definition.details" record="ctl.record">
+</driver-details-constants>
+
 <div ng-repeat="property in ctl.properties">
     <div ng-switch on="property.fieldType"
         ng-init="data = ctl.data[property.propertyName]">

--- a/web/app/scripts/details/details-tabs-partial.html
+++ b/web/app/scripts/details/details-tabs-partial.html
@@ -7,6 +7,7 @@
             data="data"
             properties="properties"
             record="ctl.record"
+            definition="definition"
             ng-if="!definition.multiple">
         </driver-details-single>
 
@@ -14,6 +15,7 @@
             data="data"
             properties="properties"
             record="ctl.record"
+            definition="definition"
             ng-if="definition.multiple">
         </driver-details-multiple>
     </tab>

--- a/web/app/scripts/details/module.js
+++ b/web/app/scripts/details/module.js
@@ -3,7 +3,8 @@
 
     angular.module('driver.details', [
         'ui.bootstrap',
-        'ui.router'
+        'ui.router',
+        'Leaflet'
     ]);
 
 })();

--- a/web/app/scripts/leaflet/leaflet-map-directive.js
+++ b/web/app/scripts/leaflet/leaflet-map-directive.js
@@ -3,7 +3,7 @@
 
     /** Provides access to the leaflet map object instantiated by the directive */
     /* ngInject */
-    function LeafletController($q) {
+    function LeafletController($timeout, $q) {
         var ctl = this;
         var _map = null;
         initialize();
@@ -28,6 +28,12 @@
          */
         function setMap(map) {
             _map.resolve(map);
+
+            // This helps in some situations where the map isn't initially rendered correctly due
+            // to the container size being changed.
+            $timeout(function() {
+                map.invalidateSize();
+            }, 0);
         }
     }
 

--- a/web/test/spec/details/details-constants-controller.spec.js
+++ b/web/test/spec/details/details-constants-controller.spec.js
@@ -1,0 +1,22 @@
+'use strict';
+
+describe('driver.details: DetailsConstantsController', function () {
+
+    beforeEach(module('driver.details'));
+
+    var $controller;
+    var $rootScope;
+    var $scope;
+    var Controller;
+
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_) {
+        $controller = _$controller_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+    }));
+
+    it('should pass this placeholder test', function () {
+        Controller = $controller('DetailsConstantsController', { $scope: $scope });
+        $scope.$apply();
+    });
+});

--- a/web/test/spec/details/details-constants-directive.spec.js
+++ b/web/test/spec/details/details-constants-directive.spec.js
@@ -1,0 +1,35 @@
+'use strict';
+
+describe('driver.details: DetailsConstants', function () {
+
+    beforeEach(module('ase.templates'));
+    beforeEach(module('driver.details'));
+    beforeEach(module('driver.mock.resources'));
+
+    var $compile;
+    var $httpBackend;
+    var $rootScope;
+    var DriverResourcesMock;
+
+    beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_, _DriverResourcesMock_) {
+        $compile = _$compile_;
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+        DriverResourcesMock = _DriverResourcesMock_;
+    }));
+
+    it('should render constants', function () {
+        var scope = $rootScope.$new();
+        scope.record = DriverResourcesMock.RecordResponse.results[0];
+
+        var element = $compile('<driver-details-constants record="record">' +
+                               '</driver-details-constants>')(scope);
+        $rootScope.$apply();
+
+        expect(element.find('.map').length).toEqual(1);
+        expect(element.find('.value.created').length).toEqual(1);
+        expect(element.find('.value.latitude').length).toEqual(1);
+        expect(element.find('.value.longitude').length).toEqual(1);
+        expect(element.find('.value.occurred').length).toEqual(1);
+    });
+});


### PR DESCRIPTION
@flibbertigibbet: for some reason the map is behaving a little weird here. See below. It has a bunch of gray area and the marker is loaded off to the upper-left. When I drag the map down-right it comes into view. Was wondering if you've seen this before or have any insight into how to fix it.

![details_constants](https://cloud.githubusercontent.com/assets/6386/9691276/77d629e4-530f-11e5-833e-83f7669f7271.png)
