### PR TITLE
Add service for tracking initial state

### DIFF
--- a/web/app/index.html
+++ b/web/app/index.html
@@ -91,6 +91,7 @@
     <script src="scripts/resources/query-builder-service.js"></script>
     <script src="scripts/resources/aggregate-query-service.js"></script>
     <script src="scripts/state/module.js"></script>
+    <script src="scripts/state/initialstate-service.js"></script>
     <script src="scripts/state/filters-service.js"></script>
     <script src="scripts/state/mapstate-service.js"></script>
     <script src="scripts/state/recordstate-service.js"></script>

--- a/web/app/scripts/recent-counts/recent-counts-controller.js
+++ b/web/app/scripts/recent-counts/recent-counts-controller.js
@@ -2,10 +2,9 @@
     'use strict';
 
     /* ngInject */
-    function RecentCountsController($scope, RecordAggregates, RecordState) {
+    function RecentCountsController($scope, InitialState, RecordAggregates, RecordState) {
         var ctl = this;
-        init();
-        $scope.$on('driver.state.recordstate:selected', init);
+        InitialState.ready().then(init);
         return ctl;
 
         function init() {

--- a/web/app/scripts/state/boundarystate-service.js
+++ b/web/app/scripts/state/boundarystate-service.js
@@ -6,7 +6,8 @@
     'use strict';
 
     /* ngInject */
-    function BoundaryState($log, $rootScope, $q, localStorageService, Polygons) {
+    function BoundaryState($log, $rootScope, $q, localStorageService,
+                           GeographyState, InitialState, Polygons) {
         var defaultParams, selected, options;
         var initialized = false;
         var svc = this;
@@ -22,7 +23,12 @@
         function init() {
           selected = null;
           options = [];
-          defaultParams = {'active': 'True'};
+          defaultParams = { active: 'True' };
+
+          GeographyState.getSelected().then(function(geography) {
+              var params = geography ? { boundary: geography.uuid } : {};
+              svc.updateOptions(params);
+          });
         }
 
         /**
@@ -71,6 +77,7 @@
                     return d.uuid === oldPoly.uuid;
                 });
                 initialized = true;
+                InitialState.setBoundaryInitialized();
             }
 
             if (_.find(options, function(d) {

--- a/web/app/scripts/state/geographystate-service.js
+++ b/web/app/scripts/state/geographystate-service.js
@@ -6,7 +6,8 @@
     'use strict';
 
     /* ngInject */
-    function GeographyState($log, $rootScope, $q, localStorageService, Geography) {
+    function GeographyState($log, $rootScope, $q, localStorageService,
+                            InitialState, Geography) {
         var defaultParams, selected, options;
         var initialized = false;
         var svc = this;
@@ -23,7 +24,6 @@
           selected = null;
           options = [];
           defaultParams = {};
-          svc.updateOptions();
         }
 
         /**
@@ -65,14 +65,18 @@
          */
         function setSelected(selection) {
             if (!initialized) {
-                selection = _.find(options, function(d) {
+                var oldSelection = _.find(options, function(d) {
                     var oldGeo = localStorageService.get('geography.selected');
                     if (!oldGeo) {
                         return {'uuid': ''};
                     }
                     return d.uuid === oldGeo.uuid;
                 });
+                if (oldSelection) {
+                    selection = oldSelection;
+                }
                 initialized = true;
+                InitialState.setGeographyInitialized();
             }
 
             if (_.find(options, function(d) { return d.uuid === selection.uuid; })) {

--- a/web/app/scripts/state/initialstate-service.js
+++ b/web/app/scripts/state/initialstate-service.js
@@ -1,0 +1,89 @@
+/**
+ * Service that keeps track of state for objects that are required to be available
+ * upon page load. This is used to ensure the common state values used within each
+ * component are fully loaded before pages make requests, preventing state problems.
+ */
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function InitialState($log, $q) {
+
+        var recordTypeInitialized = false;
+        var boundaryInitialized = false;
+        var geographyInitialized = false;
+
+        var deferreds = [];
+
+        var svc = {
+            ready: ready,
+            setRecordTypeInitialized: setRecordTypeInitialized,
+            setBoundaryInitialized: setBoundaryInitialized,
+            setGeographyInitialized: setGeographyInitialized
+        };
+
+        return svc;
+
+        /**
+         * Returns a promise that resolves when all state values are available
+         */
+        function ready() {
+            var deferred = $q.defer();
+
+            if (allInitialized()) {
+                deferred.resolve();
+            } else {
+                deferreds.push(deferred);
+            }
+
+            return deferred.promise;
+        }
+
+        /**
+         * Checks if all state values are available, and if so, resolves all deferreds
+         */
+        function resolveDeferreds() {
+            if (allInitialized()) {
+                _.each(deferreds, function(deferred) {
+                    deferred.resolve();
+                });
+                deferreds = [];
+            }
+        }
+
+        /**
+         * Returns true when all state values are available
+         */
+        function allInitialized() {
+            return recordTypeInitialized && boundaryInitialized && geographyInitialized;
+        }
+
+        /**
+         * Sets the recordType initialized state value to true
+         */
+        function setRecordTypeInitialized() {
+            recordTypeInitialized = true;
+            resolveDeferreds();
+        }
+
+        /**
+         * Sets the boundary initialized state value to true
+         */
+        function setBoundaryInitialized() {
+            boundaryInitialized = true;
+            resolveDeferreds();
+        }
+
+        /**
+         * Sets the geography initialized state value to true
+         */
+        function setGeographyInitialized() {
+            geographyInitialized = true;
+            resolveDeferreds();
+        }
+
+    }
+
+    angular.module('driver.state')
+    .factory('InitialState', InitialState);
+})();

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -6,7 +6,8 @@
     'use strict';
 
     /* ngInject */
-    function RecordState($log, $rootScope, $q, localStorageService, RecordTypes, WebConfig) {
+    function RecordState($log, $rootScope, $q, localStorageService,
+                         InitialState, RecordTypes, WebConfig) {
         var defaultParams,
             selected,
             options,
@@ -93,6 +94,7 @@
                     }
                 }
                 initialized = true;
+                InitialState.setRecordTypeInitialized();
             }
             if (_.find(options, function(d) { return d.uuid === selection.uuid; })) {
                 selected = selection;

--- a/web/app/scripts/views/dashboard/dashboard-controller.js
+++ b/web/app/scripts/views/dashboard/dashboard-controller.js
@@ -2,21 +2,22 @@
     'use strict';
 
     /* ngInject */
-    function DashboardController($scope, Records, RecordSchemas, RecordState, RecordAggregates) {
+    function DashboardController($scope, InitialState, Records, RecordSchemas,
+                                 RecordState, RecordAggregates) {
         var ctl = this;
 
-        initialize();
+        InitialState.ready().then(init);
 
-        $scope.$on('driver.state.recordstate:selected', function(event, selected) {
-            ctl.recordType = selected;
-            loadRecords();
-        });
-
-        function initialize() {
+        function init() {
             RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
                 .then(loadRecordSchema)
                 .then(loadRecords)
                 .then(onRecordsLoaded);
+
+            $scope.$on('driver.state.recordstate:selected', function(event, selected) {
+                ctl.recordType = selected;
+                loadRecords();
+            });
         }
 
         function loadRecordSchema() {

--- a/web/app/scripts/views/map/map-controller.js
+++ b/web/app/scripts/views/map/map-controller.js
@@ -2,26 +2,27 @@
     'use strict';
 
     /* ngInject */
-    function MapController($rootScope, $scope, Records, RecordSchemas, RecordState, RecordAggregates) {
+    function MapController($rootScope, $scope, InitialState,
+                           Records, RecordSchemas, RecordState, RecordAggregates) {
         var ctl = this;
 
-        initialize();
+        InitialState.ready().then(init);
 
-        // TODO: This also needs to listen for changing filters, both from the filterbar and map.
-        // This hasn't been done here, because of a couple related, in-progress tasks.
-        $scope.$on('driver.state.recordstate:selected', function(event, selected) {
-            ctl.recordType = selected;
-            loadRecords();
-        });
-
-        $rootScope.$on('driver.filterbar:changed', function() {
-            loadRecords();
-        });
-
-        function initialize() {
+        function init() {
             RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
                 .then(loadRecordSchema)
                 .then(loadRecords);
+
+            // TODO: This also needs to listen for changing filters, both from the filterbar
+            // and map. This hasn't been done here, because of a couple related, in-progress tasks.
+            $scope.$on('driver.state.recordstate:selected', function(event, selected) {
+                ctl.recordType = selected;
+                loadRecords();
+            });
+
+            $rootScope.$on('driver.filterbar:changed', function() {
+                loadRecords();
+            });
         }
 
         function loadRecordSchema() {

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -3,8 +3,8 @@
 
     /* ngInject */
     function RecordListController($scope, $rootScope, $log, $state, uuid4, FilterState,
-                                  Notifications, RecordSchemas, RecordState, BoundaryState,
-                                  QueryBuilder, WebConfig) {
+                                  InitialState, Notifications, RecordSchemas, RecordState,
+                                  BoundaryState, QueryBuilder, WebConfig) {
         var ctl = this;
         ctl.boundaryId = null;
         ctl.currentOffset = 0;
@@ -15,10 +15,9 @@
         ctl.restoreFilters = restoreFilters;
         ctl.isInitialized = false;
 
-        initialize();
+        InitialState.ready().then(init);
 
-
-        function initialize() {
+        function init() {
             ctl.isInitialized = false;
             RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
                 .then(BoundaryState.getSelected().then(function(selected) {

--- a/web/test/spec/map-layers/recent-events/recent-events-layer-directive.spec.js
+++ b/web/test/spec/map-layers/recent-events/recent-events-layer-directive.spec.js
@@ -3,16 +3,20 @@
 describe('driver.map-layers.recent-events: Recent Events Layer Directive', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.map-layers.recent-events'));
+    beforeEach(module('driver.mock.resources'));
 
     var $compile;
     var $rootScope;
     var $httpBackend;
+    var DriverResourcesMock;
     var ResourcesMock;
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_, _ResourcesMock_) {
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_,
+                                _DriverResourcesMock_, _ResourcesMock_) {
         $compile = _$compile_;
         $rootScope = _$rootScope_;
         $httpBackend = _$httpBackend_;
+        DriverResourcesMock = _DriverResourcesMock_;
         ResourcesMock = _ResourcesMock_;
     }));
 
@@ -20,14 +24,11 @@ describe('driver.map-layers.recent-events: Recent Events Layer Directive', funct
         var scope = $rootScope.$new();
         var element = $compile('<div leaflet-map recent-events></div>')(scope);
 
-        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        // TODO: Figure out why some many duplicate requests are occurring and remove.
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(/\/api\/boundarypolygons/).respond(ResourcesMock.BoundaryNoGeomResponse);
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(/\api\/records/).respond(200, ResourcesMock.RecordResponse);
-        $httpBackend.expectGET(/\api\/records/).respond(200, ResourcesMock.RecordResponse);
-        $httpBackend.expectGET(/\api\/records/).respond(200, ResourcesMock.RecordResponse);
+        $httpBackend.whenGET(/\/api\/boundaries/).respond(DriverResourcesMock.BoundaryResponse);
+        $httpBackend.expectGET(/\/api\/recordtypes\/\?active=True/)
+            .respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(/\/api\/boundarypolygons/)
+            .respond(ResourcesMock.BoundaryNoGeomResponse);
         $httpBackend.expectGET(/\api\/records/).respond(200, ResourcesMock.RecordResponse);
 
         $rootScope.$digest();

--- a/web/test/spec/recent-counts/recent-counts-controller.spec.js
+++ b/web/test/spec/recent-counts/recent-counts-controller.spec.js
@@ -11,27 +11,30 @@ describe('driver.recentCounts: RecentCountsController', function () {
     var $rootScope;
     var $scope;
     var Controller;
+    var InitialState;
     var ResourcesMock;
 
-    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_, _ResourcesMock_) {
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_,
+                                _InitialState_, _ResourcesMock_) {
         $controller = _$controller_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
         $scope = $rootScope.$new();
         ResourcesMock = _ResourcesMock_;
+
+        InitialState = _InitialState_;
+        InitialState.setBoundaryInitialized();
+        InitialState.setGeographyInitialized();
     }));
 
     it('should make requests to recent_counts', function () {
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True&limit=all/;
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
 
         var recordType = ResourcesMock.RecordType;
         var recordTypeId = recordType.uuid;
         var countsUrl = new RegExp('api/recordtypes/' + recordTypeId +
                                    '/recent_counts/\\?limit=all');
-        $httpBackend.expectGET(countsUrl).respond(200);
-        $httpBackend.expectGET(countsUrl).respond(200);
         $httpBackend.expectGET(countsUrl).respond(200);
 
         Controller = $controller('RecentCountsController', { $scope: $scope });

--- a/web/test/spec/recent-counts/recent-counts-directive.spec.js
+++ b/web/test/spec/recent-counts/recent-counts-directive.spec.js
@@ -15,8 +15,9 @@ describe('driver.recentCounts: RecentCounts', function () {
     var $q;
     var ResourcesMock;
     var RecordState;
+    var InitialState;
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_, _$q_,
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_, _$q_, _InitialState_,
                                 _RecordAggregates_, _ResourcesMock_, _RecordState_) {
         $compile = _$compile_;
         $q = _$q_;
@@ -35,6 +36,10 @@ describe('driver.recentCounts: RecentCounts', function () {
             deferred.resolve({plural: 'cthulus', year: 100, quarter: 10, month: 1});
             return deferred.promise;
         });
+
+        InitialState = _InitialState_;
+        InitialState.setBoundaryInitialized();
+        InitialState.setGeographyInitialized();
     }));
 
     it('It should construct the dom when given the appropriate object', function () {

--- a/web/test/spec/state/initialstate-service.spec.js
+++ b/web/test/spec/state/initialstate-service.spec.js
@@ -1,0 +1,53 @@
+'use strict';
+
+describe('driver.state: InitialState', function () {
+
+    beforeEach(module('driver.state'));
+
+    var $timeout;
+    var InitialState;
+
+    beforeEach(inject(function (_$timeout_, _InitialState_) {
+        $timeout = _$timeout_;
+        InitialState = _InitialState_;
+    }));
+
+    it('should wait to resolve `ready` promises', function () {
+        var testVar1 = false;
+        InitialState.ready().then(function() {
+            testVar1 = true;
+        });
+
+        expect(testVar1).toEqual(false);
+
+        var testVar2 = false;
+        InitialState.ready().then(function() {
+            testVar2 = true;
+        });
+
+        InitialState.setRecordTypeInitialized();
+        expect(testVar1).toEqual(false);
+        expect(testVar2).toEqual(false);
+
+
+        var testVar3 = false;
+        InitialState.ready().then(function() {
+            testVar3 = true;
+        });
+
+        InitialState.setBoundaryInitialized();
+        expect(testVar1).toEqual(false);
+        expect(testVar2).toEqual(false);
+        expect(testVar3).toEqual(false);
+
+        InitialState.setGeographyInitialized();
+
+        $timeout(function() {
+            expect(testVar1).toEqual(true);
+            expect(testVar2).toEqual(true);
+            expect(testVar3).toEqual(true);
+        }, 0);
+        $timeout.flush();
+    });
+
+});

--- a/web/test/spec/state/zoom-to-boundary-directive-spec.js
+++ b/web/test/spec/state/zoom-to-boundary-directive-spec.js
@@ -19,6 +19,8 @@ describe('driver.state: Zoom to Boundary Directive', function () {
         ResourcesMock = _ResourcesMock_;
         $scope = $rootScope.$new();
         Element = $compile('<div class="map" leaflet-map zoom-to-boundary></div>')($scope);
+        $httpBackend.expectGET(/\/api\/boundaries/)
+            .respond(ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(/\/api\/boundarypolygons/)
             .respond(ResourcesMock.BoundaryNoGeomResponse);
         $rootScope.$apply();

--- a/web/test/spec/views/dashboard/dashboard-controller.spec.js
+++ b/web/test/spec/views/dashboard/dashboard-controller.spec.js
@@ -27,9 +27,10 @@ describe('driver.views.dashboard: DashboardController', function () {
     it('should pass this placeholder test', function () {
         Controller = $controller('DashboardController', { $scope: $scope });
 
-        var recordTypeUrl = /\/api\/recordtypes\//;
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(/\/api\/recordtypes\//)
+            .respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(/\/api\/boundaries/)
+            .respond(ResourcesMock.GeographyResponse);
 
         $scope.$apply();
     });

--- a/web/test/spec/views/dashboard/dashboard-directive.spec.js
+++ b/web/test/spec/views/dashboard/dashboard-directive.spec.js
@@ -26,12 +26,12 @@ describe('driver.views.dashboard: Dashboard', function () {
         var scope = $rootScope.$new();
         var element = $compile('<driver-dashboard></driver-dashboard>')(scope);
 
-        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        var boundaryPolygonsUrl = /api\/boundarypolygons/;
-
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.whenGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
+        $httpBackend.expectGET(/\/api\/boundaries/)
+            .respond(ResourcesMock.GeographyResponse);
+        $httpBackend.expectGET(/\/api\/recordtypes\//)
+            .respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.whenGET(/api\/boundarypolygons/)
+            .respond(200, ResourcesMock.BoundaryNoGeomResponse);
 
         $rootScope.$apply();
 

--- a/web/test/spec/views/record/list-controller.spec.js
+++ b/web/test/spec/views/record/list-controller.spec.js
@@ -38,10 +38,11 @@ describe('driver.views.record: ListController', function () {
         var recordType = ResourcesMock.RecordType;
         var recordTypeId = recordType.uuid;
 
+        var boundariesUrl = /api\/boundaries/;
         var boundaryPolygonsUrl = /api\/boundarypolygons/;
 
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
         $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 
@@ -74,10 +75,11 @@ describe('driver.views.record: ListController', function () {
         var recordType = ResourcesMock.RecordType;
         var recordTypeId = recordType.uuid;
 
+        var boundariesUrl = /api\/boundaries/;
         var boundaryPolygonsUrl = /api\/boundarypolygons/;
 
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
         $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 

--- a/web/test/spec/views/record/list-directive.spec.js
+++ b/web/test/spec/views/record/list-directive.spec.js
@@ -33,10 +33,12 @@ describe('driver.views.record: RecordList', function () {
         var recordsUrl = /\/api\/records/;
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
         var recordSchemaUrl = /\/api\/recordschemas/;
-        var boundaryPolygonsUrl = /api\/boundarypolygons\/\?active=True&limit=all&nogeom=true/;
+
+        var boundariesUrl = /api\/boundaries/;
+        var boundaryPolygonsUrl = /api\/boundarypolygons\//;
 
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
         $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchema);
 


### PR DESCRIPTION
All pages of the app rely on the record type, geography, and boundary.
This adds a central place for keeping track of that initialization.
Previously, all components were individually requesting data on initial
page load, which led to many duplicate requests and race conditions.
This eliminates the duplicate requests and fixes a couple bugs.

Fixes #198, #228