### PR TITLE
Add UI for downloading audit log CSVs

### DIFF
--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -93,6 +93,8 @@
     <script src="ase-scripts/schemas/schemas-service.js"></script>
 
     <!-- notifications has it's own symlink, since it needs to load HTML at a certain location -->
+    <script src="scripts/audit/module.js"></script>
+    <script src="scripts/audit/audit-download-modal-controller.js"></script>
     <script src="scripts/notifications/module.js"></script>
     <script src="scripts/notifications/notifications-service.js"></script>
     <script src="scripts/notifications/notifications-directive.js"></script>

--- a/web/app/scripts/audit/audit-download-modal-controller.js
+++ b/web/app/scripts/audit/audit-download-modal-controller.js
@@ -1,0 +1,45 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function AuditDownloadModalController($modalInstance, WebConfig) {
+        var defaultDate = new Date();
+        var timeZone = WebConfig.localization.timeZone;
+        var ctl = this;
+
+        ctl.months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
+                      'September', 'October', 'November', 'December'];
+        ctl.selectedYear = defaultDate.getFullYear();
+        ctl.selectedMonth = defaultDate.getMonth().toString();
+        onDateChange(ctl.selectedYear, ctl.selectedMonth);
+        ctl.onDateChange = onDateChange;
+        ctl.close = function () {
+            $modalInstance.close();
+        };
+
+        function makeDateQueryStr(year, month) {
+            // Months are 1-indexed in the API; zero-indexed in the menu.
+            var apiMonth = month + 1;
+            // From http://stackoverflow.com/questions/315760/what-is-the-best-way-to-determine-the-number-of-days-in-a-month-with-javascript
+            // This is a bit subtle; it gets the last day of the previous month. This *seems*
+            // wrong, since we want the number of days in apiMonth, but since Javascript's months
+            // are zero-indexed, it works out for one-indexed dates. So if the current month is
+            // February, apiMonth will be 2, which to the Javascript API is *March*. It will then
+            // return the last day of the month previous to March, which is the last day of
+            // February.
+            var daysInMonth = (new Date(year, apiMonth, 0)).getDate();
+            var startDate = moment.tz([year, month], timeZone);
+            var endDate = moment.tz([year, month, daysInMonth, 23, 59, 59, 999], timeZone);
+            return 'min_date=' + startDate.toISOString() + '&max_date=' + endDate.toISOString();
+        }
+
+        function onDateChange(year, month) {
+            var monthNum = parseInt(month, 10);
+            ctl.dateQueryStr = makeDateQueryStr(year, monthNum);
+        }
+    }
+
+    angular.module('driver.audit')
+    .controller('AuditDownloadModalController', AuditDownloadModalController);
+
+})();

--- a/web/app/scripts/audit/audit-download-modal-partial.html
+++ b/web/app/scripts/audit/audit-download-modal-partial.html
@@ -1,0 +1,27 @@
+<div class="audit-download modal-content">
+    <div class="modal-content">
+        <div class="close" ng-click="modal.close()">
+            &times;
+        </div>
+        <div class="report-header">
+            <h3 class="modal-title">Monthly Audit Logs</h3>
+        </div>
+        <div class="modal-body">
+          <input type="number" ng-model="modal.selectedYear" min="1900"
+                 ng-change="modal.onDateChange(modal.selectedYear, modal.selectedMonth)">
+          <select class="month-select"
+                  ng-model="modal.selectedMonth"
+                  ng-options="index as month for (index, month) in modal.months"
+                  ng-change="modal.onDateChange(modal.selectedYear, modal.selectedMonth)">
+          </select>
+        </div>
+        <div class="modal-footer">
+            <a class="btn btn-primary" target="_self"
+               href="/api/audit-log/?{{modal.dateQueryStr}}&format=csv"
+               download="audit-log-{{model.selectedMonth + 1}}-{{modal.selectedYear}}.csv">Download CSV</a>
+            <button class="btn btn-primary" ng-click="modal.close()">
+                Close
+            </button>
+        </div>
+    </div>
+</div>

--- a/web/app/scripts/audit/module.js
+++ b/web/app/scripts/audit/module.js
@@ -1,0 +1,6 @@
+(function () {
+    'use strict';
+    angular.module('driver.audit', [
+        'driver.config',
+    ]);
+})();

--- a/web/app/scripts/navbar/module.js
+++ b/web/app/scripts/navbar/module.js
@@ -4,6 +4,7 @@
     angular.module('driver.navbar', [
         'ase.auth',
         'driver.state',
+        'driver.audit',
         'ui.bootstrap',
         'ui.router'
     ]);

--- a/web/app/scripts/navbar/navbar-controller.js
+++ b/web/app/scripts/navbar/navbar-controller.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /* ngInject */
-    function NavbarController($rootScope, $scope, $state,
+    function NavbarController($rootScope, $scope, $state, $modal,
                               AuthService, BoundaryState, GeographyState, InitialState,
                               MapState, RecordState, UserService, WebConfig) {
         var ctl = this;
@@ -19,6 +19,7 @@
         ctl.onRecordTypeSelected = onRecordTypeSelected;
         ctl.onStateSelected = onStateSelected;
         ctl.navigateToStateName = navigateToStateName;
+        ctl.showAuditDownloadModal = showAuditDownloadModal;
         ctl.getBoundaryLabel = getBoundaryLabel;
         ctl.recordTypesVisible = WebConfig.recordType.visible;
         ctl.userEmail = userDropdownDefault;
@@ -71,7 +72,6 @@
         });
         $scope.$on('driver.state.geographystate:selected', function(event, selected) {
             ctl.geographySelected = selected;
-
             // Need to get the new list of boundaries for the selected geography.
             // Only do this after initializing: otherwise an unneeded request is sent.
             if (initialized) {
@@ -141,6 +141,15 @@
             /* jshint camelcase: false */
             return boundary.data[ctl.geographySelected.display_field];
             /* jshint camelcase: true */
+        }
+
+        // Show a details modal for the given record
+        function showAuditDownloadModal() {
+            $modal.open({
+                templateUrl: 'scripts/audit/audit-download-modal-partial.html',
+                controller: 'AuditDownloadModalController as modal',
+                size: 'sm',
+            });
         }
     }
 

--- a/web/app/scripts/navbar/navbar-partial.html
+++ b/web/app/scripts/navbar/navbar-partial.html
@@ -68,6 +68,7 @@
                     <a class="dropdown-toggle" data-toggle="dropdown" role="button">{{ ctl.userEmail }} <span class="glyphicon glyphicon-option-vertical"></span></a>
                     <ul class="dropdown-menu">
                         <li><a ng-click="ctl.navigateToStateName('account')">My Account</a></li>
+                        <li><a ng-click="ctl.showAuditDownloadModal()">Download audit logs</a></li>
                         <li><a> Manage Duplicate Records</a></li>
                         <li><a ng-click="ctl.onLogoutButtonClicked()">Log Out</a></li>
                     </ul>

--- a/web/test/karma.conf.js
+++ b/web/test/karma.conf.js
@@ -76,6 +76,8 @@ module.exports = function(config) {
       'app/ase-scripts/auth/module.js',
       'app/ase-scripts/auth/**js',
 
+      'app/scripts/audit/module.js',
+      'app/scripts/audit/**.js',
       'app/scripts/notifications/module.js',
       'app/scripts/notifications/**.js',
       'app/scripts/navbar/module.js',

--- a/web/test/spec/audit/audit-download-modal-controller-spec.js
+++ b/web/test/spec/audit/audit-download-modal-controller-spec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+describe('driver.audit: AuditDownloadModalController', function () {
+    beforeEach(module('driver.audit'));
+
+    var $controller;
+    var $rootScope;
+    var $scope;
+    var Controller;
+    var ModalInstance;
+
+    beforeEach(inject(function (_$controller_, _$rootScope_) {
+        $controller = _$controller_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        ModalInstance = {
+            close: jasmine.createSpy('ModalInstance.close')
+        };
+
+        Controller = $controller('AuditDownloadModalController', {
+            $scope: $scope,
+            $modalInstance: ModalInstance
+        });
+    }));
+
+    it('should initialize the modal controller with the proper defaults', function () {
+        $scope.$apply();
+
+        expect(Controller.selectedYear).toEqual((new Date()).getFullYear());
+        expect(Controller.selectedMonth).toEqual((new Date()).getMonth().toString());
+    });
+
+    it('should have a close function', function () {
+        $scope.$apply();
+
+        Controller.close();
+        expect(ModalInstance.close).toHaveBeenCalled();
+    });
+
+    it('should update its query string when dates change', function () {
+        $scope.$apply();
+
+        // Zero-indexed, so this is September.
+        Controller.onDateChange(2015, '8');
+        expect(Controller.dateQueryStr)
+          .toEqual('min_date=2015-08-31T16:00:00.000Z&max_date=2015-09-30T15:59:59.999Z');
+        Controller.onDateChange(2012, '1');
+        expect(Controller.dateQueryStr)
+          .toEqual('min_date=2012-01-31T16:00:00.000Z&max_date=2012-02-29T15:59:59.999Z');
+    });
+});


### PR DESCRIPTION
Adds a popup where users can download CSVs dumps of audit logs, by month. I ran out of time to add the link output that we discussed in RRP; I'll make an issue for that so it doesn't get forgotten.
![prsauditlogs](https://cloud.githubusercontent.com/assets/447977/12657143/debfaf08-c5cf-11e5-80df-dcbaae35702e.png)

--Edit-- The popup is accessible from the user dropdown.
