### PR TITLE
Recent events dashboard map

### DIFF
--- a/web/app/index.html
+++ b/web/app/index.html
@@ -136,6 +136,10 @@
     <script src="scripts/views/dashboard/module.js"></script>
     <script src="scripts/views/dashboard/dashboard-controller.js"></script>
     <script src="scripts/views/dashboard/dashboard-directive.js"></script>
+    <script src="scripts/map-layers/module.js"></script>
+    <script src="scripts/map-layers/tile-url-service.js"></script>
+    <script src="scripts/map-layers/recent-events/module.js"></script>
+    <script src="scripts/map-layers/recent-events/recent-events-layer-directive.js"></script>
     <script src="scripts/views/map/module.js"></script>
     <script src="scripts/views/map/map-controller.js"></script>
     <script src="scripts/views/map/map-directive.js"></script>

--- a/web/app/scripts/map-layers/module.js
+++ b/web/app/scripts/map-layers/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('driver.map-layers', []);
+})();

--- a/web/app/scripts/map-layers/module.js
+++ b/web/app/scripts/map-layers/module.js
@@ -1,5 +1,5 @@
 (function () {
     'use strict';
 
-    angular.module('driver.map-layers', []);
+    angular.module('driver.map-layers', ['driver.config']);
 })();

--- a/web/app/scripts/map-layers/recent-events/module.js
+++ b/web/app/scripts/map-layers/recent-events/module.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    angular.module('driver.map-layers.recent-events', [
+        'Leaflet',
+        'driver.config',
+        'driver.state',
+        'driver.map-layers',
+        'driver.resources'
+        ]);
+})();

--- a/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
+++ b/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
@@ -46,7 +46,7 @@
                 detectRetina: true,
                 zIndex: 1
             };
-            TileUrlService.positronUrl().then(function(url) {
+            TileUrlService.baseLayerUrl().then(function(url) {
                 var streets = new L.tileLayer(url, streetsOptions);
                 newMap.addLayer(streets);
             });

--- a/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
+++ b/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
@@ -1,0 +1,102 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function recentEventsMapLayers(RecordState, TileUrlService, QueryBuilder) {
+        var cartoDBAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
+        var defaultLayerOptions = {attribution: 'PRS', detectRetina: true};
+        var recencyCutoffDays = 14;
+
+        var recordLayers = null;
+        var module = {
+            restrict: 'A',
+            scope: false,
+            replace: false,
+            controller: '',
+            require: ['leafletMap'],
+            link: link
+        };
+        return module;
+
+        function link(scope, element, attrs, controllers) {
+            var leafletController = controllers[0];
+
+            leafletController.getMap().then(addBaseLayers).then(updateLayers);
+
+            // Update when boundary is changed (currently a no-op, but that will change once we add
+            // boundary filtering). Function parameters commented out to show what's available.
+            scope.$on('driver.state.boundarystate:selected', function(/*event, selected*/) {
+                leafletController.getMap().then(updateLayers);
+            });
+
+            // TODO: Remove when the record type picker is removed.
+            scope.$on('driver.state.recordstate:selected', function() {
+                leafletController.getMap().then(updateLayers);
+            });
+        }
+        /**
+         * Initialize layers on map.
+         *
+         * @param {Object} map Leaflet map returned by leaflet directive initialization.
+         */
+        function addBaseLayers(newMap) {
+            // add base layer
+            var streetsOptions = {
+                attribution: cartoDBAttribution,
+                detectRetina: true,
+                zIndex: 1
+            };
+            TileUrlService.positronUrl().then(function(url) {
+                var streets = new L.tileLayer(url, streetsOptions);
+                newMap.addLayer(streets);
+            });
+
+            return newMap;
+        }
+
+        /**
+         * Update the layers displaying on the map in response to changes
+         *
+         * @param {Object} map Leaflet map to update layers on
+         */
+        function updateLayers(map) {
+            var recordsLayerOptions = angular.extend(defaultLayerOptions, {zIndex: 3});
+            var occurredMin = new Date();
+            occurredMin.setDate(occurredMin.getDate() - recencyCutoffDays);
+            // TODO: Boundary filtering somewhere in here.
+            // TODO: Since RecordType selection is going away, this may have to change
+            RecordState.getSelected().then(function(selected) {
+                return TileUrlService.recTilesUrl(selected.uuid);
+            // Construct Windshaft URL
+            }).then(function(baseUrl) {
+                // TODO: Change whenever we figure out a better Windshaft query strategy
+                return QueryBuilder.unfilteredDjangoQuery(0,
+                    {query: true,
+/* jshint camelcase: false */ occurred_min: occurredMin.toISOString()} /* jshint camelcase: true */
+                ).then(function(result) {
+                        var queryParam = baseUrl.match(/\?/) ? '&sql=' : '?sql=';
+                        var sql = encodeURIComponent(result.query);
+                        return baseUrl + queryParam + sql;
+                });
+            // Swap layers
+            }).then(function(fullUrl) {
+                // Remove existing layers
+                if (recordLayers) {
+                    angular.forEach(recordLayers, function(layer) {
+                        map.removeLayer(layer);
+                    });
+                }
+                // Add new layers
+                var recordsLayer = new L.tileLayer(fullUrl, recordsLayerOptions);
+                recordLayers = {
+                    'Recent records': recordsLayer
+                };
+                map.addLayer(recordsLayer);
+            });
+        }
+    }
+
+    angular.module('driver.map-layers.recent-events')
+        .directive('recentEvents', recentEventsMapLayers);
+
+})();

--- a/web/app/scripts/map-layers/tile-url-service.js
+++ b/web/app/scripts/map-layers/tile-url-service.js
@@ -1,0 +1,52 @@
+(function () {
+    'use strict';
+
+    // TODO: Finish refactor by changing the views/map/layers-controller.js and the embed-map
+    // controller to use this.
+    function TileUrlService($q, WebConfig) {
+        var allRecordsUrl = (WebConfig.windshaft.hostname +
+            '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.png');
+        var allRecordsUtfGridUrl = (WebConfig.windshaft.hostname +
+            '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.grid.json');
+        var positronUrl = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
+
+        var module = {
+            recTilesUrl: recordsTilesUrlForType,
+            allRecTilesUrl: recordsTilesUrlForAll,
+            recUtfGridTilesUrl: recordsUtfGridTilesUrlForType,
+            allRecUtfGridTilesUrl: recordsUtfGridTilesUrlForAll,
+            positronUrl: getPositronUrl
+        };
+        return module;
+
+        function recordsTilesUrlForAll() {
+            return _makePromise(allRecordsUrl);
+
+        }
+
+        function recordsTilesUrlForType(typeUuid) {
+            return _makePromise(allRecordsUrl.replace(/ALL/, typeUuid));
+        }
+
+        function recordsUtfGridTilesUrlForAll() {
+            return _makePromise(allRecordsUtfGridUrl);
+        }
+
+        function recordsUtfGridTilesUrlForType(typeUuid) {
+            return _makePromise((allRecordsUtfGridUrl.replace(/ALL/, typeUuid)));
+        }
+
+        function getPositronUrl() {
+            return _makePromise(positronUrl);
+        }
+
+        function _makePromise(value) {
+            var promise = $q.defer();
+            promise.resolve(value);
+            return promise.promise;
+        }
+    }
+
+    angular.module('driver.map-layers')
+    .factory('TileUrlService', TileUrlService);
+})();

--- a/web/app/scripts/map-layers/tile-url-service.js
+++ b/web/app/scripts/map-layers/tile-url-service.js
@@ -15,7 +15,7 @@
             allRecTilesUrl: recordsTilesUrlForAll,
             recUtfGridTilesUrl: recordsUtfGridTilesUrlForType,
             allRecUtfGridTilesUrl: recordsUtfGridTilesUrlForAll,
-            positronUrl: getPositronUrl
+            baseLayerUrl: getBaseLayerUrl
         };
         return module;
 
@@ -36,7 +36,7 @@
             return _makePromise((allRecordsUtfGridUrl.replace(/ALL/, typeUuid)));
         }
 
-        function getPositronUrl() {
+        function getBaseLayerUrl() {
             return _makePromise(positronUrl);
         }
 

--- a/web/app/scripts/resources/query-builder-service.js
+++ b/web/app/scripts/resources/query-builder-service.js
@@ -12,8 +12,8 @@
     function QueryBuilder($q, FilterState, RecordState, Records) {
         var svc = {
             djangoQuery: djangoQuery,
-            unfilteredDjangoQuery: function(extraParams, offset) {
-                return djangoQuery(extraParams, offset, false);
+            unfilteredDjangoQuery: function(offset, extraParams) {
+                return djangoQuery(false, offset, extraParams);
             },
             windshaftQuery: windshaftQuery,
             unfilteredWindshaftQuery: function() { return windshaftQuery({}, false); },
@@ -28,10 +28,12 @@
          * This function takes two (optional) arguments, compiles a query, and carries out the
          *  corresponding request for filtering django records.
          *
-         * @param {bool} doFilter If true: filter results
+         * @param {bool} doFilter If true: Generate a filter from FilterState service.
          * @param {number} offset The page in django's pagination to return
          * @param {object} extraParams an object whose properties are extra parameters
-         *                             not otherwise configured
+         *                             not otherwise configured. Can include extra filters here
+         *                             that will be included along with those from FilterState,
+         *                             or used independently if doFilter is false.
          */
         function djangoQuery(doFilter, offset, extraParams) {
             var deferred = $q.defer();

--- a/web/app/scripts/views/dashboard/dashboard-partial.html
+++ b/web/app/scripts/views/dashboard/dashboard-partial.html
@@ -8,11 +8,11 @@
             </div>
         </div>
         <div class="block block-1x2 quick-map">
-            <div element-stats class="block-inner">
-                <driver-stepwise chart-data="ctl.records"></driver-stepwise>
+            <div class="block-inner">
+                <div class="map" leaflet-map recent-events></div>
             </div>
-                <h3>Recent Accidents
-                    <a href="javascript:void(0);" class="small pull-right">View all accidents »</a>
+                <h3>{{ ctl.recordType.plural_label }} during the past two weeks
+                  <a ui-sref="map" class="small pull-right">View all {{ ctl.recordType.plural_label | lowercase }} »</a>
                 </h3>
             </div>
         </div>

--- a/web/app/scripts/views/dashboard/module.js
+++ b/web/app/scripts/views/dashboard/module.js
@@ -19,7 +19,8 @@
         'driver.toddow',
         'driver.stepwise',
         'driver.elemstat',
-        'driver.state'
+        'driver.state',
+        'driver.map-layers.recent-events'
     ]).config(StateConfig);
 
 })();

--- a/web/test/karma.conf.js
+++ b/web/test/karma.conf.js
@@ -96,6 +96,8 @@ module.exports = function(config) {
       'app/scripts/views/record/**.js',
       'app/scripts/leaflet/module.js',
       'app/scripts/leaflet/**.js',
+      'app/scripts/map-layers/module.js',
+      'app/scripts/map-layers/**/*.js',
       'app/scripts/details/module.js',
       'app/scripts/details/**.js',
       'test/ase-mock/**/*.js',

--- a/web/test/spec/map-layers/recent-events/recent-events-layer-directive.spec.js
+++ b/web/test/spec/map-layers/recent-events/recent-events-layer-directive.spec.js
@@ -1,0 +1,34 @@
+'use strict';
+
+describe('driver.map-layers.recent-events: Recent Events Layer Directive', function () {
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('driver.map-layers.recent-events'));
+
+    var $compile;
+    var $rootScope;
+    var $httpBackend;
+    var ResourcesMock;
+
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_, _ResourcesMock_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        $httpBackend = _$httpBackend_;
+        ResourcesMock = _ResourcesMock_;
+    }));
+
+    it('should create a leaflet map', function () {
+        var scope = $rootScope.$new();
+        var element = $compile('<div leaflet-map recent-events></div>')(scope);
+
+        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+
+        $rootScope.$digest();
+        $rootScope.$digest();
+
+        // placeholder test
+        expect(element.find('div.leaflet-tile-pane').length).toEqual(1);
+    });
+
+});

--- a/web/test/spec/map-layers/tile-url-service-spec.js
+++ b/web/test/spec/map-layers/tile-url-service-spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+describe('driver:map-layers TileUrlService', function () {
+    beforeEach(module('driver.map-layers'));
+
+    var TileUrlService;
+    var $rootScope;
+
+    beforeEach(inject(function (_$rootScope_, _TileUrlService_) {
+        TileUrlService = _TileUrlService_;
+        $rootScope = _$rootScope_;
+    }));
+
+    it('should provide URLs to access PNG tiles of all records', function () {
+        TileUrlService.allRecTilesUrl().then(function(url) {
+            expect(url).toEqual(jasmine.stringMatching(/\.png/));
+        });
+        $rootScope.$apply();
+    });
+
+    it('should provide URLs to access UTF Grid tiles of all records', function () {
+        TileUrlService.allRecUtfGridTilesUrl().then(function(url) {
+            expect(url).toEqual(jasmine.stringMatching((/\.grid\.json/)));
+        });
+        $rootScope.$apply();
+    });
+
+    it('should provide URLs to access PNG tiles per record type', function () {
+        TileUrlService.recTilesUrl('notarealuuid').then(function(url) {
+            expect(url).toEqual(jasmine.stringMatching(/\.png/));
+            expect(url).toEqual(jasmine.stringMatching(/notarealuuid/));
+        });
+        $rootScope.$apply();
+    });
+
+    it('should provide URLs to access UTF Grid tiles per record type', function () {
+        TileUrlService.recUtfGridTilesUrl('notarealuuid').then(function(url) {
+            expect(url).toEqual(jasmine.stringMatching(/\.grid\.json/));
+            expect(url).toEqual(jasmine.stringMatching(/notarealuuid/));
+        });
+        $rootScope.$apply();
+    });
+
+    it('should provide a base tile layer URL', function () {
+        TileUrlService.baseLayerUrl().then(function(url) {
+            expect(url).toEqual(jasmine.stringMatching(/\.png/));
+        });
+    });
+
+});

--- a/web/test/spec/views/dashboard/dashboard-directive.spec.js
+++ b/web/test/spec/views/dashboard/dashboard-directive.spec.js
@@ -34,6 +34,6 @@ describe('driver.views.dashboard: Dashboard', function () {
         $rootScope.$apply();
 
         // placeholder test
-        expect(element.find('driver-stepwise').length).toEqual(1);
+        expect(element.find('driver-toddow').length).toEqual(1);
     });
 });


### PR DESCRIPTION
Uses a 14-day cutoff for recent events; if none occurred, none will appear on the map. I added a service for constructing tile layer urls because we use them in several spots, but I didn't have time to fully integrate it with some of the other maps so I put in a todo.
![prsrecentevents](https://cloud.githubusercontent.com/assets/447977/10435319/3d874b28-70ed-11e5-9587-ecbe94339363.png)
