### PR TITLE
Grab polygons rather than geographies

### DIFF
--- a/web/app/scripts/navbar/navbar-controller.js
+++ b/web/app/scripts/navbar/navbar-controller.js
@@ -18,7 +18,6 @@
         function init() {
             GeographyState.getOptions().then(function(opts) { ctl.geographyResults = opts; });
             RecordState.getOptions().then(function(opts) { ctl.recordTypeResults = opts; });
-            BoundaryState.getOptions().then(function(opts) { ctl.boundaryResults = opts; });
             setStates();
         }
 

--- a/web/app/scripts/state/boundarystate-service.js
+++ b/web/app/scripts/state/boundarystate-service.js
@@ -6,7 +6,7 @@
     'use strict';
 
     /* ngInject */
-    function BoundaryState($log, $rootScope, $q, localStorageService, Boundaries) {
+    function BoundaryState($log, $rootScope, $q, localStorageService, Polygons) {
         var defaultParams, selected, options;
         var initialized = false;
         var svc = this;
@@ -32,14 +32,14 @@
          */
         function updateOptions(params) {
             var filterParams = angular.extend({}, defaultParams, params);
-            return Boundaries.query(filterParams).$promise.then(function(results) {
+            return Polygons.query(filterParams).$promise.then(function(results) {
                   options = results;
                   $rootScope.$broadcast('driver.state.boundarystate:options', options);
                   if (!results.length) {
                       $log.warn('No boundaries returned');
                   } else {
                       if (!selected && options[0]) {
-                          selected = svc.setSelected(options[0]);
+                          svc.setSelected(options[0]);
                       } else if (!_.includes(options, selected)) {
                           svc.setSelected(selected);
                       }

--- a/web/test/spec/navbar/navbar-controller.spec.js
+++ b/web/test/spec/navbar/navbar-controller.spec.js
@@ -33,15 +33,13 @@ describe('driver.navbar: NavbarController', function () {
     }));
 
     it('should have record types, boundaries, and available states', function () {
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
         var geographiesUrl = /\/api\/boundaries/;
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        var boundaryUrl = /\/api\/boundaries\/\?active=True/;
+        var boundaryUrl = /\/api\/boundarypolygons/;
 
         $httpBackend.expectGET(geographiesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(boundaryUrl).respond(200, DriverResourcesMock.BoundaryResponse);
+        $httpBackend.expectGET(boundaryUrl).respond(200, DriverResourcesMock.PolygonResponse);
 
         Controller = $controller('NavbarController', {
             $scope: $scope
@@ -57,15 +55,13 @@ describe('driver.navbar: NavbarController', function () {
     });
 
     it('should not have current state as an option', function () {
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
         var geographiesUrl = /\/api\/boundaries/;
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        var boundaryUrl = /\/api\/boundaries\/\?active=True/;
+        var boundaryUrl = /\/api\/boundarypolygons/;
 
         $httpBackend.expectGET(geographiesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(boundaryUrl).respond(200, DriverResourcesMock.BoundaryResponse);
+        $httpBackend.expectGET(boundaryUrl).respond(200, DriverResourcesMock.PolygonResponse);
 
         $state.current = $state.get('dashboard');
 
@@ -85,15 +81,13 @@ describe('driver.navbar: NavbarController', function () {
     });
 
     it('should correctly navigate to state', function () {
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
         var geographiesUrl = /\/api\/boundaries/;
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        var boundaryUrl = /\/api\/boundaries\/\?active=True/;
+        var boundaryUrl = /\/api\/boundarypolygons/;
 
         $httpBackend.expectGET(geographiesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(boundaryUrl).respond(200, DriverResourcesMock.BoundaryResponse);
+        $httpBackend.expectGET(boundaryUrl).respond(200, DriverResourcesMock.PolygonResponse);
 
         Controller = $controller('NavbarController', {
             $scope: $scope,

--- a/web/test/spec/navbar/navbar-directive.spec.js
+++ b/web/test/spec/navbar/navbar-directive.spec.js
@@ -39,7 +39,7 @@ describe('driver.navbar: Navbar', function () {
     it('should load directive', function () {
         var geographiesUrl = /\/api\/boundaries/;
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        var boundaryUrl = /.*\/api\/boundaries\/\?active=True/;
+        var boundaryUrl = /\/api\/boundarypolygons/;
 
         $httpBackend.expectGET(geographiesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);


### PR DESCRIPTION
It looks like this was errantly changed to query the same endpoint as geographies. Reverting to the previous behavior - if performance is an issue, we'll have to do something on the backend.