### PR TITLE
TODDOW fixups

### DIFF
--- a/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
+++ b/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
@@ -43,7 +43,7 @@
             // add base layer
             var streetsOptions = {
                 attribution: cartoDBAttribution,
-                detectRetina: true,
+                detectRetina: false,
                 zIndex: 1
             };
             TileUrlService.baseLayerUrl().then(function(url) {

--- a/web/app/scripts/map-layers/tile-url-service.js
+++ b/web/app/scripts/map-layers/tile-url-service.js
@@ -9,35 +9,50 @@
         var allRecordsUtfGridUrl = (WebConfig.windshaft.hostname +
             '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.grid.json');
         var positronUrl = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
+        var allBoundariesUrl = '/tiles/table/ashlar_boundary/id/ALL/{z}/{x}/{y}.png';
+        var heatmapUrl = allRecordsUrl + '?heatmap=true';
 
         var module = {
             recTilesUrl: recordsTilesUrlForType,
-            allRecTilesUrl: recordsTilesUrlForAll,
             recUtfGridTilesUrl: recordsUtfGridTilesUrlForType,
-            allRecUtfGridTilesUrl: recordsUtfGridTilesUrlForAll,
+            recHeatmapUrl: recordsHeatmapTilesUrl,
+            boundaryTilesUrl: boundaryTilesUrl,
             baseLayerUrl: getBaseLayerUrl
         };
         return module;
 
-        function recordsTilesUrlForAll() {
-            return _makePromise(allRecordsUrl);
-
-        }
-
         function recordsTilesUrlForType(typeUuid) {
-            return _makePromise(allRecordsUrl.replace(/ALL/, typeUuid));
-        }
-
-        function recordsUtfGridTilesUrlForAll() {
-            return _makePromise(allRecordsUtfGridUrl);
+            return _insertIdAtALL(allRecordsUrl, typeUuid);
         }
 
         function recordsUtfGridTilesUrlForType(typeUuid) {
-            return _makePromise((allRecordsUtfGridUrl.replace(/ALL/, typeUuid)));
+            return _insertIdAtALL(allRecordsUtfGridUrl, typeUuid);
+
+        }
+
+        function recordsHeatmapTilesUrl(typeUuid) {
+            return _insertIdAtALL(heatmapUrl, typeUuid);
+        }
+
+        function boundaryTilesUrl(boundsUuid) {
+            return _insertIdAtALL(allBoundariesUrl, boundsUuid);
         }
 
         function getBaseLayerUrl() {
             return _makePromise(positronUrl);
+        }
+
+        /* Inserts an ID into a URL at the first occurrence of ALL
+         *
+         * param {String} url The url in which to insert the id
+         * param {String} id The id to be inserted
+         * returns {String} The URL with id substituted for ALL, if id is truthy
+         */
+        function _insertIdAtALL(url, id) {
+            if (id) {
+                return _makePromise(url.replace(/ALL/, id));
+            }
+            return _makePromise(url);
         }
 
         function _makePromise(value) {

--- a/web/app/scripts/toddow/toddow-directive.js
+++ b/web/app/scripts/toddow/toddow-directive.js
@@ -9,6 +9,9 @@
 
     /* ngInject */
     function ToDDoW() {
+        // The color ramp to use
+        var rampValues = ['#ffffff', '#f6edb1', '#f7da22', '#ecbe1d', '#e77124',
+                          '#d54927', '#cf3a27', '#a33936', '#7f182a', '#68101a'];
         var module = {
             restrict: 'E',
             scope: {
@@ -31,10 +34,9 @@
                     if (val) {
                         var dateField = scope.dateField ? scope.dateField : 'occurred_from';
                         var data = formatData(val, dateField);
-                        color = d3.scale.linear()
+                        color = d3.scale.quantile()
                             .domain([0, d3.max(d3.values(data))])
-                            .interpolate(d3.interpolateRgb)
-                            .range(['#ffffff', '#355e3b']);
+                            .range(rampValues);
                         updateChart(data);
                     }
                 });
@@ -56,10 +58,10 @@
                         .text(function(d) { return d; });
 
                     var theDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-                    var theHours = ['12', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
-                                    '12', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
-                                    '12'];
-
+                    var theHours = ['0', '1', '2', '3', '4', '5',
+                                    '6', '7', '8', '9', '10', '11',
+                                    '12', '13', '14', '15', '16', '17',
+                                    '18', '19', '20', '21', '22', '23', '24'];
                     rect = svg.selectAll('.day')
                         .data(theDays)
                             .enter().append('g')
@@ -78,11 +80,7 @@
                             .attr('width', cellSize)
                             .attr('height', cellSize)
                             .attr('x', function(d, i) { return cellSize * i + 30; })
-                            .attr('y', function(d, i, j) { return j * cellSize + 20; })
-                            .attr('data-duration', function(d, i) {
-                                var time = (i <= 11) ? 'am' : 'pm';
-                                return theHours[i] + '-' + theHours[i + 1] + time;
-                            });
+                            .attr('y', function(d, i, j) { return j * cellSize + 20; });
 
                     // Day labels
                     svg.selectAll('.day')
@@ -95,24 +93,12 @@
                     svg.select('.day').selectAll('g')
                         .append('text')
                             .text(function(d, i) {
-                                if(i === 0) {
-                                    return theHours[i] + 'am';
-                                } else if (i === 12) {
-                                    return theHours[i] + 'pm';
-                                } else if (i === 24) {
-                                    return theHours[i] + 'am';
-                                } else {
                                     return theHours[i];
-                                }
                             })
                             .attr('class', 'label hours')
+                            // TODO: Actually center these in each cell
                             .attr('x', function(d, i) {
-                                var labelVal = theHours[i];
-                                if(typeof labelVal === 'number') {
-                                    return i * cellSize + 27;
-                                } else {
-                                    return i * cellSize + 22;
-                                }
+                                    return i * cellSize + 37;
                             })
                             .attr('y', 10);
 
@@ -133,7 +119,7 @@
                       return 'Event count: ' + tooltipText;
                     });
                     svg.call(tooltip);
-                    rect.attr('fill', 'white');
+                    rect.attr('fill', '#f1f2f2');
                     rect.filter(function(d) { return d in data; })
                         .attr('fill', function(d) { return color(data[d]); });
                 }

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -46,7 +46,7 @@
                 ctl.baseMaps = baseMaps.promise;
                 var streetsOptions = {
                     attribution: cartoDBAttribution,
-                    detectRetina: true,
+                    detectRetina: false,
                     zIndex: 1
                 };
                 TileUrlService.baseLayerUrl().then(function(streetsUrl) {

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function DriverLayersController($q, $log, $scope, $rootScope, $timeout,
                                     WebConfig, FilterState, RecordState, GeographyState,
-                                    Records, QueryBuilder, MapState) {
+                                    Records, QueryBuilder, MapState, TileUrlService) {
         var ctl = this;
 
         ctl.recordType = 'ALL';
@@ -17,22 +17,11 @@
         ctl.filterSql = null;
 
         var cartoDBAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
-        var streetsUrl = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
-        var heatmapUrl = '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.png?heatmap=true';
-        var recordsUrl = '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.png';
-        var recordsUtfgridUrl = '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.grid.json';
-        var boundaryUrl = '/tiles/table/ashlar_boundary/id/ALL/{z}/{x}/{y}.png';
         var filterStyle = {
             color: '#f357a1',
             fillColor: '#f357a1',
             fill: true
         };
-
-        // prepend hostname to URLs
-        heatmapUrl = WebConfig.windshaft.hostname + heatmapUrl;
-        recordsUrl = WebConfig.windshaft.hostname + recordsUrl;
-        recordsUtfgridUrl = WebConfig.windshaft.hostname + recordsUtfgridUrl;
-        boundaryUrl = WebConfig.windshaft.hostname + boundaryUrl;
 
         /**
          * Initialize layers on map.
@@ -51,20 +40,22 @@
                 } else {
                     ctl.recordType = 'ALL';
                 }
-
+            }).then(function () {
                 // add base layer
+                var baseMaps = $q.defer();
+                ctl.baseMaps = baseMaps.promise;
                 var streetsOptions = {
                     attribution: cartoDBAttribution,
                     detectRetina: true,
                     zIndex: 1
                 };
-                var streets = new L.tileLayer(streetsUrl, streetsOptions);
-                ctl.map.addLayer(streets);
+                TileUrlService.baseLayerUrl().then(function(streetsUrl) {
+                    var streets = new L.tileLayer(streetsUrl, streetsOptions);
+                    ctl.map.addLayer(streets);
 
-                ctl.baseMaps = {
-                    'CartoDB Positron': streets
-                };
-
+                    baseMaps.resolve({ 'CartoDB Positron': streets });
+                });
+            }).then(function () {
                 // add polygon draw control and layer to edit on
                 ctl.editLayers = new L.FeatureGroup();
                 ctl.map.addLayer(ctl.editLayers);
@@ -213,87 +204,103 @@
                 return;
             }
 
-            // remove overlays if already added
-            if (ctl.overlays) {
-                angular.forEach(ctl.overlays, function(overlay) {
-                    ctl.map.removeLayer(overlay);
-                });
-            }
+            $q.all([TileUrlService.recTilesUrl(ctl.recordType),
+                    TileUrlService.recUtfGridTilesUrl(ctl.recordType),
+                    TileUrlService.recHeatmapUrl(ctl.recordType)]).then(function(tileUrls) {
+                var baseRecordsUrl = tileUrls[0];
+                var baseUtfGridUrl = tileUrls[1];
+                var baseHeatmapUrl = tileUrls[2];
+                var defaultLayerOptions = {attribution: 'PRS', detectRetina: true};
 
-            var defaultLayerOptions = {attribution: 'PRS', detectRetina: true};
-
-            // Event record points. Use 'ALL' or record type UUID to filter layer
-            var recordsLayerOptions = angular.extend(defaultLayerOptions, {zIndex: 3});
-            var recordsLayer = new L.tileLayer(ctl.getFilteredRecordUrl(recordsUrl), recordsLayerOptions);
-
-            // layer with heatmap of events
-            var heatmapOptions = angular.extend(defaultLayerOptions, {zIndex: 4});
-            var heatmapLayer = new L.tileLayer(ctl.getFilteredRecordUrl(heatmapUrl), heatmapOptions);
-
-            // interactivity for record layer
-            var utfGridRecordsLayer = new L.UtfGrid(ctl.getFilteredRecordUrl(recordsUtfgridUrl),
-                                                    {useJsonP: false, zIndex: 5});
-
-            // combination of records and UTF grid layers, so they can be toggled as a group
-            var recordsLayerGroup = new L.layerGroup([recordsLayer, utfGridRecordsLayer]);
-
-            utfGridRecordsLayer.on('click', function(e) {
-                // ignore clicks where there is no event record
-                if (!e.data) {
-                    return;
+                // remove overlays if already added
+                if (ctl.overlays) {
+                    angular.forEach(ctl.overlays, function(overlay) {
+                        ctl.map.removeLayer(overlay);
+                    });
                 }
 
-                var popupOptions = {
-                    maxWidth: 400,
-                    maxHeight: 300,
-                    autoPan: true,
-                    closeButton: true,
-                    autoPanPadding: [5, 5]
+                // Event record points. Use 'ALL' or record type UUID to filter layer
+                var recordsLayerOptions = angular.extend(defaultLayerOptions, {zIndex: 3});
+                var recordsLayer = new L.tileLayer(ctl.addFilterSql(baseRecordsUrl),
+                                                   recordsLayerOptions);
+
+                // layer with heatmap of events
+                var heatmapOptions = angular.extend(defaultLayerOptions, {zIndex: 4});
+                var heatmapLayer = new L.tileLayer(ctl.addFilterSql(baseHeatmapUrl), heatmapOptions);
+
+                // interactivity for record layer
+                var utfGridRecordsLayer = new L.UtfGrid(ctl.addFilterSql(baseUtfGridUrl),
+                                                        {useJsonP: false, zIndex: 5});
+
+                // combination of records and UTF grid layers, so they can be toggled as a group
+                var recordsLayerGroup = new L.layerGroup([recordsLayer, utfGridRecordsLayer]);
+
+                utfGridRecordsLayer.on('click', function(e) {
+                    // ignore clicks where there is no event record
+                    if (!e.data) {
+                        return;
+                    }
+
+                    var popupOptions = {
+                        maxWidth: 400,
+                        maxHeight: 300,
+                        autoPan: true,
+                        closeButton: true,
+                        autoPanPadding: [5, 5]
+                    };
+
+                    new L.popup(popupOptions)
+                        .setLatLng(e.latlng)
+                        .setContent(ctl.buildRecordPopup(e.data))
+                        .openOn(ctl.map);
+                });
+                // TODO: find a reasonable way to get the current layers selected, to add those back
+                // when switching record type, so selected layers does not change with filter change.
+
+                // Add layers to show by default.
+                // Layers added to map will automatically be selected in the layer switcher.
+                ctl.map.addLayer(recordsLayerGroup);
+
+                var recordsOverlays = {
+                    'Events': recordsLayerGroup,
+                    'Heatmap': heatmapLayer
                 };
 
-                new L.popup(popupOptions)
-                    .setLatLng(e.latlng)
-                    .setContent(ctl.buildRecordPopup(e.data))
-                    .openOn(ctl.map);
-            });
-
-            // user-uploaded boundary layer(s)
-            var availableBoundaries = $q.defer();
-            GeographyState.getOptions().then(function(boundaries) {
-                var boundaryLayerOptions = angular.extend(defaultLayerOptions, {zIndex: 2});
-                var boundaryLabelLayer = boundaries.map(function(boundary) {
-                    var url = (ctl.getFilteredUrl(boundaryUrl, boundary.uuid) +
-                        '?color=' +
-                        encodeURIComponent(boundary.color));
-                    var boundaryLayer = new L.tileLayer(url, boundaryLayerOptions);
-                    return [boundary.label, boundaryLayer];
+                // construct user-uploaded boundary layer(s)
+                var availableBoundaries = $q.defer();
+                GeographyState.getOptions().then(function(boundaries) {
+                    var boundaryLayerOptions = angular.extend(defaultLayerOptions, {zIndex: 2});
+                    $q.all(boundaries.map(function(boundary) {
+                        return TileUrlService.boundaryTilesUrl(boundary.uuid).then(
+                            function(baseBoundUrl) {
+                                var colorUrl = (baseBoundUrl +
+                                    '?color=' +
+                                    encodeURIComponent(boundary.color));
+                                var layer = new L.tileLayer(colorUrl, boundaryLayerOptions);
+                                return [boundary.label, layer];
+                            }
+                        );
+                    })).then(function(boundaryLabelsLayers) { // Array of [label, layer] pairs
+                        availableBoundaries.resolve(_.zipObject(boundaryLabelsLayers));
+                    });
                 });
-                availableBoundaries.resolve(_.zipObject(boundaryLabelLayer));
-            });
 
-            // TODO: find a reasonable way to get the current layers selected, to add those back
-            // when switching record type, so selected layers does not change with filter change.
+                // Once boundary layers have been created, add them (along with the other layers
+                // created so far) to the map.
+                $q.all([availableBoundaries.promise, ctl.baseMaps]).then(function(allOverlays) {
+                    var boundaryOverlays = allOverlays[0];
+                    var baseMaps = allOverlays[1];
+                    ctl.overlays = angular.extend({}, boundaryOverlays, recordsOverlays);
 
-            // Add layers to show by default.
-            // Layers added to map will automatically be selected in the layer switcher.
-            ctl.map.addLayer(recordsLayerGroup);
+                    // add layer switcher control; expects to have layer zIndex already set
 
-            var recordsOverlays = {
-                'Events': recordsLayerGroup,
-                'Heatmap': heatmapLayer
-            };
-
-            availableBoundaries.promise.then(function(boundaryOverlays) {
-                ctl.overlays = angular.extend({}, boundaryOverlays, recordsOverlays);
-
-                // add layer switcher control; expects to have layer zIndex already set
-
-                // If layer switcher already initialized, must re-initialize it.
-                if (ctl.layerSwitcher) {
-                    ctl.layerSwitcher.removeFrom(ctl.map);
-                }
-                ctl.layerSwitcher = L.control.layers(ctl.baseMaps, ctl.overlays, {autoZIndex: false});
-                ctl.layerSwitcher.addTo(ctl.map);
+                    // If layer switcher already initialized, must re-initialize it.
+                    if (ctl.layerSwitcher) {
+                        ctl.layerSwitcher.removeFrom(ctl.map);
+                    }
+                    ctl.layerSwitcher = L.control.layers(baseMaps, ctl.overlays, {autoZIndex: false});
+                    ctl.layerSwitcher.addTo(ctl.map);
+                });
             });
         };
 
@@ -341,20 +348,6 @@
             return str;
         };
 
-        /**
-         * Helper function to get map layers URL with resource ID set.
-         *
-         * @param {String} baseUrl Map layer url with resource parameter set to 'ALL'
-         * @param {String} resourceId Resource ID to put into the URL.
-         * @returns {String} The baseUrl with the record type parameter set to the selected type.
-         */
-        ctl.getFilteredUrl = function(baseUrl, resourceId) {
-            var url = baseUrl;
-            if (resourceId && resourceId !== 'ALL') {
-                url = url.replace(/ALL/, resourceId);
-            }
-            return url;
-        };
 
         /**
          * Helper function to add a SQL filter parameter to the windshaft URL
@@ -370,18 +363,6 @@
                 url += url.match(/\?/) ? '&sql=' : '?sql=';
                 url += encodeURIComponent(sql);
             }
-            return url;
-        };
-
-        /**
-         * Helper function to completely construct a records URL (dots / heatmap / utfGrid)
-         * @param {String} baseUrl Map layer URL
-         * @returns {String} The baseUrl with the record type parameter set and sql parameter set.
-         */
-        ctl.getFilteredRecordUrl = function(baseUrl) {
-            var url = baseUrl;
-            url = ctl.getFilteredUrl(url, ctl.recordType);
-            url = ctl.addFilterSql(url, ctl.filterSql);
             return url;
         };
 

--- a/web/app/scripts/views/map/module.js
+++ b/web/app/scripts/views/map/module.js
@@ -16,6 +16,7 @@
         'ui.bootstrap',
         'Leaflet',
         'driver.config',
+        'driver.map-layers',
         'driver.state'
     ]).config(StateConfig);
 

--- a/web/app/scripts/views/record/embed-map-controller.js
+++ b/web/app/scripts/views/record/embed-map-controller.js
@@ -25,7 +25,7 @@
 
             TileUrlService.baseLayerUrl().then(function(streetsUrl) {
                 var streets = new L.tileLayer(streetsUrl, {attribution: cartoDBAttribution});
-                ctl.map.addLayer(streets, {detectRetina: true});
+                ctl.map.addLayer(streets, {detectRetina: false});
             });
 
             if (ctl.isEditable) {

--- a/web/app/scripts/views/record/embed-map-controller.js
+++ b/web/app/scripts/views/record/embed-map-controller.js
@@ -4,7 +4,7 @@
     var cartoDBAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
 
     /* ngInject */
-    function EmbedMapController($log, $scope, $rootScope) {
+    function EmbedMapController($log, $scope, $rootScope, TileUrlService) {
         var ctl = this;
 
         ctl.isEditable = false;
@@ -23,9 +23,10 @@
             ctl.map = leafletMap;
             ctl.isEditable = !!isEditable;
 
-            var streets = new L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-                                          {attribution: cartoDBAttribution});
-            ctl.map.addLayer(streets, {detectRetina: true});
+            TileUrlService.baseLayerUrl().then(function(streetsUrl) {
+                var streets = new L.tileLayer(streetsUrl, {attribution: cartoDBAttribution});
+                ctl.map.addLayer(streets, {detectRetina: true});
+            });
 
             if (ctl.isEditable) {
                 ctl.map.on('click', function(e) {

--- a/web/app/scripts/views/record/module.js
+++ b/web/app/scripts/views/record/module.js
@@ -40,6 +40,7 @@
         'ase.schemas',
         'datetimepicker',
         'driver.config',
+        'driver.map-layers',
         'driver.details',
         'Leaflet',
         'driver.resources',

--- a/web/test/spec/map-layers/tile-url-service-spec.js
+++ b/web/test/spec/map-layers/tile-url-service-spec.js
@@ -11,21 +11,7 @@ describe('driver:map-layers TileUrlService', function () {
         $rootScope = _$rootScope_;
     }));
 
-    it('should provide URLs to access PNG tiles of all records', function () {
-        TileUrlService.allRecTilesUrl().then(function(url) {
-            expect(url).toEqual(jasmine.stringMatching(/\.png/));
-        });
-        $rootScope.$apply();
-    });
-
-    it('should provide URLs to access UTF Grid tiles of all records', function () {
-        TileUrlService.allRecUtfGridTilesUrl().then(function(url) {
-            expect(url).toEqual(jasmine.stringMatching((/\.grid\.json/)));
-        });
-        $rootScope.$apply();
-    });
-
-    it('should provide URLs to access PNG tiles per record type', function () {
+    it('should provide URLs to access PNG tiles', function () {
         TileUrlService.recTilesUrl('notarealuuid').then(function(url) {
             expect(url).toEqual(jasmine.stringMatching(/\.png/));
             expect(url).toEqual(jasmine.stringMatching(/notarealuuid/));
@@ -33,9 +19,25 @@ describe('driver:map-layers TileUrlService', function () {
         $rootScope.$apply();
     });
 
-    it('should provide URLs to access UTF Grid tiles per record type', function () {
+    it('should provide URLs to access UTF Grid tiles', function () {
         TileUrlService.recUtfGridTilesUrl('notarealuuid').then(function(url) {
-            expect(url).toEqual(jasmine.stringMatching(/\.grid\.json/));
+            expect(url).toEqual(jasmine.stringMatching((/\.grid\.json/)));
+            expect(url).toEqual(jasmine.stringMatching(/notarealuuid/));
+        });
+        $rootScope.$apply();
+    });
+
+    it('should provide URLs to access boundary tiles', function () {
+        TileUrlService.boundaryTilesUrl('notarealuuid').then(function(url) {
+            expect(url).toEqual(jasmine.stringMatching(/\.png/));
+            expect(url).toEqual(jasmine.stringMatching(/notarealuuid/));
+        });
+        $rootScope.$apply();
+    });
+
+    it('should provide URLs to access boundary tiles', function () {
+        TileUrlService.recHeatmapUrl('notarealuuid').then(function(url) {
+            expect(url).toEqual(jasmine.stringMatching(/\.png/));
             expect(url).toEqual(jasmine.stringMatching(/notarealuuid/));
         });
         $rootScope.$apply();

--- a/web/test/spec/views/map/layers-controller.spec.js
+++ b/web/test/spec/views/map/layers-controller.spec.js
@@ -77,15 +77,6 @@ describe('driver.views.map: Layers Controller', function () {
         expect(popup).toEqual(expected);
     });
 
-    it('should filter URLs', function () {
-        var interactivityUrl = 'http://localhost:7000/tiles/table/ashlar_record/id/ALL/5/26/15.grid.json';
-
-        Controller.recordType = 'b4e49ec6-32f2-46db-9b27-d0f6ba5c9406';
-        var resultUrl = Controller.getFilteredRecordUrl(interactivityUrl);
-
-        expect(resultUrl).toBe('http://localhost:7000/tiles/table/ashlar_record/id/b4e49ec6-32f2-46db-9b27-d0f6ba5c9406/5/26/15.grid.json');
-    });
-
     it('should listen for record type change', function() {
         spyOn(Controller, 'setRecordLayers');
         RecordState.setSelected({uuid: 'foo'});


### PR DESCRIPTION
This does most of the tasks from #159; I'll leave it up to @mtedeschi to close that
 since there are some tasks there for him too.

The bulk of the changes, however, are related to the refactor mentioned in #184 so that all three maps use URLs generated by the `TileUrlService`.

![prstoddow](https://cloud.githubusercontent.com/assets/447977/10459980/3f851ca8-71a0-11e5-80ed-9a88fbc04617.png)
(This toddow is using the old imported events so it doesn't have a good range of dates and times)