### PR TITLE
Add audit logging for changes to records

### DIFF
--- a/app/data/filters.py
+++ b/app/data/filters.py
@@ -1,0 +1,14 @@
+import django_filters
+
+from models import RecordAuditLogEntry
+
+
+class RecordAuditLogFilter(django_filters.FilterSet):
+    """Allow filtering audit log entries by user, record, min_date, max_date"""
+    min_date = django_filters.IsoDateTimeFilter(name="date", lookup_type='gte')
+    max_date = django_filters.IsoDateTimeFilter(name="date", lookup_type='lte')
+    action = django_filters.ChoiceFilter(choices=RecordAuditLogEntry.ActionTypes.choices)
+
+    class Meta:
+        model = RecordAuditLogEntry
+        fields = ['user', 'username', 'record', 'record_uuid', 'action', 'min_date', 'max_date']

--- a/app/data/migrations/0001_initial.py
+++ b/app/data/migrations/0001_initial.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ashlar', '0021_add_weather_fields'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RecordAuditLogEntry',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('username', models.CharField(max_length=30)),
+                ('record_uuid', models.CharField(max_length=36)),
+                ('date', models.DateTimeField(auto_now_add=True)),
+                ('action', models.CharField(max_length=6, choices=[(b'create', b'Create'), (b'update', b'Update'), (b'delete', b'Delete')])),
+                ('record', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to='ashlar.Record', null=True)),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+        ),
+    ]

--- a/app/data/migrations/0002_auto_20160126_0404.py
+++ b/app/data/migrations/0002_auto_20160126_0404.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='recordauditlogentry',
+            name='id',
+        ),
+        migrations.AddField(
+            model_name='recordauditlogentry',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='recordauditlogentry',
+            name='date',
+            field=models.DateTimeField(auto_now_add=True, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='recordauditlogentry',
+            name='record_uuid',
+            field=models.CharField(max_length=36, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='recordauditlogentry',
+            name='username',
+            field=models.CharField(max_length=30, db_index=True),
+        ),
+    ]

--- a/app/data/models.py
+++ b/app/data/models.py
@@ -1,0 +1,40 @@
+import uuid
+
+from django.db import models
+from django.contrib.auth.models import User
+from ashlar.models import Record
+
+
+class RecordAuditLogEntry(models.Model):
+    """Records an occurrence of a Record being altered, who did it, and when.
+
+    Note that 'user' and 'record' are maintained as foreign keys for convenience querying,
+    but these fields can be set to NULL if the referenced object is deleted. If a user or
+    record has been deleted, then 'username' or 'record_uuid' should be used, respectively.
+    """
+    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # Store both a foreign key and the username so that if the user is deleted this can still
+    # be useful.
+    user = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
+    username = models.CharField(max_length=30, db_index=True)
+    # Same for the record; if the record this refers to is deleted we still want to be able to
+    # determine which audit log entries pertained to that record.
+    record = models.ForeignKey(Record, null=True, on_delete=models.SET_NULL)
+    record_uuid = models.CharField(max_length=36, db_index=True)
+
+    date = models.DateTimeField(auto_now_add=True, db_index=True)
+
+    class ActionTypes(object):
+        CREATE = 'create'
+        UPDATE = 'update'
+        DELETE = 'delete'
+
+        choices = (
+            (CREATE, 'Create'),
+            (UPDATE, 'Update'),
+            (DELETE, 'Delete')
+        )
+        @classmethod
+        def as_list(cls):
+            return [cls.CREATE, cls.UPDATE, cls.DELETE]
+    action = models.CharField(max_length=6, choices=ActionTypes.choices)

--- a/app/data/serializers.py
+++ b/app/data/serializers.py
@@ -1,5 +1,9 @@
+from rest_framework.serializers import ModelSerializer
+
 from ashlar import serializers
 from ashlar import serializer_fields
+
+from models import RecordAuditLogEntry
 
 from django.conf import settings
 
@@ -30,3 +34,9 @@ class DetailsReadOnlyRecordSchemaSerializer(serializers.RecordSchemaSerializer):
             if k in settings.READ_ONLY_FIELDS:
                 new_value[k] = value[k]
         return key, new_value
+
+
+class RecordAuditLogEntrySerializer(ModelSerializer):
+    """Serialize Audit Log Entries"""
+    class Meta:
+        model = RecordAuditLogEntry

--- a/app/data/tests/test_serializers.py
+++ b/app/data/tests/test_serializers.py
@@ -1,9 +1,11 @@
 from django.test import TestCase
 
 from django.conf import settings
+from rest_framework.serializers import ModelSerializer
 from ashlar import serializer_fields
 
 from data import serializers
+from data.models import RecordAuditLogEntry
 
 
 class DetailsReadOnlyRecordSerializerTestCase(TestCase):
@@ -31,3 +33,13 @@ class DetailsReadOnlyRecordSchemaSerializerTestCase(TestCase):
                          self.serializer.make_read_only_schema('properties', test_value))
         self.assertEqual(('no_transform', test_value),
                          self.serializer.make_read_only_schema('no_transform', test_value))
+
+
+class RecordAuditLogEntrySerializerTestCase(TestCase):
+    def setUp(self):
+        self.serializer = serializers.RecordAuditLogEntrySerializer()
+
+    def test_serializer_type(self):
+        """Ensure that the serializer has the correct inheritances"""
+        self.assertIsInstance(self.serializer, ModelSerializer)
+        self.assertIs(self.serializer.Meta.model, RecordAuditLogEntry)

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -1,8 +1,9 @@
 import uuid
 
 from dateutil.parser import parse as parse_date
+from datetime import timedelta
 
-from django.db import connection
+from django.db import connection, transaction
 from django.db.models import (Case,
                               When,
                               IntegerField,
@@ -12,9 +13,14 @@ from django.db.models import (Case,
 
 from django_redis import get_redis_connection
 
+from rest_framework import viewsets
 from rest_framework.decorators import list_route
-from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework.settings import api_settings
+
+from rest_framework_csv import renderers as csv_renderer
 
 from ashlar.views import (BoundaryPolygonViewSet,
                           RecordViewSet,
@@ -26,9 +32,13 @@ from ashlar.serializers import RecordSerializer, RecordSchemaSerializer
 
 from driver_auth.permissions import (IsAdminOrReadOnly,
                                      ReadersReadWritersWrite,
+                                     IsAdminAndReadOnly,
                                      is_admin_or_writer)
 
-from serializers import DetailsReadOnlyRecordSerializer, DetailsReadOnlyRecordSchemaSerializer
+import filters
+from models import RecordAuditLogEntry
+from serializers import (DetailsReadOnlyRecordSerializer, DetailsReadOnlyRecordSchemaSerializer,
+                         RecordAuditLogEntrySerializer)
 import transformers
 
 
@@ -47,6 +57,35 @@ class DriverRecordViewSet(RecordViewSet):
             return RecordSerializer
         return DetailsReadOnlyRecordSerializer
 
+    # Change auditing
+    def add_to_audit_log(self, request, instance, action):
+        """Creates a new audit log entry; instance must have an ID"""
+        if not instance.pk:
+            raise ValueError('Cannot create audit log entries for unsaved model objects')
+        if action not in RecordAuditLogEntry.ActionTypes.as_list():
+            raise ValueError("{} not one of 'create', 'update', or 'delete'".format(action))
+        RecordAuditLogEntry.objects.create(user=request.user,
+                                           username=request.user.username,
+                                           record=instance,
+                                           record_uuid=str(instance.pk),
+                                           action=action)
+
+    @transaction.atomic
+    def perform_create(self, serializer):
+        instance = serializer.save()
+        self.add_to_audit_log(self.request, instance, RecordAuditLogEntry.ActionTypes.CREATE)
+
+    @transaction.atomic
+    def perform_update(self, serializer):
+        instance = serializer.save()
+        self.add_to_audit_log(self.request, instance, RecordAuditLogEntry.ActionTypes.UPDATE)
+
+    @transaction.atomic
+    def perform_delete(self, instance):
+        self.add_to_audit_log(self.request, instance, RecordAuditLogEntry.ActionTypes.DELETE)
+        instance.delete()
+
+    # Views
     def list(self, request, *args, **kwargs):
         # Don't generate a tile key unless the user specifically requests it, to avoid
         # filling up the Redis cache with queries that will never be viewed as tiles
@@ -151,6 +190,37 @@ class DriverRecordViewSet(RecordViewSet):
         # to store the data exactly as it is.
         redis_conn = get_redis_connection('default')
         redis_conn.set(token, sql.encode('utf-8'))
+
+
+class DriverRecordAuditLogViewSet(viewsets.ModelViewSet):
+    """Viewset for accessing audit logs; will output CSVs if Accept text/csv is specified"""
+    queryset = RecordAuditLogEntry.objects.all()
+    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [csv_renderer.CSVRenderer]
+    serializer_class = RecordAuditLogEntrySerializer
+    permission_classes = (IsAdminAndReadOnly,)
+    filter_class = filters.RecordAuditLogFilter
+    pagination_class = None
+
+    def list(self, request, *args, **kwargs):
+        """Validate filter params"""
+        # Will throw an error if these are missing or not valid ISO-8601
+        try:
+            min_date = parse_date(request.query_params['min_date'])
+            max_date = parse_date(request.query_params['max_date'])
+        except KeyError:
+            raise ParseError("min_date and max_date must both be provided")
+        except ValueError:
+            raise ParseError("occurred_min and occurred_max must both be valid dates")
+        # Make sure that min_date and max_date are less than 32 days apart
+        if max_date - min_date >= timedelta(days=32):
+            raise ParseError('max_date and min_date must be less than one month apart')
+        return super(DriverRecordAuditLogViewSet, self).list(request, *args, **kwargs)
+
+    # Override default CSV field ordering for ease of use
+    def get_renderer_context(self):
+        context = super(DriverRecordAuditLogViewSet, self).get_renderer_context()
+        context['header'] = ('date', 'username', 'record_uuid', 'action', 'uuid',)
+        return context
 
 
 # override ashlar views to set permissions

--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -10,6 +10,7 @@ from driver_auth import views as auth_views
 from user_filters import views as filt_views
 
 router = routers.DefaultRouter()
+router.register('audit-log', data_views.DriverRecordAuditLogViewSet)
 router.register('blackspots', black_spot_views.BlackSpotViewSet, base_name='blackspots')
 router.register('blackspotsets', black_spot_views.BlackSpotSetViewSet, base_name='blackspotsets')
 router.register('boundaries', data_views.DriverBoundaryViewSet)
@@ -18,6 +19,7 @@ router.register('records', data_views.DriverRecordViewSet)
 router.register('recordschemas', data_views.DriverRecordSchemaViewSet)
 router.register('recordtypes', data_views.DriverRecordTypeViewSet)
 router.register('userfilters', filt_views.SavedFilterViewSet, base_name='userfilters')
+
 
 # user management
 router.register(r'users', auth_views.UserViewSet)

--- a/app/driver_auth/permissions.py
+++ b/app/driver_auth/permissions.py
@@ -90,6 +90,17 @@ class IsAdminOrReadOnly(permissions.BasePermission):
         return False
 
 
+class IsAdminAndReadOnly(permissions.BasePermission):
+    """
+    Allow read-only access to administrators; entries should be immutable
+    """
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated():
+            if request.method in permissions.SAFE_METHODS and is_admin(request.user):
+                return True
+        return False
+
+
 class ReadersReadWritersWrite(permissions.BasePermission):
     """
     Allow read-only access to readers group, and full access to writers or admins.

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -11,4 +11,5 @@ django-redis==4.2.0
 python-dateutil==2.4.2
 pytz==2015.7
 mock==1.3.0
+djangorestframework-csv==1.4.1
 git+https://github.com/azavea/ashlar.git@develop#egg=ashlar


### PR DESCRIPTION
Audit logs are generated on each create, update, or delete operation for a Record.
The audit-log endpoint is accessible only by admin users, and even for
them it is read-only. The endpoint is unpaginated by default, and
supports filtering by date ranges. It supports CSV output, since the
desired functionality is for users to be able to download monthly CSVs
of audit log activity.