### PR TITLE
Fix details tabs and order them.

### DIFF
--- a/web/app/scripts/details/details-tabs-controller.js
+++ b/web/app/scripts/details/details-tabs-controller.js
@@ -7,12 +7,27 @@
         ctl.sortedDefinitions = sortedDefinitions;
         ctl.sortedProperties = sortedProperties;
 
-        // Sorts definitions alphabetically, and puts the details definition first
         function sortedDefinitions() {
-            return _(ctl.recordSchema.schema.definitions)
-                .toArray()
-                .sortByAll(['details', 'plural_title'])
+            // get the section names, sorted by propertyOrder
+            var ordering = _(ctl.recordSchema.schema.properties)
+                .sortBy(function(obj, key) {
+                    obj.propertyName = key;
+                    return (obj.propertyOrder !== undefined) ? obj.propertyOrder : 99;
+                })
+                .map(function(obj) {
+                    return obj.propertyName;
+                })
                 .value();
+
+
+            // get section definitions as sorted array, with added property for the section name
+            var sorted = _.map(ordering, function(section) {
+                var definition = ctl.recordSchema.schema.definitions[section];
+                definition.propertyName = section;
+                return definition;
+            });
+
+            return sorted;
         }
 
         // Returning an array of definition properties sorted by propertyOrder

--- a/web/app/scripts/details/details-tabs-partial.html
+++ b/web/app/scripts/details/details-tabs-partial.html
@@ -1,7 +1,7 @@
 <tabset>
     <tab ng-repeat="definition in ctl.sortedDefinitions()"
          heading="{{ definition.multiple ? definition.plural_title : definition.title }}"
-         ng-init="data = ctl.record.data[definition.title]; properties = ctl.sortedProperties(definition.properties)">
+         ng-init="data = ctl.record.data[definition.propertyName]; properties = ctl.sortedProperties(definition.properties)">
 
         <driver-details-single
             data="data"


### PR DESCRIPTION
Record view tabs other than details section were broken by #377, causing them to show no data. (Sections were looked up by `title` instead of field name).

Also sort tab order by defined propertyOrder instead of sorting alpabetically.