### PR TITLE
Filter map graphs with user-drawn polygons

### DIFF
--- a/web/app/scripts/resources/query-builder-service.js
+++ b/web/app/scripts/resources/query-builder-service.js
@@ -118,7 +118,7 @@
                 if (!isNaN(min.getTime())) {
                     paramObj.occurred_min = min.toISOString();
                 }
-                var max = new Date(maxDateString + ' 23:59:59.999');
+                var max = new Date(maxDateString + ' 23:59:59');
                 if (!isNaN(max.getTime())) {
                     paramObj.occurred_max = max.toISOString();
                 }

--- a/web/app/scripts/views/map/map-controller.js
+++ b/web/app/scripts/views/map/map-controller.js
@@ -3,7 +3,7 @@
 
     /* ngInject */
     function MapController($rootScope, $scope, $modal, BoundaryState, InitialState, FilterState,
-                           Records, RecordSchemaState, RecordState, RecordAggregates) {
+                           Records, RecordSchemaState, RecordState, MapState, RecordAggregates) {
         var ctl = this;
 
         /** This is one half of some fairly ugly code which serves to wire up a click
@@ -70,8 +70,15 @@
 
         function loadRecords() {
             /* jshint camelcase: false */
-            var params = ctl.boundaryId ? { polygon_id: ctl.boundaryId } : {};
+            var params = {};
+            if (ctl.boundaryId) {
+                params.polygon_id = ctl.boundaryId;
+            }
             /* jshint camelcase: true */
+            var userDrawnPoly = MapState.getFilterGeoJSON();
+            if (userDrawnPoly) {
+                params.polygon = userDrawnPoly;
+            }
 
             RecordAggregates.stepwise(true, params).then(function(stepwiseData) {
                 // minDate and maxDate are important for determining where the barchart begins/ends


### PR DESCRIPTION
Filters the toddow and bar graphs on the map using a user-drawn polygon, if there is one. Also fixes a problem with date formatting that was preventing the bar graph from showing up on FireFox.

![screenshot from 2015-11-20 11 21 45](https://cloud.githubusercontent.com/assets/447977/11305093/ed9ba4ba-8f78-11e5-86c3-25a344ccee93.png)
![screenshot from 2015-11-20 11 21 05](https://cloud.githubusercontent.com/assets/447977/11305092/ed9b15ea-8f78-11e5-986e-6ab63c3674d7.png)
