### PR TITLE
Use a list of 24 hours rather than 25

### DIFF
--- a/web/app/scripts/toddow/toddow-directive.js
+++ b/web/app/scripts/toddow/toddow-directive.js
@@ -25,6 +25,7 @@
                     width = 660;
                 var rect, color, svg;  // GLOBAL
                 var tooltip = d3.tip();
+                tooltip.offset(function() { return [-16, -18]; });
                 init();
 
                 /**
@@ -70,10 +71,15 @@
                             })
                         .selectAll('.hour')
                         .data(function(d, i) {
-                            var weekStart = d3.time.week(new Date());
+                            /**
+                             * We use 01/01/2001 for construction of our week to avoid daylight
+                             *  savings time weirdness
+                            **/
+                            var weekStart = d3.time.week(new Date('01/01/2001'));
                             return d3.time.hours(
                               moment(weekStart).add(i, 'days').toDate(),
-                              moment(weekStart).add(i + 1, 'days').toDate());
+                              moment(weekStart).add(i + 1, 'days').toDate()
+                            );
                         })
                         .enter().append('g').append('rect')
                             .attr('class', 'hour')
@@ -98,9 +104,8 @@
                                     return theHours[i];
                             })
                             .attr('class', 'label hours')
-                            // TODO: Actually center these in each cell
                             .attr('x', function(d, i) {
-                                    return i * cellSize + 37;
+                                return i * cellSize + 37;
                             })
                             .attr('y', 10);
 

--- a/web/app/scripts/toddow/toddow-directive.js
+++ b/web/app/scripts/toddow/toddow-directive.js
@@ -60,7 +60,7 @@
                     var theHours = ['0', '1', '2', '3', '4', '5',
                                     '6', '7', '8', '9', '10', '11',
                                     '12', '13', '14', '15', '16', '17',
-                                    '18', '19', '20', '21', '22', '23', '24'];
+                                    '18', '19', '20', '21', '22', '23'];
                     rect = svg.selectAll('.day')
                         .data(theDays)
                             .enter().append('g')
@@ -71,7 +71,10 @@
                         .selectAll('.hour')
                         .data(function(d, i) {
                             var weekStart = d3.time.week(new Date());
-                            return d3.time.hours(moment(weekStart).add(i, 'days').toDate(), moment(weekStart).add(i + 1, 'days').toDate()); })
+                            return d3.time.hours(
+                              moment(weekStart).add(i, 'days').toDate(),
+                              moment(weekStart).add(i + 1, 'days').toDate());
+                        })
                         .enter().append('g').append('rect')
                             .attr('class', 'hour')
                             .attr('fill', 'white')
@@ -85,7 +88,7 @@
                     svg.selectAll('.day')
                         .append('text')
                           .text(function(d, i) { return theDays[i]; })
-                          .attr('class', 'label month')
+                          .attr('class', 'label')
                           .attr('x', 0)
                           .attr('y', function(d, i) { return i * cellSize + 40; });
 


### PR DESCRIPTION
The extra hour we had recently been seeing was the result of daylight savings time - there were 25 hours last sunday. I've changed the logic to just use 01/01/2001's week (no daylight savings time weirdness) as we only need a canonical week for the chart to work.

PR BONUS ROUND: I also added an offset to the tooltip that should center the tooltip