### PR TITLE
Use static title label for options filters

### DIFF
--- a/web/app/scripts/filterbar/options.html
+++ b/web/app/scripts/filterbar/options.html
@@ -1,7 +1,10 @@
-<div class="btn-group dropdown options open" dropdown="">
+<div class="btn-group dropdown options open" ng-class="{ 'active': filter.contains.length }">
     <div class="form-group">
         <select data-ng-options="val for val in data.enum"
                 data-header="{{ label | labelFormatter }}"
+                data-selected-text-format="static"
+                data-title="{{ label | labelFormatter }}"
+                {{ label | labelFormatter }}
                 class="selectpicker form-control"
                 multiple
                 name="options[]"

--- a/web/app/styles/partials/_filterbar.scss
+++ b/web/app/styles/partials/_filterbar.scss
@@ -25,3 +25,7 @@ div.navbar-default.filterbar {
 .no-filterbar {
     top: 50px;
 }
+
+.active .filter-option {
+    text-decoration: underline;
+}


### PR DESCRIPTION
Also adds an `active` class on the div for styling purposes.
Currently the text is underlined when active as a proof-of-concept.

Fixes #220