### PR TITLE
Feature/form error feedback

### DIFF
--- a/schema_editor/app/index.html
+++ b/schema_editor/app/index.html
@@ -50,6 +50,7 @@
     <script src="bower_components/ng-file-upload/ng-file-upload.js"></script>
     <script src="bower_components/angular-spinkit/build/angular-spinkit.js"></script>
     <script src="bower_components/angular-resource/angular-resource.js"></script>
+    <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
     <script src="bower_components/json-editor/dist/jsoneditor.js"></script>
     <script src="bower_components/angular-local-storage/dist/angular-local-storage.js"></script>

--- a/schema_editor/app/scripts/notifications/module.js
+++ b/schema_editor/app/scripts/notifications/module.js
@@ -1,5 +1,5 @@
 (function () {
     'use strict';
 
-    angular.module('ase.notifications', []);
+    angular.module('ase.notifications', ['ngSanitize']);
 })();

--- a/schema_editor/app/scripts/notifications/notifications-partial.html
+++ b/schema_editor/app/scripts/notifications/notifications-partial.html
@@ -1,5 +1,5 @@
 <div class="notifications alert" ng-hide="!ntf.active" ng-class="ntf.alert.displayClass">
-  <table>
+  <table ng-if="ntf.alert.text">
     <tr>
       <td><span class="glyphicon"
           ng-class="ntf.alert.imageClass"
@@ -10,4 +10,22 @@
           ng-click="ntf.hideAlert()"></span></td>
     </tr>
   </table>
+  <div ng-if="ntf.alert.html">
+    <span class="glyphicon pull-left"
+      ng-class="ntf.alert.imageClass"
+      ng-if="ntf.alert.imageClass">
+    </span>
+    <span class="glyphicon glyphicon-remove pull-right"
+      ng-if="ntf.alert.closeButton"
+      ng-click="ntf.hideAlert()">
+    </span>
+    <div class="container-fluid">
+      <div class="row">
+        <h4 class="text-center">{{ ntf.alert.header }}</h4>
+      </div>
+      <div class="row">
+        <div ng-bind-html="ntf.alert.html"></div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/schema_editor/app/scripts/notifications/notifications-service.js
+++ b/schema_editor/app/scripts/notifications/notifications-service.js
@@ -46,6 +46,7 @@
             var defaults = {
                 timeout: 0,
                 closeButton: true,
+                html: '',
                 text: '',
                 imageClass: 'glyphicon-warning-sign',
                 displayClass: 'alert-info'

--- a/schema_editor/bower.json
+++ b/schema_editor/bower.json
@@ -10,6 +10,7 @@
     "ng-file-upload": "^4.0.0",
     "angular-spinkit": "^0.3.3",
     "angular-resource": "^1.3.0",
+    "angular-sanitize": "^1.3.0",
     "angular-ui-router": "~0.2.14",
     "json-editor": "0.7.22",
     "angular-local-storage": "~0.2.2",

--- a/schema_editor/test/karma.conf.js
+++ b/schema_editor/test/karma.conf.js
@@ -35,6 +35,7 @@ module.exports = function(config) {
       'bower_components/ng-file-upload/ng-file-upload.js',
       'bower_components/angular-spinkit/build/angular-spinkit.js',
       'bower_components/angular-resource/angular-resource.js',
+      'bower_components/angular-sanitize/angular-sanitize.js',
       'bower_components/angular-ui-router/release/angular-ui-router.js',
       'bower_components/json-editor/dist/jsoneditor.js',
       'bower_components/angular-local-storage/dist/angular-local-storage.js',

--- a/schema_editor/test/spec/notifications/notifications-directive.spec.js
+++ b/schema_editor/test/spec/notifications/notifications-directive.spec.js
@@ -12,12 +12,26 @@ describe('ase.notifications: Directive', function () {
         $rootScope = _$rootScope_;
     }));
 
-    it('should load directive', function () {
+    it('should load directive with text message', function () {
         var scope = $rootScope.$new();
         var element = $compile('<ase-notifications></ase-notifications>')(scope);
         $rootScope.$apply();
 
+        $rootScope.$broadcast('ase.notifications.show', {text: 'Danger, Will Robinson!'});
+        $rootScope.$apply();
+
         expect(element.find('table').length).toEqual(1);
+    });
+
+    it('should load directive with HTML message', function () {
+        var scope = $rootScope.$new();
+        var element = $compile('<ase-notifications></ase-notifications>')(scope);
+        $rootScope.$apply();
+
+        $rootScope.$broadcast('ase.notifications.show', {html: '<p>Danger, Will Robinson!</p>'});
+        $rootScope.$apply();
+
+        expect(element.find('div[ng-bind-html]').length).toEqual(1);
     });
 
 });

--- a/web/app/index.html
+++ b/web/app/index.html
@@ -41,6 +41,7 @@
     <script src="bower_components/angular-cookies/angular-cookies.js"></script>
     <script src="bower_components/angular-spinkit/build/angular-spinkit.js"></script>
     <script src="bower_components/angular-resource/angular-resource.js"></script>
+    <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
     <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
     <script src="bower_components/bootstrap-select/dist/js/bootstrap-select.js"></script>

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -66,7 +66,8 @@
                      class="form-area-body">
         </json-editor>
         <div class="save-area">
-            <button type="button" class="btn btn-default" ng-disabled="ctl.editor.errors.length > 0"
+            <button type="button" class="btn btn-default"
+                    ng-disabled="ctl.editor.errors.length > 0 || ctl.missingConstantField"
                     ng-click="ctl.onSaveClicked()">Save</button>
             <button type="button" class="btn btn-default"
                     ng-click="ctl.goBack()">Cancel</button>

--- a/web/app/scripts/views/record/module.js
+++ b/web/app/scripts/views/record/module.js
@@ -35,6 +35,7 @@
     }
 
     angular.module('driver.views.record', [
+        'ngSanitize',
         'ase.notifications',
         'ase.resources',
         'ase.schemas',

--- a/web/bower.json
+++ b/web/bower.json
@@ -9,6 +9,7 @@
     "angular-cookies": "^1.3.0",
     "angular-spinkit": "^0.3.3",
     "angular-resource": "^1.3.0",
+    "angular-sanitize": "^1.3.0",
     "angular-ui-router": "~0.2.14",
     "angular-bootstrap": "~0.13.0",
     "angular-bootstrap-select": "0.0.5",

--- a/web/test/karma.conf.js
+++ b/web/test/karma.conf.js
@@ -37,6 +37,7 @@ module.exports = function(config) {
       'bower_components/angular-cookies/angular-cookies.js',
       'bower_components/angular-spinkit/build/angular-spinkit.js',
       'bower_components/angular-resource/angular-resource.js',
+      'bower_components/angular-sanitize/angular-sanitize.js',
       'bower_components/angular-ui-router/release/angular-ui-router.js',
       'bower_components/angular-bootstrap/ui-bootstrap-tpls.js',
       'bower_components/bootstrap-select/dist/js/bootstrap-select.js',


### PR DESCRIPTION
* Modify notifications to alternatively display sanitized HTML
* Disable form save when missing constant field(s)
* Should validation errors from any field make it past 'save' press, display list as HTML notification
* Display non-validation errors in notification, like so:

![image](https://cloud.githubusercontent.com/assets/960264/10706257/6e23c5ee-79b3-11e5-88da-31f5f96a6666.png)
