### PR TITLE
Ensure Windshaft starts on boot

### DIFF
--- a/deployment/ansible/roles/driver.app/handlers/main.yml
+++ b/deployment/ansible/roles/driver.app/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: Restart driver-app
   service: name=driver-app state=restarted
 
-- name: Restart windshaft
+- name: Restart Windshaft
   service: name=windshaft state=restarted

--- a/deployment/ansible/roles/driver.app/tasks/windshaft.yml
+++ b/deployment/ansible/roles/driver.app/tasks/windshaft.yml
@@ -10,11 +10,13 @@
                dest="/opt/windshaft"
   sudo: False
   when: staging
+  notify:
+    - Restart Windshaft
 
 - name: Configure Windshaft service definition
   template: src=upstart-windshaft.conf.j2 dest=/etc/init/windshaft.conf
   notify:
-    - Restart windshaft
+    - Restart Windshaft
 
 - name: Ensure Windshaft application is running
   service: name=windshaft state=started

--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -1,10 +1,6 @@
 description "driver-app"
 
-{% if 'development' in group_names -%}
-start on (vagrant-mounted and started docker)
-{% else -%}
 start on (filesystem and started docker)
-{% endif -%}
 stop on stopping docker
 
 kill timeout 20
@@ -12,6 +8,10 @@ kill signal CONT
 respawn
 
 pre-start script
+  {% if 'development' in group_names -%}
+  until mountpoint -q {{ root_app_dir }}; do sleep 1; done
+  {% endif %}
+
   /usr/bin/docker kill driver-app || true
   /usr/bin/docker rm driver-app || true
 

--- a/deployment/ansible/roles/driver.app/templates/upstart-windshaft.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-windshaft.conf.j2
@@ -1,10 +1,6 @@
 description "windshaft"
 
-{% if 'development' in group_names -%}
-start on (vagrant-mounted and started docker)
-{% else -%}
 start on (filesystem and started docker)
-{% endif -%}
 stop on stopping docker
 
 kill timeout 20
@@ -12,8 +8,16 @@ kill signal CONT
 respawn
 
 pre-start script
+  {% if 'development' in group_names -%}
+  until mountpoint -q {{ root_windshaft_dir }}; do sleep 1; done
+  {% endif %}
+
   /usr/bin/docker kill windshaft || true
   /usr/bin/docker rm windshaft || true
+
+  {% if 'staging' in group_names -%}
+  /usr/bin/docker pull quay.io/azavea/windshaft:0.1.0
+  {% endif %}
 end script
 
 exec /usr/bin/docker run \


### PR DESCRIPTION
Now, when configuration files associated with Windshaft change, the Windshaft service is restarted.

In addition to this fix, it was discovered that there is a Vagrant regression in emitting the `vagrant-mounted` Upstart event. To work around that, the `pre-start` stanza of both the Windshaft and Driver applications include a wait for their respective source code mount points (in development).

Attempts to resolve #115.

See also: https://github.com/mitchellh/vagrant/issues/6074