### PR TITLE
Disable scroll zoom everywhere (except the big Map)

### DIFF
--- a/web/app/scripts/app.js
+++ b/web/app/scripts/app.js
@@ -19,7 +19,9 @@
         LeafletDefaultsProvider.setDefaults({
             center: [12.375, 121.5], // geographic center of Philippines
             zoom: 5,
-            crs: L.CRS.EPSG3857
+            crs: L.CRS.EPSG3857,
+            touchZoom: false,
+            scrollWheelZoom: false
         });
     }
 

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -27,6 +27,13 @@
 
         // Ensure initial state is ready before initializing layers
         ctl.initLayers = function(map) {
+            // TODO (maybe): This approach to setting map options is only tenable so long as most
+            // of our maps use the same options, with very limited exceptions. If we ever
+            // need to have lots of customized options for each map, then we'll need to find a way to
+            // insert arbitrary config options into each map directive instance. One possibility
+            // would be to define them as attributes, similar to how angular-leaflet-directive does
+            // it, but there may be better approaches.
+            map.scrollWheelZoom.enable();
             InitialState.ready().then(function() {
                 ctl.init(map);
             });


### PR DESCRIPTION
There's a comment in the source, but if we need to do more significant customization, we may want to come up with a way to pass in configuration options directly to the `leaflet-map` directive; currently we have to set them manually in one of the dependent directives' `bind` methods (or something that it calls). I talked to @CloudNiner about this and we didn't come up with any easy and elegant solutions, but we may want to revisit the issue later.