### PR TITLE
Feature/user boundary filter

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -105,7 +105,7 @@ Vagrant.configure("2") do |config|
     app.ssh.forward_x11 = true
 
     app.vm.provider :virtualbox do |v|
-      v.memory = ENV.fetch("DRIVER_APP_MEM", 2094)
+      v.memory = ENV.fetch("DRIVER_APP_MEM", 3072)
       v.cpus = ENV.fetch("DRIVER_APP_CPUS", 2)
     end
   end

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -124,12 +124,10 @@
         };
 
         function filterShapeCreated(event) {
-            var type = event.layerType;
-            var layer = event.layer;
+            // TODO: is the shape type useful info?
+            //var type = event.layerType;
 
-            $log.debug('shape type: ' + type);
-            $log.debug('drew layer:');
-            $log.debug(layer);
+            var layer = event.layer;
 
             ctl.editLayers.clearLayers();
             ctl.filterSql = null;
@@ -254,6 +252,7 @@
         ctl.buildRecordPopup = function(record) {
             // read arbitrary record fields object
             var data = JSON.parse(record.data);
+            var startingUnderscoreRegex = /^_/;
 
             // add header with event date constant field
             /* jshint camelcase: false */
@@ -264,14 +263,19 @@
             // build HTML for popup from the record object
             function strFromObj(obj) {
                 angular.forEach(obj, function(value, key) {
-                    if (typeof value === 'object') {
-                        str += '<h4>' + key + '</h4><div style="margin:15px;">';
-                        // recursively add child things, indented
-                        strFromObj(value);
-                        str += '</div>';
-                    } else {
-                        // have a simple value; display it
-                        str += '<p>' + key + ': ' + value + '</p>';
+                    // Skip _localId hashes, any other presumably private values
+                    // starting with an underscore, and their children.
+                    // Checking type because some keys are numeric.
+                    if (typeof key === 'string' && !key.match(startingUnderscoreRegex)) {
+                        if (typeof value === 'object') {
+                            str += '<h4>' + key + '</h4><div style="margin:15px;">';
+                            // recursively add child things, indented
+                            strFromObj(value);
+                            str += '</div>';
+                        } else {
+                            // have a simple value; display it
+                            str += '<p>' + key + ': ' + value + '</p>';
+                        }
                     }
                 });
             }

--- a/web/test/spec/views/map/layers-controller.spec.js
+++ b/web/test/spec/views/map/layers-controller.spec.js
@@ -62,7 +62,7 @@ describe('driver.views.map: Layers Controller', function () {
         // JSONB from record is returned as string from UTFGrid
         record.data = JSON.stringify(record.data);
 
-        var expected = '<div class="record-popup"><div><h3>Occurred on: 2015-07-30T17:36:29.263000Z</h3><h4>Person</h4><div style="margin:15px;"></div><h4>Crime Details</h4><div style="margin:15px;"><p>County: Philadelphia</p><p>Description: First test</p><p>District: 13</p><p>_localId: e116f30b-e493-4d57-9797-a901abddf7d5</p></div><h4>Vehicle</h4><div style="margin:15px;"></div></div></div>';
+        var expected = '<div class="record-popup"><div><h3>Occurred on: 2015-07-30T17:36:29.263000Z</h3><h4>Person</h4><div style="margin:15px;"></div><h4>Crime Details</h4><div style="margin:15px;"><p>County: Philadelphia</p><p>Description: First test</p><p>District: 13</p></div><h4>Vehicle</h4><div style="margin:15px;"></div></div></div>';
 
         var popup = Controller.buildRecordPopup(record);
         expect(popup).toEqual(expected);

--- a/windshaft/driver.js
+++ b/windshaft/driver.js
@@ -86,18 +86,20 @@ function getRequestParameters(request) {
         params.interactivity = 'uuid,occurred_from,data';
         params.style = eventsStyle;
 
-        // build query for record points
-        params.sql = baseRecordQuery;
-        if (params.id !== 'ALL') {
-            params.sql += filterRecordQuery + params.id + "'";
+        // build query for record points if do not already have a query
+        if (request.query.sql) {
+            params.sql = request.query.sql;
+        } else {
+            params.sql = baseRecordQuery;
+            if (params.id !== 'ALL') {
+                params.sql += filterRecordQuery + params.id + "'" + endRecordQuery;
+            }
         }
 
         if (request.query.heatmap) {
             // make a heatmap if optional parameter for that was sent in
             params.style = heatmapStyle;
         }
-
-        params.sql += endRecordQuery;
     } else {
         params.interactivity = 'label';
         params.style = boundaryStyle;


### PR DESCRIPTION
Filter map view by user drawn boundary.

Record list does not yet filter by user boundary, and the map view still does not filter by anything else, other than record type. Those things can go in separate PRs.

Companion PR on ashlar for the boundary filter back-end and endpoint used to get SQL to pass along to Windshaft: azavea/ashlar/pull/47

Also bumps memory for app Vagrant box.