### PR TITLE
Add service for storage of records pulled down to prevent redundancies

### DIFF
--- a/web/app/index.html
+++ b/web/app/index.html
@@ -94,6 +94,7 @@
     <script src="scripts/state/filters-service.js"></script>
     <script src="scripts/state/mapstate-service.js"></script>
     <script src="scripts/state/recordstate-service.js"></script>
+    <script src="scripts/state/recordtypestate-service.js"></script>
     <script src="scripts/state/boundarystate-service.js"></script>
     <script src="scripts/state/geographystate-service.js"></script>
     <script src="scripts/state/zoom-to-boundary-directive.js"></script>

--- a/web/app/scripts/filterbar/filterbar-controller.js
+++ b/web/app/scripts/filterbar/filterbar-controller.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /* ngInject */
-    function FilterbarController($log, $scope, FilterState, RecordState, RecordSchemas) {
+    function FilterbarController($log, $scope, FilterState, RecordTypeState, RecordSchemas) {
         var ctl = this;
         ctl.filters = {};
         ctl.filterPolygon = null;
@@ -10,7 +10,7 @@
         init();
 
         function init() {
-            RecordState.getSelected().then(function(selected) {
+            RecordTypeState.getSelected().then(function(selected) {
                 onRecordSelected(selected);
             });
         }
@@ -61,7 +61,7 @@
         /**
          * When the record type changes, request the new schema
          */
-        $scope.$on('driver.state.recordstate:selected',
+        $scope.$on('driver.state.recordtypestate:selected',
                    function(event, selected) { onRecordSelected(selected); });
 
         function onRecordSelected(selected) {

--- a/web/app/scripts/filterbar/options-directive.js
+++ b/web/app/scripts/filterbar/options-directive.js
@@ -57,7 +57,7 @@
                         if (scope.data.multiple) {
                             // TODO: Implement a filter for related containment in djsonb
                             filterbarController.updateFilter(filterLabel,
-                                                             _.merge({'_rule_type': 'related_containment'},
+                                                             _.merge({'_rule_type': 'containment_multiple'},
                                                                      scope.filter));
                         } else {
                             filterbarController.updateFilter(filterLabel,

--- a/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
+++ b/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /* ngInject */
-    function recentEventsMapLayers($q, RecordState, BoundaryState, TileUrlService, QueryBuilder) {
+    function recentEventsMapLayers($q, RecordTypeState, BoundaryState, TileUrlService, QueryBuilder) {
         var cartoDBAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
         var defaultLayerOptions = {attribution: 'PRS', detectRetina: true};
         var recencyCutoffDays = 14;
@@ -38,7 +38,7 @@
             });
 
             // TODO: Remove when the record type picker is removed.
-            scope.$on('driver.state.recordstate:selected', function() {
+            scope.$on('driver.state.recordtypestate:selected', function() {
                 leafletController.getMap().then(updateLayers);
             });
         }
@@ -73,7 +73,7 @@
             occurredMin.setDate(occurredMin.getDate() - recencyCutoffDays);
             // TODO: Boundary filtering somewhere in here.
             // TODO: Since RecordType selection is going away, this may have to change
-            RecordState.getSelected().then(function(selected) {
+            RecordTypeState.getSelected().then(function(selected) {
                 return TileUrlService.recTilesUrl(selected.uuid);
             // Construct Windshaft URL
             }).then(function(baseUrl) {

--- a/web/app/scripts/navbar/navbar-controller.js
+++ b/web/app/scripts/navbar/navbar-controller.js
@@ -3,7 +3,7 @@
 
     /* ngInject */
     function NavbarController($log, $window, $rootScope, $scope, $state,
-                              GeographyState, RecordState, BoundaryState) {
+                              GeographyState, RecordTypeState, BoundaryState) {
         var ctl = this;
         var _ = $window._;
         init();
@@ -18,7 +18,7 @@
         function init() {
             setFilters($state.current);
             GeographyState.getOptions().then(function(opts) { ctl.geographyResults = opts; });
-            RecordState.getOptions().then(function(opts) { ctl.recordTypeResults = opts; });
+            RecordTypeState.getOptions().then(function(opts) { ctl.recordTypeResults = opts; });
             setStates();
         }
 
@@ -27,10 +27,10 @@
         });
 
         // Record Type selections
-        $scope.$on('driver.state.recordstate:options', function(event, options) {
+        $scope.$on('driver.state.recordtypestate:options', function(event, options) {
             ctl.recordTypeResults = options;
         });
-        $scope.$on('driver.state.recordstate:selected', function(event, selected) {
+        $scope.$on('driver.state.recordtypestate:selected', function(event, selected) {
             ctl.recordTypeSelected = selected;
             updateState();
         });
@@ -97,7 +97,7 @@
 
         // Handler for when a record type is selected from the dropdown
         function onRecordTypeSelected(recordType) {
-            RecordState.setSelected(recordType);
+            RecordTypeState.setSelected(recordType);
         }
 
         // Handler for when a navigation state is selected from the dropdown

--- a/web/app/scripts/recent-counts/recent-counts-controller.js
+++ b/web/app/scripts/recent-counts/recent-counts-controller.js
@@ -2,14 +2,14 @@
     'use strict';
 
     /* ngInject */
-    function RecentCountsController($scope, RecordAggregates, RecordState) {
+    function RecentCountsController($scope, RecordAggregates, RecordTypeState) {
         var ctl = this;
         init();
-        $scope.$on('driver.state.recordstate:selected', init);
+        $scope.$on('driver.state.recordtypestate:selected', init);
         return ctl;
 
         function init() {
-            RecordState.getSelected().then(function(recordType) {
+            RecordTypeState.getSelected().then(function(recordType) {
                 /* jshint camelcase: false */
                 ctl.recordTypePlural = recordType.plural_label;
                 RecordAggregates.recentCounts().then(function(aggregate) {

--- a/web/app/scripts/resources/aggregate-query-service.js
+++ b/web/app/scripts/resources/aggregate-query-service.js
@@ -5,7 +5,7 @@
     'use strict';
 
     /* ngInject */
-    function RecordAggregates($q, RecordTypes, RecordState, Records, QueryBuilder) {
+    function RecordAggregates($q, RecordTypes, RecordTypeState, Records, QueryBuilder) {
         var svc = {
             recentCounts: recentCounts,
             toddow: toddow
@@ -33,7 +33,7 @@
         function recentCounts() {
             var deferred = $q.defer();
             // Record Type
-            RecordState.getSelected().then(function(selected) {
+            RecordTypeState.getSelected().then(function(selected) {
                 var uuid = selected.uuid;
                 RecordTypes.recentCounts({id: uuid}).$promise.then(function(counts) {
                     deferred.resolve(counts);

--- a/web/app/scripts/resources/query-builder-service.js
+++ b/web/app/scripts/resources/query-builder-service.js
@@ -9,7 +9,7 @@
     'use strict';
 
     /* ngInject */
-    function QueryBuilder($q, FilterState, RecordState, Records, WebConfig) {
+    function QueryBuilder($q, FilterState, RecordTypeState, Records, WebConfig) {
         var svc = {
             djangoQuery: djangoQuery,
             unfilteredDjangoQuery: function(offset, extraParams) {
@@ -128,7 +128,7 @@
             paramObj.limit = WebConfig.record.limit;
 
             // Record Type
-            RecordState.getSelected().then(function(selected) {
+            RecordTypeState.getSelected().then(function(selected) {
                 paramObj.record_type = selected.uuid;
                 deferred.resolve(paramObj);
             });

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -39,8 +39,8 @@
                 // If parameters differ from the last call
                 if (doFilter !== lastDoFilter || offset !== lastOffset || !_.isEqual(extraParams, lastExtraParams)) {
                     records = QueryBuilder.djangoQuery(doFilter, offset, extraParams);
-                } else { // If parameters do not differ 
-                    $log.debug('saved a request');
+                } else { // If parameters do not differ
+                    $log.debug('Saved a `Record` request');
                 }
             } else { // If no records found
                 records = QueryBuilder.djangoQuery(doFilter, offset, extraParams);

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -6,120 +6,32 @@
     'use strict';
 
     /* ngInject */
-    function RecordState($log, $rootScope, $q, localStorageService, RecordTypes) {
-        var defaultParams,
-            selected,
-            options,
-            gettingSelected,
-            selectedPromise,
-            gettingOptions,
-            optionPromise;
-        var initialized = false;
-        var svc = this;
-        svc.updateOptions = updateOptions;
-        svc.getOptions = getOptions;
-        svc.setSelected = setSelected;
-        svc.getSelected = getSelected;
-        init();
+    function RecordState($log, $rootScope, $q, QueryBuilder) {
+        var records,
+            lastDoFilter,
+            lastOffset,
+            lastExtraParams;
 
-        /**
-         * initialization
-         */
-        function init() {
-          selected = null;
-          gettingSelected = false;
-          gettingOptions = false;
-          options = [];
-          defaultParams = {'active': 'True'};
-          svc.updateOptions();
-        }
-
-        /**
-         * Query the backend for the available options
-         *
-         * @param {object} params - The query params to use in place of defaultParams
-         */
-        function updateOptions(params) {
-            var filterParams = angular.extend({}, params, defaultParams);
-            return RecordTypes.query(filterParams).$promise.then(function(results) {
-                  options = results;
-                  $rootScope.$broadcast('driver.state.recordstate:options', options);
-                  if (!results.length) {
-                      $log.warn('No record types returned');
-                  } else {
-                      if (!selected && options[0]) {
-                          selected = svc.setSelected(options[0]);
-                      } else if (!_.includes(options, selected)) {
-                          svc.setSelected(selected);
-                      }
-                  }
-            });
-        }
-
-        function getOptions() {
-            if (!gettingOptions) {
-                gettingOptions = true;
-                var deferred = $q.defer();
-                if (!options) {
-                    updateOptions().then(function() { deferred.resolve(options); });
-                } else {
-                    deferred.resolve(options);
-                }
-                optionPromise = deferred.promise;
-            }
-            optionPromise.then(function() { gettingOptions = false; });
-            return optionPromise;
-        }
-
-        /**
-         * Set the state selection
-         *
-         * @param {object} selection - The selection among available options
-         */
-        function setSelected(selection) {
-            if (!initialized) {
-                var oldRecordType = localStorageService.get('recordtype.selected');
-                if (oldRecordType) {
-                    selection = _.find(options, function(d) {
-                        return d.uuid === oldRecordType.uuid;
-                    });
-                    initialized = true;
-                }
-            }
-            if (_.find(options, function(d) { return d.uuid === selection.uuid; })) {
-                selected = selection;
-            } else if (options.length) {
-                selected = options[0];
-            } else {
-                selected = null;
-            }
-            localStorageService.set('recordtype.selected', selected);
-            $rootScope.$broadcast('driver.state.recordstate:selected', selected);
-            return selected;
-        }
-
-        function getSelected() {
-            if (!gettingSelected) {
-                gettingSelected = true;
-            } else {
-                return selectedPromise;
-            }
-
-            var deferred = $q.defer();
-            if (!selected && !options.length) {
-                updateOptions().then(function() { deferred.resolve(selected); });
-            } else if (!selected) {
-                deferred.resolve(setSelected());
-            } else {
-                deferred.resolve(selected);
-            }
-            selectedPromise = deferred.promise;
-
-            selectedPromise.then(function() { gettingSelected = false; });
-            return selectedPromise;
-        }
-
+        var svc = {
+            getRecords: getRecords
+        };
         return svc;
+
+        function getRecords(doFilter, offset, extraParams, force) {
+            // Fresh request if `force`
+            if (force) { records = null; }
+
+            if (records) { // If we have records already
+                if (doFilter !== lastDoFilter || offset !== lastOffset || extraParams !== lastExtraParams) {
+                    records = QueryBuilder.djangoQuery(doFilter, offset, extraParams);
+                } // If parameters differ from the last call
+                $log.debug('saved a request');
+            } else { // If no records found
+                records = QueryBuilder.djangoQuery(doFilter, offset, extraParams);
+            }
+
+            return records;
+        }
     }
 
     angular.module('driver.state')

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -17,15 +17,31 @@
         };
         return svc;
 
+        /**
+         * Take a series of parameters (the params consumed by the QueryBuilder that this function
+         *  wraps) and do a little work to ensure that duplicate requests aren't getting sent out
+         */
         function getRecords(doFilter, offset, extraParams, force) {
+            // Standardize to avoid js equality checking weirdness
+            doFilter = doFilter || false;
+            offset = offset || 0;
+            extraParams = extraParams || {};
+
+            // Store current parameters to check if a new request is necessary in a future request
+            lastDoFilter = doFilter;
+            lastOffset = offset;
+            lastExtraParams = extraParams;
+
             // Fresh request if `force`
             if (force) { records = null; }
 
             if (records) { // If we have records already
-                if (doFilter !== lastDoFilter || offset !== lastOffset || extraParams !== lastExtraParams) {
+                // If parameters differ from the last call
+                if (doFilter !== lastDoFilter || offset !== lastOffset || !_.isEqual(extraParams, lastExtraParams)) {
                     records = QueryBuilder.djangoQuery(doFilter, offset, extraParams);
-                } // If parameters differ from the last call
-                $log.debug('saved a request');
+                } else { // If parameters do not differ 
+                    $log.debug('saved a request');
+                }
             } else { // If no records found
                 records = QueryBuilder.djangoQuery(doFilter, offset, extraParams);
             }

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -27,11 +27,6 @@
             offset = offset || 0;
             extraParams = extraParams || {};
 
-            // Store current parameters to check if a new request is necessary in a future request
-            lastDoFilter = doFilter;
-            lastOffset = offset;
-            lastExtraParams = extraParams;
-
             // Fresh request if `force`
             if (force) { records = null; }
 
@@ -46,6 +41,10 @@
                 records = QueryBuilder.djangoQuery(doFilter, offset, extraParams);
             }
 
+            // Store current parameters to check if a new request is necessary in a future request
+            lastDoFilter = doFilter;
+            lastOffset = offset;
+            lastExtraParams = extraParams;
             return records;
         }
     }

--- a/web/app/scripts/state/recordtypestate-service.js
+++ b/web/app/scripts/state/recordtypestate-service.js
@@ -1,0 +1,127 @@
+/**
+ * Record Type state control - changes to the private vars which define this state
+ *  are broadcast to rootscope for use by controllers
+ */
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordTypeState($log, $rootScope, $q, localStorageService, RecordTypes) {
+        var defaultParams,
+            selected,
+            options,
+            gettingSelected,
+            selectedPromise,
+            gettingOptions,
+            optionPromise;
+        var initialized = false;
+        var svc = this;
+        svc.updateOptions = updateOptions;
+        svc.getOptions = getOptions;
+        svc.setSelected = setSelected;
+        svc.getSelected = getSelected;
+        init();
+
+        /**
+         * initialization
+         */
+        function init() {
+          selected = null;
+          gettingSelected = false;
+          gettingOptions = false;
+          options = [];
+          defaultParams = {'active': 'True'};
+          svc.updateOptions();
+        }
+
+        /**
+         * Query the backend for the available options
+         *
+         * @param {object} params - The query params to use in place of defaultParams
+         */
+        function updateOptions(params) {
+            var filterParams = angular.extend({}, params, defaultParams);
+            return RecordTypes.query(filterParams).$promise.then(function(results) {
+                  options = results;
+                  $rootScope.$broadcast('driver.state.recordtypestate:options', options);
+                  if (!results.length) {
+                      $log.warn('No record types returned');
+                  } else {
+                      if (!selected && options[0]) {
+                          selected = svc.setSelected(options[0]);
+                      } else if (!_.includes(options, selected)) {
+                          svc.setSelected(selected);
+                      }
+                  }
+            });
+        }
+
+        function getOptions() {
+            if (!gettingOptions) {
+                gettingOptions = true;
+                var deferred = $q.defer();
+                if (!options) {
+                    updateOptions().then(function() { deferred.resolve(options); });
+                } else {
+                    deferred.resolve(options);
+                }
+                optionPromise = deferred.promise;
+            }
+            optionPromise.then(function() { gettingOptions = false; });
+            return optionPromise;
+        }
+
+        /**
+         * Set the state selection
+         *
+         * @param {object} selection - The selection among available options
+         */
+        function setSelected(selection) {
+            if (!initialized) {
+                var oldRecordType = localStorageService.get('recordtype.selected');
+                if (oldRecordType) {
+                    selection = _.find(options, function(d) {
+                        return d.uuid === oldRecordType.uuid;
+                    });
+                    initialized = true;
+                }
+            }
+            if (_.find(options, function(d) { return d.uuid === selection.uuid; })) {
+                selected = selection;
+            } else if (options.length) {
+                selected = options[0];
+            } else {
+                selected = null;
+            }
+            localStorageService.set('recordtype.selected', selected);
+            $rootScope.$broadcast('driver.state.recordtypestate:selected', selected);
+            return selected;
+        }
+
+        function getSelected() {
+            if (!gettingSelected) {
+                gettingSelected = true;
+            } else {
+                return selectedPromise;
+            }
+
+            var deferred = $q.defer();
+            if (!selected && !options.length) {
+                updateOptions().then(function() { deferred.resolve(selected); });
+            } else if (!selected) {
+                deferred.resolve(setSelected());
+            } else {
+                deferred.resolve(selected);
+            }
+            selectedPromise = deferred.promise;
+
+            selectedPromise.then(function() { gettingSelected = false; });
+            return selectedPromise;
+        }
+
+        return svc;
+    }
+
+    angular.module('driver.state')
+    .factory('RecordTypeState', RecordTypeState);
+})();

--- a/web/app/scripts/views/dashboard/dashboard-controller.js
+++ b/web/app/scripts/views/dashboard/dashboard-controller.js
@@ -2,18 +2,19 @@
     'use strict';
 
     /* ngInject */
-    function DashboardController($scope, Records, RecordSchemas, RecordState, RecordAggregates) {
+    function DashboardController($scope, Records, RecordSchemas, RecordAggregates,
+                                 RecordTypeState, RecordState) {
         var ctl = this;
 
         initialize();
 
-        $scope.$on('driver.state.recordstate:selected', function(event, selected) {
+        $scope.$on('driver.state.recordtypestate:selected', function(event, selected) {
             ctl.recordType = selected;
             loadRecords();
         });
 
         function initialize() {
-            RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
+            RecordTypeState.getSelected().then(function(selected) { ctl.recordType = selected; })
                 .then(loadRecordSchema)
                 .then(loadRecords)
                 .then(onRecordsLoaded);
@@ -46,8 +47,8 @@
                 ctl.toddow = toddowData;
             });
 
-            return Records.get(params)
-                .$promise.then(function(records) {
+            return RecordState.getRecords(false, 0, params)
+                .then(function(records) {
                     ctl.records = records.results;
                 });
         }

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -3,7 +3,7 @@
 
     /* ngInject */
     function DriverLayersController($q, $log, $scope, $rootScope, $timeout,
-                                    WebConfig, FilterState, RecordState, GeographyState,
+                                    WebConfig, FilterState, RecordTypeState, GeographyState,
                                     BoundaryState, Records, QueryBuilder, MapState,
                                     TileUrlService) {
         var ctl = this;
@@ -39,7 +39,7 @@
             ctl.map = map;
 
             // get the current record type selection for filtering
-            RecordState.getSelected().then(function(selected) {
+            RecordTypeState.getSelected().then(function(selected) {
                 if (selected && selected.uuid) {
                     ctl.recordType = selected.uuid;
                 } else {
@@ -388,7 +388,7 @@
             return url;
         };
 
-        $scope.$on('driver.state.recordstate:selected', function(event, selected) {
+        $scope.$on('driver.state.recordtypestate:selected', function(event, selected) {
             if (ctl.recordType !== selected && selected && selected.uuid) {
                 ctl.recordType = selected.uuid;
                 // re-add the layers to refresh with filtered content

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function DriverLayersController($q, $log, $scope, $rootScope, $timeout,
                                     WebConfig, FilterState, RecordTypeState, GeographyState,
-                                    BoundaryState, Records, QueryBuilder, MapState,
+                                    BoundaryState, Records, RecordState, MapState,
                                     TileUrlService) {
         var ctl = this;
 
@@ -52,7 +52,7 @@
                     }
                 });
             }).then(function () {
-                return QueryBuilder.djangoQuery(true, 0, getAdditionalParams())
+                return RecordState.getRecords(true, 0, getAdditionalParams())
                 .then(function(records) {
                     ctl.filterSql = castQueryToStrings(records.query);
                 });
@@ -399,7 +399,7 @@
         $scope.$on('driver.state.boundarystate:selected', function(event, selected) {
             if (selected && selected.uuid && selected.uuid !== ctl.boundaryId) {
                 ctl.boundaryId = selected.uuid;
-                QueryBuilder.djangoQuery(true, 0, getAdditionalParams())
+                RecordState.getRecords(true, 0, getAdditionalParams())
                 .then(function(records) {
                     ctl.filterSql = castQueryToStrings(records.query);
                     ctl.setRecordLayers();
@@ -464,7 +464,7 @@
         var filterHandler = $rootScope.$on('driver.filterbar:changed', function() {
 
             // get the raw SQL for the filter to send along to Windshaft
-            QueryBuilder.djangoQuery(true, 0, getAdditionalParams()).then(function(records) {
+            RecordState.getRecords(true, 0, getAdditionalParams()).then(function(records) {
                 ctl.filterSql = castQueryToStrings(records.query);
                 ctl.setRecordLayers();
             });

--- a/web/app/scripts/views/map/map-controller.js
+++ b/web/app/scripts/views/map/map-controller.js
@@ -2,20 +2,20 @@
     'use strict';
 
     /* ngInject */
-    function MapController($scope, Records, RecordSchemas, RecordState) {
+    function MapController($scope, Records, RecordSchemas, RecordTypeState) {
         var ctl = this;
 
         initialize();
 
         // TODO: This also needs to listen for changing filters, both from the filterbar and map.
         // This hasn't been done here, because of a couple related, in-progress tasks.
-        $scope.$on('driver.state.recordstate:selected', function(event, selected) {
+        $scope.$on('driver.state.recordtypestate:selected', function(event, selected) {
             ctl.recordType = selected;
             loadRecords();
         });
 
         function initialize() {
-            RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
+            RecordTypeState.getSelected().then(function(selected) { ctl.recordType = selected; })
                 .then(loadRecordSchema)
                 .then(loadRecords);
         }

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function RecordAddEditController($log, $scope, $state, $stateParams, $window, uuid4,
                                      Nominatim, Notifications, Records, RecordSchemas,
-                                     RecordState) {
+                                     RecordTypeState) {
         var ctl = this;
         var editorData = null;
         var bbox = null;
@@ -88,7 +88,7 @@
         }
 
         function loadRecordType() {
-            return RecordState.getSelected()
+            return RecordTypeState.getSelected()
                 .then(function(recordType) {
                     ctl.recordType = recordType;
                 });

--- a/web/app/scripts/views/record/details-controller.js
+++ b/web/app/scripts/views/record/details-controller.js
@@ -3,7 +3,7 @@
 
     /* ngInject */
     function RecordDetailsController($stateParams,
-                                     Records, RecordSchemas, RecordState) {
+                                     Records, RecordSchemas, RecordTypeState) {
         var ctl = this;
         initialize();
 
@@ -21,7 +21,7 @@
         }
 
         function loadRecordType () {
-            return RecordState.getSelected()
+            return RecordTypeState.getSelected()
                 .then(function(recordType) {
                     ctl.recordType = recordType;
                 });

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function RecordListController($scope, $rootScope, $log, $state, uuid4, FilterState,
                                   Notifications, RecordSchemas, RecordTypeState, BoundaryState,
-                                  QueryBuilder, WebConfig) {
+                                  RecordState, WebConfig) {
         var ctl = this;
         ctl.boundaryId = null;
         ctl.currentOffset = 0;
@@ -66,7 +66,7 @@
                 paramsOffset = 0;
             }
             /* jshint camelcase: false */
-            return QueryBuilder.djangoQuery(true, paramsOffset, {polygon_id: ctl.boundaryId})
+            return RecordState.getRecords(true, paramsOffset, {polygon_id: ctl.boundaryId})
             /* jshint camelcase: true */
             .then(function(records) {
                 ctl.records = records;

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -3,7 +3,7 @@
 
     /* ngInject */
     function RecordListController($scope, $rootScope, $log, $state, uuid4, FilterState,
-                                  Notifications, RecordSchemas, RecordState, BoundaryState,
+                                  Notifications, RecordSchemas, RecordTypeState, BoundaryState,
                                   QueryBuilder, WebConfig) {
         var ctl = this;
         ctl.boundaryId = null;
@@ -20,7 +20,7 @@
 
         function initialize() {
             ctl.isInitialized = false;
-            RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
+            RecordTypeState.getSelected().then(function(selected) { ctl.recordType = selected; })
                 .then(BoundaryState.getSelected().then(function(selected) {
                     ctl.boundaryId = selected.uuid;
                 }))
@@ -117,7 +117,7 @@
               });
         });
 
-        $scope.$on('driver.state.recordstate:selected', function(event, selected) {
+        $scope.$on('driver.state.recordtypestate:selected', function(event, selected) {
             // Only reload records in this handler after initialization is done.
             // This handler is for when the user changes the record type selection.
             if (!ctl.isInitialized) {

--- a/web/test/spec/filterbar/date-range-directive.spec.js
+++ b/web/test/spec/filterbar/date-range-directive.spec.js
@@ -9,15 +9,15 @@ describe('driver.filterbar: Date Range', function () {
 
     var $compile;
     var $rootScope;
-    var RecordState;
+    var RecordTypeState;
     var $httpBackend;
     var ResourcesMock;
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _RecordState_, _$httpBackend_, _ResourcesMock_) {
+    beforeEach(inject(function (_$compile_, _$rootScope_, _RecordTypeState_, _$httpBackend_, _ResourcesMock_) {
         $compile = _$compile_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
-        RecordState = _RecordState_;
+        RecordTypeState = _RecordTypeState_;
         ResourcesMock = _ResourcesMock_;
     }));
 

--- a/web/test/spec/recent-counts/recent-counts-directive.spec.js
+++ b/web/test/spec/recent-counts/recent-counts-directive.spec.js
@@ -14,18 +14,18 @@ describe('driver.recentCounts: RecentCounts', function () {
     var $httpBackend;
     var $q;
     var ResourcesMock;
-    var RecordState;
+    var RecordTypeState;
 
     beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_, _$q_,
-                                _RecordAggregates_, _ResourcesMock_, _RecordState_) {
+                                _RecordAggregates_, _ResourcesMock_, _RecordTypeState_) {
         $compile = _$compile_;
         $q = _$q_;
         $httpBackend = _$httpBackend_;
         RecordAggregates = _RecordAggregates_;
         $rootScope = _$rootScope_;
         ResourcesMock = _ResourcesMock_;
-        RecordState = _RecordState_;
-        spyOn(RecordState, 'getSelected').and.callFake(function() {
+        RecordTypeState = _RecordTypeState_;
+        spyOn(RecordTypeState, 'getSelected').and.callFake(function() {
             var deferred = $q.defer();
             deferred.resolve({uuid: 'a-uuid', plural_label: 'cthulus'});
             return deferred.promise;

--- a/web/test/spec/resources/aggregate-query-service.spec.js
+++ b/web/test/spec/resources/aggregate-query-service.spec.js
@@ -11,17 +11,17 @@ describe('driver.resources: Aggregate Queries', function () {
     var $httpBackend;
     var $q;
     var ResourcesMock;
-    var RecordState;
+    var RecordTypeState;
 
     beforeEach(inject(function (_$rootScope_, _$httpBackend_, _$q_,
-                                _RecordAggregates_, _RecordState_, _ResourcesMock_) {
+                                _RecordAggregates_, _RecordTypeState_, _ResourcesMock_) {
         $q = _$q_;
         $httpBackend = _$httpBackend_;
         RecordAggregates = _RecordAggregates_;
         $rootScope = _$rootScope_;
         ResourcesMock = _ResourcesMock_;
-        RecordState = _RecordState_;
-        spyOn(RecordState, 'getSelected').and.callFake(function() {
+        RecordTypeState = _RecordTypeState_;
+        spyOn(RecordTypeState, 'getSelected').and.callFake(function() {
           var deferred = $q.defer();
           deferred.resolve({uuid: 'a-very-weird-uuid'});
           return deferred.promise;

--- a/web/test/spec/state/recordtypestate-service.spec.js
+++ b/web/test/spec/state/recordtypestate-service.spec.js
@@ -7,20 +7,20 @@ describe('driver.state: Records', function () {
 
     var $rootScope;
     var $httpBackend;
-    var RecordState;
+    var RecordTypeState;
     var ResourcesMock;
 
-    beforeEach(inject(function (_$rootScope_, _$httpBackend_, _RecordState_, _ResourcesMock_) {
+    beforeEach(inject(function (_$rootScope_, _$httpBackend_, _RecordTypeState_, _ResourcesMock_) {
         $rootScope = _$rootScope_;
         $httpBackend = _$httpBackend_;
-        RecordState = _RecordState_;
+        RecordTypeState = _RecordTypeState_;
         ResourcesMock = _ResourcesMock_;
     }));
 
     it('should make a request for state options on call to "updateOptions"', function () {
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
 
-        RecordState.updateOptions();
+        RecordTypeState.updateOptions();
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
     });
 

--- a/web/test/spec/views/map/layers-controller.spec.js
+++ b/web/test/spec/views/map/layers-controller.spec.js
@@ -27,12 +27,12 @@ describe('driver.views.map: Layers Controller', function () {
     var Element;
     var ResourcesMock;
     var DriverResourcesMock;
-    var RecordState;
+    var RecordTypeState;
     var MapState;
 
     beforeEach(inject(function (_$compile_, _$controller_, _$httpBackend_, _$rootScope_,
                                 _ResourcesMock_, _DriverResourcesMock_,
-                                _RecordState_, _MapState_) {
+                                _RecordTypeState_, _MapState_) {
         $compile = _$compile_;
         $controller = _$controller_;
         $httpBackend = _$httpBackend_;
@@ -40,7 +40,7 @@ describe('driver.views.map: Layers Controller', function () {
         $rootScope = _$rootScope_;
         DriverResourcesMock = _DriverResourcesMock_;
         ResourcesMock = _ResourcesMock_;
-        RecordState = _RecordState_;
+        RecordTypeState = _RecordTypeState_;
         MapState = _MapState_;
 
         // Set these for testing persistence
@@ -84,7 +84,7 @@ describe('driver.views.map: Layers Controller', function () {
 
     it('should listen for record type change', function() {
         spyOn(Controller, 'setRecordLayers');
-        RecordState.setSelected({uuid: 'foo'});
+        RecordTypeState.setSelected({uuid: 'foo'});
         expect(Controller.setRecordLayers).toHaveBeenCalled();
     });
 

--- a/web/test/spec/views/record/list-directive.spec.js
+++ b/web/test/spec/views/record/list-directive.spec.js
@@ -12,17 +12,15 @@ describe('driver.views.record: RecordList', function () {
     var $httpBackend;
     var $rootScope;
     var localStorageService;
-    var recordState;
     var DriverResourcesMock;
     var ResourcesMock;
 
     beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_, _localStorageService_,
-                                _RecordState_, _DriverResourcesMock_, _ResourcesMock_) {
+                                _DriverResourcesMock_, _ResourcesMock_) {
         $compile = _$compile_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
         localStorageService = _localStorageService_;
-        recordState = _RecordState_;
         DriverResourcesMock = _DriverResourcesMock_;
         ResourcesMock = _ResourcesMock_;
 


### PR DESCRIPTION
This PR does a couple of things.

First, the `RecordState` is now `RecordTypeState` - thus bringing the service name in line with what it *actually* holds the state of.
Second, `RecordState` is now a service for storing the most recent record request and the parameters used for requesting it (this allows us to cut down on requests - I'm seeing two fewer requests on the dashboard, for instance).