### PR TITLE
Switch boundary colors to lowercase

### DIFF
--- a/schema_editor/app/scripts/views/geography/add-controller.js
+++ b/schema_editor/app/scripts/views/geography/add-controller.js
@@ -90,7 +90,7 @@
                                       'select a primary field for display',
                                 displayClass: 'alert-info'});
             ctl.files = [];
-            ctl.colors = ['Red', 'Blue', 'Green'];
+            ctl.colors = ['red', 'blue', 'green'];
         }
     }
 

--- a/schema_editor/app/scripts/views/geography/edit-controller.js
+++ b/schema_editor/app/scripts/views/geography/edit-controller.js
@@ -29,7 +29,7 @@
         };
 
         function initialize() {
-            ctl.colors = ['Red', 'Blue', 'Green'];
+            ctl.colors = ['red', 'blue', 'green'];
             ctl.workingGeo = Geography.get({ uuid: $stateParams.uuid });
         }
     }

--- a/schema_editor/app/styles/partials/_add-new.scss
+++ b/schema_editor/app/styles/partials/_add-new.scss
@@ -9,21 +9,21 @@
 
 /* background-image in select doesn't work in Chrome */
 
-	select#boundary-color option[value="Red"] {
+	select#boundary-color option[value="red"] {
 		background-image: url(red.png);
 		background-repeat: no-repeat;
 		background-position: bottom left; 
 		padding-left: 30px;
 	}
 
-	select#boundary-color option[value="Blue"] {
+	select#boundary-color option[value="blue"] {
 		background-image: url(blue.png);
 		background-repeat: no-repeat;
 		background-position: bottom left; 
 		padding-left: 30px;
 	}
 
-	select#boundary-color option[value="Green"] {
+	select#boundary-color option[value="green"] {
 		background-image: url(green.png);
 		background-repeat: no-repeat;
 		background-position: bottom left; 


### PR DESCRIPTION
This should allow boundary colors specified in the schema-editor to properly show up properly on the map. Existing boundaries may need to be manually updated.