### PR TITLE
Make windshaft and client-side code use tilekey

### DIFF
--- a/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
+++ b/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
@@ -39,7 +39,6 @@
                     leafletController.getMap().then(updateLayers);
                 });
 
-                // TODO: Remove when the record type picker is removed.
                 scope.$on('driver.state.recordstate:selected', function() {
                     leafletController.getMap().then(updateLayers);
                 });
@@ -74,25 +73,20 @@
             var recordsLayerOptions = angular.extend(defaultLayerOptions, {zIndex: 3});
             var occurredMin = new Date();
             occurredMin.setDate(occurredMin.getDate() - recencyCutoffDays);
-            // TODO: Boundary filtering somewhere in here.
-            // TODO: Since RecordType selection is going away, this may have to change
             RecordState.getSelected().then(function(selected) {
                 return TileUrlService.recTilesUrl(selected.uuid);
             // Construct Windshaft URL
             }).then(function(baseUrl) {
-                // TODO: Change and uncomment boundary filtering whenever Windshaft filtering is fixed.
-                return BoundaryState.getSelected().then(function(/*boundary*/) {
-                    return QueryBuilder.unfilteredDjangoQuery(0,
-                        {query: true,
-                         /* jshint camelcase: false */
-                         occurred_min: occurredMin.toISOString(),
-                         //polygon_id: boundary.uuid
-                         /* jshint camelcase: true */
-                        }
-                    ).then(function(result) {
-                            var queryParam = baseUrl.match(/\?/) ? '&sql=' : '?sql=';
-                            var sql = encodeURIComponent(result.query);
-                            return baseUrl + queryParam + sql;
+                return BoundaryState.getSelected().then(function(boundary) {
+                    return QueryBuilder.unfilteredDjangoQuery(0, {
+                        tilekey: true,
+                        /* jshint camelcase: false */
+                        occurred_min: occurredMin.toISOString(),
+                        polygon_id: boundary.uuid
+                        /* jshint camelcase: true */
+                    }).then(function(result) {
+                        var tilekeyParam = (baseUrl.match(/\?/) ? '&' : '?') + 'tilekey=';
+                        return baseUrl + tilekeyParam + result.tilekey;
                     });
                 });
             // Swap layers

--- a/web/app/scripts/map-layers/tile-url-service.js
+++ b/web/app/scripts/map-layers/tile-url-service.js
@@ -9,7 +9,8 @@
         var allRecordsUtfGridUrl = (WebConfig.windshaft.hostname +
             '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.grid.json');
         var positronUrl = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
-        var allBoundariesUrl = '/tiles/table/ashlar_boundary/id/ALL/{z}/{x}/{y}.png';
+        var allBoundariesUrl = (WebConfig.windshaft.hostname +
+            '/tiles/table/ashlar_boundary/id/ALL/{z}/{x}/{y}.png');
         var heatmapUrl = allRecordsUrl + '?heatmap=true';
 
         var module = {

--- a/web/test/spec/views/map/layers-controller.spec.js
+++ b/web/test/spec/views/map/layers-controller.spec.js
@@ -16,6 +16,7 @@ describe('driver.views.map: Layers Controller', function () {
     beforeEach(module('driver.resources'));
     beforeEach(module('ase.templates'));
     beforeEach(module('driver.views.map'));
+    beforeEach(module('driver.state'));
 
     var $compile;
     var $controller;
@@ -29,10 +30,11 @@ describe('driver.views.map: Layers Controller', function () {
     var DriverResourcesMock;
     var RecordState;
     var MapState;
+    var InitialState;
 
     beforeEach(inject(function (_$compile_, _$controller_, _$httpBackend_, _$rootScope_,
                                 _ResourcesMock_, _DriverResourcesMock_,
-                                _RecordState_, _MapState_) {
+                                _RecordState_, _MapState_, _InitialState_) {
         $compile = _$compile_;
         $controller = _$controller_;
         $httpBackend = _$httpBackend_;
@@ -42,6 +44,11 @@ describe('driver.views.map: Layers Controller', function () {
         ResourcesMock = _ResourcesMock_;
         RecordState = _RecordState_;
         MapState = _MapState_;
+        InitialState = _InitialState_;
+
+        InitialState.setRecordTypeInitialized();
+        InitialState.setBoundaryInitialized();
+        InitialState.setGeographyInitialized();
 
         // Set these for testing persistence
         MapState.setLocation({lat: 123, lng: 234});
@@ -53,9 +60,12 @@ describe('driver.views.map: Layers Controller', function () {
         $httpBackend.whenGET(boundaryUrl).respond(200, ResourcesMock.BoundaryResponse);
         var boundaryPolygonsUrl = /api\/boundarypolygons/;
         $httpBackend.whenGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
-        var recordsUrl = new RegExp('api/records/\\?limit=50&query=true&record_type=' + 
-                                    ResourcesMock.RecordTypeResponse.results[0].uuid);
-        $httpBackend.whenGET(recordsUrl).respond(200, '{"query": "SELECT * FROM ashlar_records"}');
+        var recordsUrl = new RegExp('api/records/\\?limit=50&polygon_id=' +
+                                    ResourcesMock.BoundaryNoGeomResponse.results[0].uuid +
+                                    '&record_type=' +
+                                    ResourcesMock.RecordTypeResponse.results[0].uuid +
+                                    '&tilekey=true');
+        $httpBackend.whenGET(recordsUrl).respond(200, '{"tilekey": "xxx"}');
 
         Element = $compile('<div leaflet-map driver-map-layers></div>')($scope);
         Controller = Element.controller('driverMapLayers');

--- a/web/test/spec/views/map/layers-directive.spec.js
+++ b/web/test/spec/views/map/layers-directive.spec.js
@@ -16,21 +16,29 @@ describe('driver.views.map: Layers Directive', function () {
     beforeEach(module('driver.resources'));
     beforeEach(module('ase.templates'));
     beforeEach(module('driver.views.map'));
+    beforeEach(module('driver.state'));
 
     var $compile;
     var $httpBackend;
     var $rootScope;
     var $scope;
     var ResourcesMock;
+    var InitialState;
 
     var Element;
 
-    beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_, _ResourcesMock_) {
+    beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_,
+                                _ResourcesMock_, _InitialState_) {
         $compile = _$compile_;
         $httpBackend = _$httpBackend_;
         $scope = _$rootScope_.$new();
         $rootScope = _$rootScope_;
         ResourcesMock = _ResourcesMock_;
+        InitialState = _InitialState_;
+
+        InitialState.setRecordTypeInitialized();
+        InitialState.setBoundaryInitialized();
+        InitialState.setGeographyInitialized();
 
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
         $httpBackend.whenGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
@@ -38,9 +46,12 @@ describe('driver.views.map: Layers Directive', function () {
         $httpBackend.whenGET(boundaryUrl).respond(200, ResourcesMock.BoundaryResponse);
         var boundaryPolygonsUrl = /api\/boundarypolygons/;
         $httpBackend.whenGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
-        var recordsUrl = new RegExp('api/records/\\?limit=50&query=true&record_type=' + 
-                                    ResourcesMock.RecordTypeResponse.results[0].uuid);
-        $httpBackend.whenGET(recordsUrl).respond(200, '{"query": "SELECT * FROM ashlar_records"}');
+        var recordsUrl = new RegExp('api/records/\\?limit=50&polygon_id=' +
+                                    ResourcesMock.BoundaryNoGeomResponse.results[0].uuid +
+                                    '&record_type=' +
+                                    ResourcesMock.RecordTypeResponse.results[0].uuid +
+                                    '&tilekey=true');
+        $httpBackend.whenGET(recordsUrl).respond(200, '{"tilekey": "xxx"}');
 
         Element = $compile('<div leaflet-map driver-map-layers></div>')($rootScope);
         $rootScope.$apply();


### PR DESCRIPTION
The client-side code sends the `tilekey` parameter, and Windshaft
uses it to obtain the stored SQL from redis. Specifying sql directly
from the client is no longer possible. The `polygon_id` parameter
is also now being sent along with the request, so filtering map point
based on the selected region now works.

Also fixes a problem with boundaries not showing up on dev instances.

Fixes #213