### PR TITLE
Make record type dropdown visibility configurable

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -34,5 +34,8 @@ redis_port: 6379
 web_js_nominatim_key: ""
 web_js_html5mode: "true"
 web_js_html5mode_prefix: "!"
+web_js_record_type_visible: "false"
+web_js_record_type_primary_label: "Accident"
+web_js_record_type_secondary_label: "Intervention"
 editor_js_html5mode: "true"
 editor_js_html5mode_prefix: "!"

--- a/deployment/ansible/roles/driver.web/templates/web-config-js.j2
+++ b/deployment/ansible/roles/driver.web/templates/web-config-js.j2
@@ -28,6 +28,11 @@
         },
         record: {
             limit: 50
+        },
+        recordType: {
+            visible: {{ web_js_record_type_visible }},
+            primaryLabel: '{{ web_js_record_type_primary_label }}',
+            secondaryLabel: '{{ web_js_record_type_secondary_label }}'
         }
     };
 

--- a/web/app/scripts/navbar/navbar-controller.js
+++ b/web/app/scripts/navbar/navbar-controller.js
@@ -3,7 +3,7 @@
 
     /* ngInject */
     function NavbarController($log, $window, $rootScope, $scope, $state,
-                              GeographyState, RecordState, BoundaryState) {
+                              GeographyState, RecordState, BoundaryState, WebConfig) {
         var ctl = this;
         var _ = $window._;
         init();
@@ -13,6 +13,7 @@
         ctl.onStateSelected = onStateSelected;
         ctl.navigateToStateName = navigateToStateName;
         ctl.getBoundaryLabel = getBoundaryLabel;
+        ctl.recordTypesVisible = WebConfig.recordType.visible;
         $rootScope.$on('$stateChangeSuccess', setStates);
 
         function init() {

--- a/web/app/scripts/navbar/navbar-partial.html
+++ b/web/app/scripts/navbar/navbar-partial.html
@@ -18,7 +18,7 @@
                         </li>
                     </ul>
                 </li>
-                <li class="dropdown">
+                <li class="dropdown" ng-if="ctl.recordTypesVisible">
                     <a class="dropdown-toggle" data-toggle="dropdown" role="button">
                         {{ ctl.recordTypeSelected.plural_label }}
                         <span class="caret"></span></a>

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -6,7 +6,7 @@
     'use strict';
 
     /* ngInject */
-    function RecordState($log, $rootScope, $q, localStorageService, RecordTypes) {
+    function RecordState($log, $rootScope, $q, localStorageService, RecordTypes, WebConfig) {
         var defaultParams,
             selected,
             options,
@@ -78,13 +78,21 @@
          */
         function setSelected(selection) {
             if (!initialized) {
-                var oldRecordType = localStorageService.get('recordtype.selected');
-                if (oldRecordType) {
+                // If the record type is not configured as visible, always use the primary.
+                // The primary is obtained by finding a record type label matching the primaryLabel.
+                if (!WebConfig.recordType.visible) {
                     selection = _.find(options, function(d) {
-                        return d.uuid === oldRecordType.uuid;
+                        return d.label === WebConfig.recordType.primaryLabel;
                     });
-                    initialized = true;
+                } else {
+                    var oldRecordType = localStorageService.get('recordtype.selected');
+                    if (oldRecordType) {
+                        selection = _.find(options, function(d) {
+                            return d.uuid === oldRecordType.uuid;
+                        });
+                    }
                 }
+                initialized = true;
             }
             if (_.find(options, function(d) { return d.uuid === selection.uuid; })) {
                 selected = selection;

--- a/web/test/mock/config.js
+++ b/web/test/mock/config.js
@@ -18,6 +18,11 @@
         },
         record: {
             limit: 50
+        },
+        recordType: {
+            visible: false,
+            primaryLabel: 'Accident',
+            secondaryLabel: 'Intervention'
         }
     };
 


### PR DESCRIPTION
A web config setting of `recordType.visible` controls visibility.
If the record type is configured to not be visible, the record type
is chosen by using the config setting of `recordType.primaryLabel`.

A seting for `recordType.secondaryLabel` has also been added, though
it is not yet in use. It will be used when displaying interventions.