### PR TITLE
Bump version of Docker Ansible role

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -2,6 +2,6 @@ azavea.postgresql,0.3.3
 azavea.postgresql-support,0.2.1
 azavea.postgis,0.2.1
 azavea.nginx,0.2.1
-azavea.docker,1.0.1
+azavea.docker,1.0.2
 azavea.pip,0.1.1
 azavea.redis,0.1.0


### PR DESCRIPTION
Attempts to resolve transient build failures due to lack of APT repository key server availability.

See also: https://github.com/azavea/ansible-docker/pull/7