### PR TITLE
Feature/show required

### DIFF
--- a/schema_editor/bower.json
+++ b/schema_editor/bower.json
@@ -12,7 +12,7 @@
     "angular-resource": "^1.3.0",
     "angular-sanitize": "^1.3.0",
     "angular-ui-router": "~0.2.14",
-    "json-editor": "0.7.22",
+    "json-editor": "flibbertigibbet/json-editor#develop",
     "angular-local-storage": "~0.2.2",
     "angular-bootstrap": "~0.13.0",
     "lodash": "^3.8.0"

--- a/schema_editor/bower.json
+++ b/schema_editor/bower.json
@@ -12,7 +12,7 @@
     "angular-resource": "^1.3.0",
     "angular-sanitize": "^1.3.0",
     "angular-ui-router": "~0.2.14",
-    "json-editor": "flibbertigibbet/json-editor#develop",
+    "json-editor": "azavea/json-editor#develop",
     "angular-local-storage": "~0.2.2",
     "angular-bootstrap": "~0.13.0",
     "lodash": "^3.8.0"

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -30,7 +30,7 @@
 
             ctl.nominatimValue = '';
 
-            ctl.missingConstantField = true;
+            ctl.constantFieldErrors = null;
             ctl.geom = {
                 lat: null,
                 lng: null
@@ -237,16 +237,21 @@
             };
             /* jshint camelcase: true */
 
+            ctl.constantFieldErrors = {};
             var errorMessage = '';
             angular.forEach(required, function(value, fieldName) {
                 if (!value) {
                     // message formatted to match errors from json-editor
                     errorMessage += '<p>' + fieldName + ': Value required</p>';
+                    ctl.constantFieldErrors[fieldName] = true;
                 }
             });
 
-            // let controller know if we have all the constant fields or not
-            ctl.missingConstantField = !!errorMessage;
+            // make field errors falsy if empty, for partial to check easily
+            if (Object.keys(ctl.constantFieldErrors).length === 0) {
+                ctl.constantFieldErrors = null;
+            }
+
             return errorMessage;
         }
 

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -26,23 +26,25 @@
                 </div>
                 <div class="row">
                     <div class="col-md-6">
-                        <div class="form-group">
+                        <div class="form-group" ng-class="!ctl.geom.lat ? 'has-error' : ''">
                             <label class="control-label">Latitude</label>
                             <input type="number" class="form-control"
                                 ng-change="ctl.onGeomChanged(false)" ng-model="ctl.geom.lat">
+                            <p ng-if="!ctl.geom.lat" class="help-block errormsg">Value required.</p>
                         </div>
                     </div>
                     <div class="col-md-6">
-                        <div class="form-group">
+                        <div class="form-group" ng-class="!ctl.geom.lng ? 'has-error' : ''">
                             <label class="control-label">Longitude</label>
                             <input type="number" class="form-control"
                                 ng-change="ctl.onGeomChanged(false)" ng-model="ctl.geom.lng">
+                            <p ng-if="!ctl.geom.lng" class="help-block errormsg">Value required.</p>
                         </div>
                     </div>
 				</div>
 				<div class= "row">
                     <div class="col-md-6">
-                        <div class="form-group">
+                        <div class="form-group" ng-class="!ctl.record.occurred_from ? 'has-error' : ''">
                             <label class="control-label">Occurred</label>
                             <div class="input-group" id="datetimepicker-From">
                                 <input type="text" class="form-control"
@@ -55,6 +57,8 @@
                                     <span class="glyphicon glyphicon-calendar"></span>
                                 </span>
                             </div>
+                            <p ng-if="!ctl.record.occurred_from"
+                                class="help-block errormsg">Value required.</p>
                         </div>
                     </div>
                 </div>

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -26,26 +26,31 @@
                 </div>
                 <div class="row">
                     <div class="col-md-6">
-                        <div class="form-group" ng-class="!ctl.geom.lat ? 'has-error' : ''">
-                            <label class="control-label">Latitude</label>
+                        <div class="form-group"
+                            ng-class="ctl.constantFieldErrors.latitude ? 'has-error' : ''">
+                            <label class="control-label required">Latitude</label>
                             <input type="number" class="form-control"
                                 ng-change="ctl.onGeomChanged(false)" ng-model="ctl.geom.lat">
-                            <p ng-if="!ctl.geom.lat" class="help-block errormsg">Value required.</p>
+                            <p ng-if="ctl.constantFieldErrors.latitude"
+                                class="help-block errormsg">Value required.</p>
                         </div>
                     </div>
                     <div class="col-md-6">
-                        <div class="form-group" ng-class="!ctl.geom.lng ? 'has-error' : ''">
-                            <label class="control-label">Longitude</label>
+                        <div class="form-group"
+                            ng-class="ctl.constantFieldErrors.longitude ? 'has-error' : ''">
+                            <label class="control-label required">Longitude</label>
                             <input type="number" class="form-control"
                                 ng-change="ctl.onGeomChanged(false)" ng-model="ctl.geom.lng">
-                            <p ng-if="!ctl.geom.lng" class="help-block errormsg">Value required.</p>
+                            <p ng-if="ctl.constantFieldErrors.longitude"
+                                class="help-block errormsg">Value required.</p>
                         </div>
                     </div>
 				</div>
 				<div class= "row">
                     <div class="col-md-6">
-                        <div class="form-group" ng-class="!ctl.record.occurred_from ? 'has-error' : ''">
-                            <label class="control-label">Occurred</label>
+                        <div class="form-group"
+                            ng-class="ctl.constantFieldErrors.occurred ? 'has-error' : ''">
+                            <label class="control-label required">Occurred</label>
                             <div class="input-group" id="datetimepicker-From">
                                 <input type="text" class="form-control"
                                     datetimepicker
@@ -57,7 +62,7 @@
                                     <span class="glyphicon glyphicon-calendar"></span>
                                 </span>
                             </div>
-                            <p ng-if="!ctl.record.occurred_from"
+                            <p ng-if="ctl.constantFieldErrors.occurred"
                                 class="help-block errormsg">Value required.</p>
                         </div>
                     </div>
@@ -71,7 +76,7 @@
         </json-editor>
         <div class="save-area">
             <button type="button" class="btn btn-default"
-                    ng-disabled="ctl.editor.errors.length > 0 || ctl.missingConstantField"
+                    ng-disabled="ctl.editor.errors.length > 0 || ctl.constantFieldErrors"
                     ng-click="ctl.onSaveClicked()">Save</button>
             <button type="button" class="btn btn-default"
                     ng-click="ctl.goBack()">Cancel</button>

--- a/web/app/styles/partials/_json-editor.scss
+++ b/web/app/styles/partials/_json-editor.scss
@@ -5,3 +5,7 @@ json-editor > div > h3 {
 .map {
     height:300px;
 }
+
+label.required {
+    color: black;
+}

--- a/web/bower.json
+++ b/web/bower.json
@@ -17,7 +17,7 @@
     "angular-local-storage": "0.2.2",
     "bootstrap-sass-official": "^3.2.0",
     "ng-file-upload": "^4.0.0",
-    "json-editor": "0.7.22",
+    "json-editor": "flibbertigibbet/json-editor#develop",
     "bootstrap-select": "1.7.3",
     "lodash": "^3.8.0",
     "leaflet": "~0.7.3",

--- a/web/bower.json
+++ b/web/bower.json
@@ -17,7 +17,7 @@
     "angular-local-storage": "0.2.2",
     "bootstrap-sass-official": "^3.2.0",
     "ng-file-upload": "^4.0.0",
-    "json-editor": "flibbertigibbet/json-editor#develop",
+    "json-editor": "azavea/json-editor#develop",
     "bootstrap-select": "1.7.3",
     "lodash": "^3.8.0",
     "leaflet": "~0.7.3",


### PR DESCRIPTION
Depends on azavea/json-editor#1.

* Sets a `required` class on labels for required fields (here, changes the font color for those from grey to black; will be easy to change if we want something else).

* Adds standard error class and 'Value required' message on the constant fields after form edit, to match behavior of non-constant fields.