### PR TITLE
Add label for vehicle drop-down

### DIFF
--- a/scripts/accident_schema_v3.json
+++ b/scripts/accident_schema_v3.json
@@ -398,7 +398,7 @@
                         {
                             "source":"target",
                             "value":"{{item._localId}}",
-                            "title":""
+                            "title":"{{item.Vehicle type}} {{item.Make}} {{item.Model}}"
                         }
                     ],
                     "type":"string",


### PR DESCRIPTION
Changes drop-down text for vehicle in person to be formatted as `type make model`. Currently it just shows as the UUID.