### PR TITLE
Feature/fix schema uris

### DIFF
--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -138,11 +138,7 @@
          * @return {string} Currently just returns encodeURIComponent(string)
          */
         function encodeJSONPointer(str) {
-            // TODO: This can probably be switched after upgrading json-editor:
-            // https://github.com/jdorn/json-editor/issues/402
-            // return encodeURIComponent(str);
-            // But the current version of json-editor doesn't support this properly.
-            return str;
+            return encodeURIComponent(str);
         }
 
         /**

--- a/scripts/accident_schema_v3.json
+++ b/scripts/accident_schema_v3.json
@@ -475,7 +475,7 @@
     "type":"object",
     "properties":{
         "Accident Details":{
-            "$ref":"#/definitions/Accident Details",
+            "$ref":"#/definitions/Accident%20Details",
             "propertyOrder": 0,
             "options": {
                 "collapsed": true


### PR DESCRIPTION
Encode schema ref URIs.

Produces schemas that now pass [this validator](http://json-schema-validator.herokuapp.com/syntax.jsp).