### PR TITLE
Closes #110: Add CSRF header to angular apps

### DIFF
--- a/schema_editor/app/scripts/app.js
+++ b/schema_editor/app/scripts/app.js
@@ -14,6 +14,12 @@
         $logProvider.debugEnabled(Config.debug);
     }
 
+    /* ngInject */
+    function HttpConfig($httpProvider) {
+        $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
+        $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+    }
+
     /**
      * @ngdoc overview
      * @name ase
@@ -31,5 +37,6 @@
         'ui.router'
     ])
     .config(DefaultRoutingConfig)
+    .config(HttpConfig)
     .config(LogConfig);
 })();

--- a/web/app/scripts/app.js
+++ b/web/app/scripts/app.js
@@ -26,6 +26,12 @@
         localStorageServiceProvider.setPrefix('DRIVER');
     }
 
+    /* ngInject */
+    function HttpConfig($httpProvider) {
+        $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
+        $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+    }
+
     /**
      * @ngdoc overview
      * @name driver
@@ -52,5 +58,6 @@
     .config(DefaultRoutingConfig)
     .config(LogConfig)
     .config(LeafletDefaultsConfig)
-    .config(LocalStorageConfig);
+    .config(LocalStorageConfig)
+    .config(HttpConfig);
 })();


### PR DESCRIPTION
`X-CSRFToken` header is now sent from angular apps on port 7000 when accessing django.

@kshepard The reason we didn't see the angular apps served on 7001 and 7002 sending `X-CSRFToken` is because they were requesting resources from port 7000; effectively across domains.