### PR TITLE
Only return Accident Details to read-only users

### DIFF
--- a/app/data/serializers.py
+++ b/app/data/serializers.py
@@ -1,0 +1,32 @@
+from ashlar import serializers
+from ashlar import serializer_fields
+
+from django.conf import settings
+
+
+class DetailsReadOnlyRecordSerializer(serializers.RecordSerializer):
+    """Serialize records with only read-only fields included"""
+    data = serializer_fields.MethodTransformJsonField('filter_details_only')
+
+    def filter_details_only(self, key, value):
+        """Return only the details object and no other related info"""
+        if key in settings.READ_ONLY_FIELDS:
+            return key, value
+        else:
+            raise serializer_fields.DropJsonKeyException
+
+
+class DetailsReadOnlyRecordSchemaSerializer(serializers.RecordSchemaSerializer):
+    """Serialize Schema with only read-only fields included"""
+    schema = serializer_fields.MethodTransformJsonField('make_read_only_schema')
+
+    def make_read_only_schema(self, key, value):
+        if key != 'properties' and key != 'definitions':
+            return key, value
+
+        # If we're looking at properties/definitions, remove everything that isn't read-only
+        new_value = {}
+        for k in value.viewkeys():
+            if k in settings.READ_ONLY_FIELDS:
+                new_value[k] = value[k]
+        return key, new_value

--- a/app/data/tests/test_serializers.py
+++ b/app/data/tests/test_serializers.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+
+from django.conf import settings
+from ashlar import serializer_fields
+
+from data import serializers
+
+
+class DetailsReadOnlyRecordSerializerTestCase(TestCase):
+    def setUp(self):
+        self.serializer = serializers.DetailsReadOnlyRecordSerializer()
+
+    def test_filter_details_only(self):
+        """Test that non-read-only fields are dropped"""
+        with self.assertRaises(serializer_fields.DropJsonKeyException):
+            self.serializer.filter_details_only('Definitely Not Details', {})
+        for field_name in settings.READ_ONLY_FIELDS:
+            self.assertEqual((field_name, {}), self.serializer.filter_details_only(field_name, {}))
+
+
+class DetailsReadOnlyRecordSchemaSerializerTestCase(TestCase):
+    def setUp(self):
+        self.serializer = serializers.DetailsReadOnlyRecordSchemaSerializer()
+
+    def test_transform_details_only(self):
+        """Test that non-read-only keys are removed from 'properties' and 'definitions'"""
+        test_value = {'Accident Details': {}, 'Related Info 1': {}, 'Related Info 2': {}}
+        self.assertEqual(('definitions', {'Accident Details': {}}),
+                         self.serializer.make_read_only_schema('definitions', test_value))
+        self.assertEqual(('properties', {'Accident Details': {}}),
+                         self.serializer.make_read_only_schema('properties', test_value))
+        self.assertEqual(('no_transform', test_value),
+                         self.serializer.make_read_only_schema('no_transform', test_value))

--- a/app/data/tests/test_views.py
+++ b/app/data/tests/test_views.py
@@ -5,6 +5,7 @@ import uuid
 import mock
 import pytz
 
+from rest_framework.request import Request
 from rest_framework.test import APIClient, APITestCase, APIRequestFactory, force_authenticate
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
@@ -12,7 +13,8 @@ from django.conf import settings
 
 from ashlar.models import RecordSchema, RecordType, Record
 
-from data.views import DriverRecordViewSet
+from data.views import DriverRecordViewSet, DriverRecordSchemaViewSet
+from data.serializers import DetailsReadOnlyRecordSerializer, DetailsReadOnlyRecordSchemaSerializer
 
 
 class DriverRecordViewTestCase(APITestCase):
@@ -123,3 +125,26 @@ class DriverRecordViewTestCase(APITestCase):
             force_authenticate(request, user=self.admin)
             response = view(request)
             self.assertEqual(mocked_redis.call_count, 1)
+
+    def test_get_serializer_class(self):
+        """Test that get_serializer_class returns read-only serializer correctly"""
+        read_only = User.objects.create_user('public', 'public@public.com', 'public')
+        view = DriverRecordViewSet()
+        mock_req = mock.Mock(spec=Request)
+        mock_req.user = read_only
+        view.request = mock_req
+        serializer_class = view.get_serializer_class()
+        self.assertEqual(serializer_class, DetailsReadOnlyRecordSerializer)
+
+
+class DriverRecordSchemaViewTestCase(APITestCase):
+
+    def test_get_serializer_class(self):
+        """Test that get_serializer_class returns read-only serializer correctly"""
+        read_only = User.objects.create_user('public', 'public@public.com', 'public')
+        view = DriverRecordSchemaViewSet()
+        mock_req = mock.Mock(spec=Request)
+        mock_req.user = read_only
+        view.request = mock_req
+        serializer_class = view.get_serializer_class()
+        self.assertEqual(serializer_class, DetailsReadOnlyRecordSchemaSerializer)

--- a/app/data/transformers.py
+++ b/app/data/transformers.py
@@ -14,6 +14,7 @@ class WeekTransform(Transform):
     def output_field(self):
         return IntegerField()
 
+
 class ISOYearTransform(Transform):
     """A custom transform to turn a date field into the integer which represents its isoyear.
     Look here for more: http://www.postgresql.org/docs/8.3/static/functions-datetime.html"""

--- a/app/data/transformers.py
+++ b/app/data/transformers.py
@@ -1,4 +1,4 @@
-from django.db.models import IntegerField, DateTimeField, Transform
+from django.db.models import IntegerField, Transform
 
 
 class WeekTransform(Transform):
@@ -27,6 +27,3 @@ class ISOYearTransform(Transform):
     @property
     def output_field(self):
         return IntegerField()
-
-DateTimeField.register_lookup(ISOYearTransform)
-DateTimeField.register_lookup(WeekTransform)

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -6,6 +6,7 @@ from django.db import connection
 from django.db.models import (Case,
                               When,
                               IntegerField,
+                              DateTimeField,
                               Value,
                               Count)
 
@@ -18,7 +19,6 @@ from rest_framework.exceptions import ParseError
 from ashlar.views import (BoundaryPolygonViewSet,
                           RecordViewSet,
                           RecordTypeViewSet,
-                          SchemaViewSet,
                           RecordSchemaViewSet,
                           BoundaryViewSet)
 
@@ -29,6 +29,11 @@ from driver_auth.permissions import (IsAdminOrReadOnly,
                                      is_admin_or_writer)
 
 from serializers import DetailsReadOnlyRecordSerializer, DetailsReadOnlyRecordSchemaSerializer
+import transformers
+
+
+DateTimeField.register_lookup(transformers.ISOYearTransform)
+DateTimeField.register_lookup(transformers.WeekTransform)
 
 
 class DriverRecordViewSet(RecordViewSet):

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -22,16 +22,26 @@ from ashlar.views import (BoundaryPolygonViewSet,
                           RecordSchemaViewSet,
                           BoundaryViewSet)
 
-from data import transformers
+from ashlar.serializers import RecordSerializer, RecordSchemaSerializer
 
 from driver_auth.permissions import (IsAdminOrReadOnly,
-                                     ReadersReadWritersWrite)
+                                     ReadersReadWritersWrite,
+                                     is_admin_or_writer)
+
+from serializers import DetailsReadOnlyRecordSerializer, DetailsReadOnlyRecordSchemaSerializer
 
 
 class DriverRecordViewSet(RecordViewSet):
     """Override base RecordViewSet from ashlar to provide aggregation and tiler integration
     """
     permission_classes = (ReadersReadWritersWrite,)
+
+    # Filter out everything except details for read-only users
+    def get_serializer_class(self):
+        if is_admin_or_writer(self.request.user):
+            return RecordSerializer
+        return DetailsReadOnlyRecordSerializer
+
     def list(self, request, *args, **kwargs):
         # Don't generate a tile key unless the user specifically requests it, to avoid
         # filling up the Redis cache with queries that will never be viewed as tiles
@@ -147,13 +157,14 @@ class DriverRecordTypeViewSet(RecordTypeViewSet):
     permission_classes = (IsAdminOrReadOnly,)
 
 
-class DriverSchemaViewSet(SchemaViewSet):
-    """Base ViewSet for viewsets displaying subclasses of SchemaModel"""
-    permission_classes = (IsAdminOrReadOnly,)
-
-
 class DriverRecordSchemaViewSet(RecordSchemaViewSet):
     permission_classes = (IsAdminOrReadOnly,)
+
+    # Filter out everything except details for read-only users
+    def get_serializer_class(self):
+        if is_admin_or_writer(self.request.user):
+            return RecordSchemaSerializer
+        return DetailsReadOnlyRecordSchemaSerializer
 
 
 class DriverBoundaryViewSet(BoundaryViewSet):

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -351,3 +351,6 @@ if DEVELOP:
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
     )
+
+# These fields will be visible to read-only users
+READ_ONLY_FIELDS = ['Accident Details']

--- a/app/driver_auth/permissions.py
+++ b/app/driver_auth/permissions.py
@@ -8,11 +8,13 @@ ADMIN_GROUP = settings.DRIVER_GROUPS['ADMIN']
 READ_GROUP = settings.DRIVER_GROUPS['READ_ONLY']
 WRITE_GROUP = settings.DRIVER_GROUPS['READ_WRITE']
 
+
 def belongs_to_group(user, group):
     try:
         return user.groups.filter(name=group).exists()
     except (User.DoesNotExist, Group.DoesNotExist):
         return False
+
 
 def is_reader_or_writer(user):
     try:
@@ -20,17 +22,21 @@ def is_reader_or_writer(user):
     except (User.DoesNotExist, Group.DoesNotExist):
         return False
 
+
 def is_admin_or_writer(user):
     try:
         return user.groups.filter(name__in=(ADMIN_GROUP, WRITE_GROUP)).exists()
     except (User.DoesNotExist, Group.DoesNotExist):
         return False
 
+
 def is_admin(user):
     return belongs_to_group(user, ADMIN_GROUP)
 
+
 def is_writer(user):
     return belongs_to_group(user, WRITE_GROUP)
+
 
 def is_reader(user):
     return belongs_to_group(user, READ_GROUP)


### PR DESCRIPTION
Filters out fields besides Accident Details if a user is read-only. Relies on a forthcoming PR to Ashlar for the `MethodTransformJsonField`.
![publicdetails](https://cloud.githubusercontent.com/assets/447977/11819854/1e7eea2c-a330-11e5-9cd0-9a40ddbe9dd2.png)
![admindetails](https://cloud.githubusercontent.com/assets/447977/11819853/1e6181c6-a330-11e5-8b7e-b684c2ecb2bd.png)
