### PR TITLE
Add temporary 'Add New' record button

### DIFF
--- a/web/app/scripts/views/record/list-partial.html
+++ b/web/app/scripts/views/record/list-partial.html
@@ -1,6 +1,13 @@
 <div class="table-view">
     <div class="table-view-container">
         <div class="overflow">
+            <!-- TODO: this is a temporary location for the Add Record button which has been removed -->
+            <div>
+                <a class="btn btn-default pull-right" ui-sref="record.add()">
+                    Add New {{ ctl.recordType.label }}
+                </a>
+            </div>
+
             <table class="table">
                 <thead>
                     <tr>


### PR DESCRIPTION
This button was accidentally removed during some styling changes in #171. Adding it back here temporarily to re-enable the ability to add new records, but it will need to be moved/styled accordingly.

Trivial, merging.