### PR TITLE
Styling fixes from October 5th

### DIFF
--- a/app/Dockerfile.base
+++ b/app/Dockerfile.base
@@ -4,7 +4,7 @@ RUN mkdir -p /opt/app
 WORKDIR /opt/app
 
 COPY . /opt/app
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --process-dependency-links --allow-external djsonb -r requirements.txt
 
 EXPOSE 4000
 

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -1,5 +1,5 @@
 <div class="form-area no-filterbar">
-    <div class="col-sm-8 col-sm-offset-3">
+    <div class="col-sm-8 col-sm-offset-2">
         <ase-notifications></ase-notifications>
         <div class="form-area-heading">
             <h2>{{ ::ctl.recordType.label }} Input Form</h2>

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -2,48 +2,46 @@
     <div class="col-sm-8 col-sm-offset-3">
         <ase-notifications></ase-notifications>
         <div class="form-area-heading">
-            <h2>{{ ::ctl.recordType.label }} input form</h2>
+            <h2>{{ ::ctl.recordType.label }} Input Form</h2>
             <div class="content-border"></div>
         </div>
         <div class="constant-fields">
-            <div class="col-md-12">
-                <h3><span>Constant fields</span></h3>
-                <p>These fields exist for every record.</p>
-                <div class="well well-sm">
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="form-group">
-                                <label class="control-label">Latitude</label>
-                                <input type="number" class="form-control"
-                                    ng-change="ctl.onGeomChanged()" ng-model="ctl.geom.lat">
-                            </div>
-                        </div>
-                        <div class="col-md-6 pull-right">
-                            <div class="form-group">
-                                <label class="control-label">Longitude</label>
-                                <input type="number" class="form-control"
-                                    ng-change="ctl.onGeomChanged()" ng-model="ctl.geom.lng">
-                            </div>
-                        </div>
-                        <div class="col-md-12">
-                            <div class="map" leaflet-map driver-embed-map editable="true"></div>
+            <h3><span>Constant fields</span></h3>
+            <p>These fields exist for every record.</p>
+            <div class="well">
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="form-group">
+                            <label class="control-label">Latitude</label>
+                            <input type="number" class="form-control"
+                                ng-change="ctl.onGeomChanged()" ng-model="ctl.geom.lat">
                         </div>
                     </div>
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="form-group">
-                                <label class="control-label">Occurred</label>
-                                <div class="input-group" id="datetimepicker-From">
-                                    <input type="text" class="form-control"
-                                        datetimepicker
-                                        datetimepicker-options="{{ ctl.occurredFromOptions }}"
-                                        ng-change="ctl.occurredFromChanged()"
-                                        ng-model="ctl.record.occurred_from"
-                                        placeholder="From">
-                                    <span class="input-group-addon">
-                                        <span class="glyphicon glyphicon-calendar"></span>
-                                    </span>
-                                </div>
+                    <div class="col-md-6 pull-right">
+                        <div class="form-group">
+                            <label class="control-label">Longitude</label>
+                            <input type="number" class="form-control"
+                                ng-change="ctl.onGeomChanged()" ng-model="ctl.geom.lng">
+                        </div>
+                    </div>
+                    <div class="col-md-12">
+                        <div class="map" leaflet-map driver-embed-map editable="true"></div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="form-group">
+                            <label class="control-label">Occurred</label>
+                            <div class="input-group" id="datetimepicker-From">
+                                <input type="text" class="form-control"
+                                    datetimepicker
+                                    datetimepicker-options="{{ ctl.occurredFromOptions }}"
+                                    ng-change="ctl.occurredFromChanged()"
+                                    ng-model="ctl.record.occurred_from"
+                                    placeholder="From">
+                                <span class="input-group-addon">
+                                    <span class="glyphicon glyphicon-calendar"></span>
+                                </span>
                             </div>
                         </div>
                     </div>

--- a/web/app/scripts/views/record/details-partial.html
+++ b/web/app/scripts/views/record/details-partial.html
@@ -1,5 +1,5 @@
 <div class="form-area no-filterbar">
-    <div class="col-sm-8 col-sm-offset-3">
+    <div class="col-sm-8 col-sm-offset-2">
         <ase-notifications></ase-notifications>
         <div class="form-area-heading">
             <h2>{{ ::ctl.recordType.label }} details</h2>

--- a/web/app/scripts/views/record/list-partial.html
+++ b/web/app/scripts/views/record/list-partial.html
@@ -1,27 +1,5 @@
 <div class="table-view">
     <div class="table-view-container">
-        <div class="filters">
-            <div class="row">
-                <div class="col-xs-3">
-                    <input type="search" class="form-control" placeholder="Search by name, keyword" /></div>
-                <div class="col-xs-6">
-                    <select class="selectpicker">
-                        <option>Status</option>
-                    </select>
-                    <select class="selectpicker">
-                        <option>All Records</option>
-                    </select>
-                    <select class="selectpicker">
-                        <option>Last 90 Days</option>
-                    </select>
-                </div>
-                <div class="col-xs-3">
-                    <a class="btn btn-default pull-right" ui-sref="record.add()">
-                        Add New {{ ctl.recordType.label }}
-                    </a>
-                </div>
-            </div>
-        </div>
         <div class="overflow">
             <table class="table">
                 <thead>

--- a/web/app/scripts/views/record/list-partial.html
+++ b/web/app/scripts/views/record/list-partial.html
@@ -36,24 +36,26 @@
                     </tr>
                 </tbody>
             </table>
-            <div>
-                <button ng-if="ctl.records.next" type="button" class="btn btn-primary pull-right"
-                        ng-click="ctl.getNextRecords()">
-                    Next
-                </button>
-                <button ng-if="ctl.records.previous" type="button" class="btn btn-primary"
-                        ng-click="ctl.getPreviousRecords()">
-                    Previous
-                </button>
-            </div>
-            <div ng-if="ctl.records.count">
-                <i>
-                    Showing results
-                    {{ ctl.currentOffset + 1}} -
-                    {{ ctl.currentOffset + ctl.records.results.length }} of
-                    {{ ctl.records.count }}
-                </i>
-            </div>
+            <nav>
+                <ul class="pager">
+                    <li class="previous" ng-if="ctl.records.previous">
+                        <a type="button" class="btn btn-default" ng-click="ctl.getPreviousRecords()">
+                            <span aria-hidden="true">&larr;</span> Previous</a>
+                    </li>
+                    <li ng-if="ctl.records.count" class="text-center">
+                        <i>
+                            Showing results
+                            {{ ctl.currentOffset + 1}} -
+                            {{ ctl.currentOffset + ctl.records.results.length }} of
+                            {{ ctl.records.count }}
+                        </i>
+                    </li>
+                    <li class="next" ng-if="ctl.records.next">
+                        <a type="button" class="btn btn-default" ng-click="ctl.getNextRecords()">
+                            Next <span aria-hidden="true">&rarr;</span></a>
+                    </li>
+                </ul>
+            </nav>
         </div>
     </div>
 </div>

--- a/web/app/scripts/views/record/list-partial.html
+++ b/web/app/scripts/views/record/list-partial.html
@@ -29,9 +29,13 @@
                         </td>
 
                         <td class="links">
-                            <a ui-sref="record.details({ rtuuid: ctl.recordType.uuid, recorduuid: record.uuid })">View</a>
-                            /
-                            <a ui-sref="record.edit({ rtuuid: ctl.recordType.uuid, recorduuid: record.uuid })">Edit</a>
+                            <a ui-sref="record.details({ rtuuid: ctl.recordType.uuid, recorduuid: record.uuid })">
+                                <span class="glyphicon glyphicon-eye-open"></span> View
+                            </a>
+                            <span class="links-separator">|</span>
+                            <a ui-sref="record.edit({ rtuuid: ctl.recordType.uuid, recorduuid: record.uuid })">
+                                <span class="glyphicon glyphicon-pencil"></span> Edit
+                            </a>
                         </td>
                     </tr>
                 </tbody>

--- a/web/app/styles/_helpers.scss
+++ b/web/app/styles/_helpers.scss
@@ -5,3 +5,23 @@
     width: 100%;
     background: #ddd;
 }
+.n {
+    padding: 5px 10px;
+    font-size: 14px;
+    font-weight: 700;
+    background-color: black;
+    background-color: rgba(0,0,0,0.9);
+    color: white;
+
+    &:after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        margin-left: -5px;
+        width: 0; 
+        height: 0; 
+        border-left: 10px solid transparent;
+        border-right: 10px solid transparent;
+        border-top: 10px solid rgba(0,0,0,0.9);
+    }
+}

--- a/web/app/styles/_layout.scss
+++ b/web/app/styles/_layout.scss
@@ -51,7 +51,7 @@ main {
 
 .form-area {
 	position: relative;
-	padding-top: 80px;
+	padding-top: 40px;
 }
 
 /* MAIN BODY HEADING */

--- a/web/app/styles/partials/_filterbar.scss
+++ b/web/app/styles/partials/_filterbar.scss
@@ -23,5 +23,5 @@ div.navbar-default.filterbar {
 }
 
 .no-filterbar {
-    top: 0;
+    top: 50px;
 }

--- a/web/app/styles/partials/_filterbar.scss
+++ b/web/app/styles/partials/_filterbar.scss
@@ -23,5 +23,5 @@ div.navbar-default.filterbar {
 }
 
 .no-filterbar {
-    top: 57px;
+    top: 0;
 }

--- a/web/app/styles/partials/_map.scss
+++ b/web/app/styles/partials/_map.scss
@@ -1,6 +1,29 @@
 .records-map, driver-map {
 	position: fixed;
-  top: 112px;
-  width: 100%;
-  bottom: 0;
+    top: 112px;
+    width: 100%;
+    bottom: 0;
+}
+
+.leaflet-control-layers-expanded {
+    
+    label {
+        margin-top: 4px;
+    }
+
+    .leaflet-control-layers-base label {
+        margin-top: 0;
+    }
+    .leaflet-control-layers-list {
+        background: none;
+        padding: 5px 5px 10px;
+    }
+    .leaflet-control-layers-separator {
+        margin: 5px -15px 10px -11px;
+    }
+
+    input[type=checkbox], input[type=radio] {
+        margin-right: 5px;
+        top: -1px;
+    }
 }

--- a/web/app/styles/partials/_record-list.scss
+++ b/web/app/styles/partials/_record-list.scss
@@ -1,8 +1,7 @@
-driver-record-list, driver-record-details {
+driver-record-list {
 	position: fixed;
     top: 55px;
     width: 100%;
     bottom: 0;
     overflow: scroll;
 }
-

--- a/web/app/styles/partials/_record-list.scss
+++ b/web/app/styles/partials/_record-list.scss
@@ -1,6 +1,6 @@
 driver-record-list {
 	position: fixed;
-    top: 55px;
+    top: 105px;
     width: 100%;
     bottom: 0;
     overflow: scroll;

--- a/web/app/styles/partials/_record-list.scss
+++ b/web/app/styles/partials/_record-list.scss
@@ -1,8 +1,8 @@
 driver-record-list, driver-record-details {
 	position: fixed;
-  top: 112px;
-  width: 100%;
-  bottom: 0;
-  overflow: scroll;
+    top: 55px;
+    width: 100%;
+    bottom: 0;
+    overflow: scroll;
 }
 

--- a/web/app/styles/partials/_table-view.scss
+++ b/web/app/styles/partials/_table-view.scss
@@ -20,6 +20,11 @@
         top: 0;
         bottom: 0;
         overflow: auto;
+
+        nav {
+            position: relative;
+            padding: 0 20px;
+        }
     }
     .table {
         margin: 0;

--- a/web/app/styles/partials/_table-view.scss
+++ b/web/app/styles/partials/_table-view.scss
@@ -13,6 +13,18 @@
         top: 0;
         left: 0;
         right: 0;
+
+        .links {
+            font-weight: 700;
+            
+            span {
+                margin-right: 5px;
+            }
+            .links-separator {
+                padding: 0 10px;
+                color: #CCC;
+            }
+        }
     }
     .overflow {
         position: absolute;

--- a/web/app/styles/partials/_table-view.scss
+++ b/web/app/styles/partials/_table-view.scss
@@ -3,7 +3,7 @@
     position: absolute;
     bottom: 0;
     width: 100%;
-    top: 52px;
+    top: 0;
 
     .table-view-container {
         margin: 25px;
@@ -14,23 +14,10 @@
         left: 0;
         right: 0;
     }
-    .filters {
-        padding: 15px;
-
-        .form-control {
-            padding: 20px 16px;
-        }
-        .bootstrap-select {
-            margin-right: 10px;
-        }
-        .btn {
-            padding: 10px 16px;
-        }
-    }
     .overflow {
         position: absolute;
         width: 100%;
-        top: 75px;
+        top: 0;
         bottom: 0;
         overflow: auto;
     }


### PR DESCRIPTION
A number of things to note in this pull request (each commit has details, and I've started discussions on several issues now labeled "Help wanted" where needed).

•  We have prototypes, and where possible, we should try to use them. I only noticed a few places, particular the filter bar, where we need to pull in that styling.
•  We shouldn't hide buttons, instead use disabled state when not clickable.
•  I've added in a prototype view of the "Saved filters" modal in the `topic/prototype` directory.
•  I made some suggestions on how to improve the TODDOW styling, and added some style to the tooltip which currently gets a class of "n"—if that changes, we'll need to update the Sass.