### PR TITLE
Feature/back on cancel

### DIFF
--- a/web/app/scripts/filterbar/filterbar-controller.js
+++ b/web/app/scripts/filterbar/filterbar-controller.js
@@ -6,6 +6,7 @@
         var ctl = this;
         ctl.filters = {};
         ctl.filterPolygon = null;
+        ctl.recordLabel = '';
 
         /**
          * A simple function to add/update a filter
@@ -55,6 +56,10 @@
          */
         $scope.$on('driver.state.recordstate:selected', function(event, selected) {
             if (selected) {
+
+                // get label for add record button
+                ctl.recordLabel = selected.label;
+
                 RecordSchemas.get({
                   /* jshint ignore:start */
                   id: selected.current_schema

--- a/web/app/scripts/filterbar/filterbar.html
+++ b/web/app/scripts/filterbar/filterbar.html
@@ -1,5 +1,5 @@
 <div class="navbar navbar-default drop-shadow filterbar collapse navbar-collapse">
-    <div class="pull-left form-inline nav navbar=nav">
+    <div class="navbar-left form-inline nav navbar=nav">
         <div class="navbar-header">
             <input type="search" class="form-control" placeholder="Geographic code"></input>
         </div>
@@ -10,6 +10,12 @@
             <ul class="nav navbar-nav" ng-repeat="(key, value) in filterbar.filterables">
                 <li ng-if="value.format=='number'" numeric-range-field label="key" data="value" class="dropdown"></li>
                 <li ng-if="value.fieldType=='selectlist'" options-field label="key" data="value" class="dropdown"></li>
+            </ul>
+            <ul class="nav navbar-nav navbar-right">
+                <!-- TODO: this is a temporary location for the Add Record button which has been removed -->
+                <a class="btn btn-default" ui-sref="record.add()">
+                    Add New {{ ctl.recordType.label }}
+                </a>
             </ul>
         </ul>
     </div>

--- a/web/app/scripts/filterbar/filterbar.html
+++ b/web/app/scripts/filterbar/filterbar.html
@@ -14,7 +14,7 @@
             <ul class="nav navbar-nav navbar-right">
                 <!-- TODO: this is a temporary location for the Add Record button which has been removed -->
                 <a class="btn btn-default" ui-sref="record.add()">
-                    Add New {{ ctl.recordType.label }}
+                    Add New {{ filterbar.recordLabel }}
                 </a>
             </ul>
         </ul>

--- a/web/app/scripts/filterbar/filterbar.html
+++ b/web/app/scripts/filterbar/filterbar.html
@@ -12,7 +12,6 @@
                 <li ng-if="value.fieldType=='selectlist'" options-field label="key" data="value" class="dropdown"></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <!-- TODO: this is a temporary location for the Add Record button which has been removed -->
                 <a class="btn btn-default" ui-sref="record.add()">
                     Add New {{ filterbar.recordLabel }}
                 </a>

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /* ngInject */
-    function RecordAddEditController($log, $scope, $state, $stateParams, uuid4,
+    function RecordAddEditController($log, $scope, $state, $stateParams, $window, uuid4,
                                      Nominatim, Notifications, Records, RecordSchemas,
                                      RecordState) {
         var ctl = this;
@@ -17,6 +17,7 @@
 
         // Initialize for either adding or editing, depending on recorduuid being supplied
         function initialize() {
+            ctl.goBack = goBack;
             ctl.onDataChange = onDataChange;
             ctl.onSaveClicked = onSaveClicked;
             ctl.occurredFromChanged = occurredFromChanged;
@@ -226,6 +227,10 @@
             /* jshint camelcase: true */
 
             return true;
+        }
+
+        function goBack() {
+            $window.history.back();
         }
 
         function onSaveClicked() {

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -67,7 +67,7 @@
             <button type="button" class="btn btn-default" ng-disabled="ctl.editor.errors.length > 0"
                     ng-click="ctl.onSaveClicked()">Save</button>
             <button type="button" class="btn btn-default"
-                    ui-sref="dashboard">Cancel</button>
+                    ui-sref="record.list">Cancel</button>
             </div>
         </div>
     </div>

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -67,7 +67,7 @@
             <button type="button" class="btn btn-default" ng-disabled="ctl.editor.errors.length > 0"
                     ng-click="ctl.onSaveClicked()">Save</button>
             <button type="button" class="btn btn-default"
-                    ui-sref="record.list">Cancel</button>
+                    ng-click="ctl.goBack()">Cancel</button>
             </div>
         </div>
     </div>

--- a/web/app/scripts/views/record/list-partial.html
+++ b/web/app/scripts/views/record/list-partial.html
@@ -1,13 +1,6 @@
 <div class="table-view">
     <div class="table-view-container">
         <div class="overflow">
-            <!-- TODO: this is a temporary location for the Add Record button which has been removed -->
-            <div>
-                <a class="btn btn-default pull-right" ui-sref="record.add()">
-                    Add New {{ ctl.recordType.label }}
-                </a>
-            </div>
-
             <table class="table">
                 <thead>
                     <tr>


### PR DESCRIPTION
* Moves the add new record button to the filterbar, so new records can be added from either the map or record list view (wireframes had it in both places).

* Uses browser history to allow `Cancel` button to go back to record list or map view, as is appropriate.