### PR TITLE
Fix edit/delete draw tools

### DIFF
--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -88,13 +88,10 @@
                             shapeOptions: {
                                 //color: '#bdda55'
                             }
-                        },
-                        edit: {
-                            FeatureGroup: ctl.editLayers,
-                            // TODO: why aren't the edit and remove toolbar buttons showing?
-                            edit: true,
-                            remove: true
                         }
+                    },
+                    edit: {
+                        featureGroup: ctl.editLayers
                     }
                 });
 
@@ -105,8 +102,10 @@
                     filterShapeCreated(e.layer);
                 });
 
-                ctl.map.on('draw:editstop', function(e) {
-                    filterShapeCreated(e.layer);
+                ctl.map.on('draw:edited', function(e) {
+                    e.layers.eachLayer(function(layer) {
+                        filterShapeCreated(layer);
+                    });
                 });
 
                 // only allow one filter shape at a time


### PR DESCRIPTION
The reasons why this wasn't working is that the `featureGroup` key was incorrectly capitalized, and the `edit` key was inside the `draw` object, when it should have been parallel to it.