### PR TITLE
Feature/scrolling dropdowns

### DIFF
--- a/schema_editor/app/README.md
+++ b/schema_editor/app/README.md
@@ -1,7 +1,8 @@
 
 ## URL Hierarchy
 
-/recordtype                         // list all available recordtypes
+/recordtype/?offset=1               // get first page of recordtypes
+/recordtype/?limit=all              // list all available recordtypes
 /recordtype/add                     // Add new record type
 /recordtype/:uuid                   // list related content for recordtype
 /recordtype/:uuid/schema/add        // Add new related content type to recordtype

--- a/schema_editor/app/scripts/resources/recordschemas-service.js
+++ b/schema_editor/app/scripts/resources/recordschemas-service.js
@@ -4,7 +4,9 @@
 
     /* ngInject */
     function RecordSchemas($resource, ASEConfig) {
-        return $resource(ASEConfig.api.hostname + '/api/recordschemas/:id/', {id: '@uuid'}, {
+        return $resource(ASEConfig.api.hostname + '/api/recordschemas/:id/',
+                         {id: '@uuid', limit: 'all'}, {
+
             create: {
                 method: 'POST'
             },

--- a/schema_editor/app/scripts/resources/recordschemas-service.js
+++ b/schema_editor/app/scripts/resources/recordschemas-service.js
@@ -6,7 +6,6 @@
     function RecordSchemas($resource, ASEConfig) {
         return $resource(ASEConfig.api.hostname + '/api/recordschemas/:id/',
                          {id: '@uuid', limit: 'all'}, {
-
             create: {
                 method: 'POST'
             },

--- a/schema_editor/app/scripts/resources/recordtypes-service.js
+++ b/schema_editor/app/scripts/resources/recordtypes-service.js
@@ -3,7 +3,9 @@
 
     /* ngInject */
     function RecordTypes($resource, ASEConfig) {
-        return $resource(ASEConfig.api.hostname + '/api/recordtypes/:id/', {id: '@uuid'}, {
+        return $resource(ASEConfig.api.hostname + '/api/recordtypes/:id/',
+                         {id: '@uuid', limit: 'all'}, {
+
             create: {
                 method: 'POST'
             },

--- a/web/app/scripts/resources/boundaries-service.js
+++ b/web/app/scripts/resources/boundaries-service.js
@@ -3,7 +3,8 @@
 
     /* ngInject */
     function Boundaries($resource, WebConfig) {
-        return $resource(WebConfig.api.hostname + '/api/boundaries/:id/', {id: '@uuid'}, {
+        return $resource(WebConfig.api.hostname + '/api/boundaries/:id/',
+                         {id: '@uuid', limit: 'all'}, {
             create: {
                 method: 'POST'
             },

--- a/web/app/scripts/resources/polygons-service.js
+++ b/web/app/scripts/resources/polygons-service.js
@@ -3,7 +3,8 @@
 
     /* ngInject */
     function Polygons($resource, WebConfig) {
-        return $resource(WebConfig.api.hostname + '/api/boundarypolygons/:id/', {id: '@uuid'}, {
+        return $resource(WebConfig.api.hostname + '/api/boundarypolygons/:id/',
+                         {id: '@uuid', limit: 'all'}, {
             create: {
                 method: 'POST'
             },

--- a/web/app/styles/_helpers.scss
+++ b/web/app/styles/_helpers.scss
@@ -18,10 +18,16 @@
         position: absolute;
         left: 50%;
         margin-left: -5px;
-        width: 0; 
-        height: 0; 
+        width: 0;
+        height: 0;
         border-left: 10px solid transparent;
         border-right: 10px solid transparent;
         border-top: 10px solid rgba(0,0,0,0.9);
     }
+}
+
+.dropdown-menu {
+    height: auto;
+    max-height: 500px;
+    overflow-x: auto;
 }


### PR DESCRIPTION
Depends on companion PR azavea/ashlar#52.

![image](https://cloud.githubusercontent.com/assets/960264/10461931/c9531968-71a9-11e5-9586-24d79cf586ee.png)

Partially addresses #191 by fetching all record types into the schema editor, but paginating with screen controls would probably be better than a scrolling page with everything. Also, the editor sidebar apparently doesn't scroll, so the geographies get cut off if there are too many record types listed.