### PR TITLE
Duplicates list view

### DIFF
--- a/app/data/filters.py
+++ b/app/data/filters.py
@@ -1,6 +1,6 @@
 import django_filters
 
-from models import RecordAuditLogEntry
+from models import RecordAuditLogEntry, RecordDuplicate
 
 
 class RecordAuditLogFilter(django_filters.FilterSet):
@@ -12,3 +12,18 @@ class RecordAuditLogFilter(django_filters.FilterSet):
     class Meta:
         model = RecordAuditLogEntry
         fields = ['user', 'username', 'record', 'record_uuid', 'action', 'min_date', 'max_date']
+
+
+class RecordDuplicateFilter(django_filters.FilterSet):
+    record_type = django_filters.MethodFilter(name='record_type', action='filter_record_type')
+
+    def filter_record_type(self, queryset, value):
+        """ Filter duplicates by the record type of their first record
+
+        e.g. /api/duplicates/?record_type=44a51b83-470f-4e3d-b71b-e3770ec79772
+        """
+        return queryset.filter(record__schema__record_type=value)
+
+    class Meta:
+        model = RecordDuplicate
+        fields = ['resolved', 'job', 'record_type']

--- a/app/data/models.py
+++ b/app/data/models.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.db import models
 from django.contrib.auth.models import User
+
 from ashlar.models import AshlarModel, Record
 
 

--- a/app/data/serializers.py
+++ b/app/data/serializers.py
@@ -3,7 +3,7 @@ from rest_framework.serializers import ModelSerializer
 from ashlar import serializers
 from ashlar import serializer_fields
 
-from models import RecordAuditLogEntry
+from models import RecordAuditLogEntry, RecordDuplicate
 
 from django.conf import settings
 
@@ -40,3 +40,11 @@ class RecordAuditLogEntrySerializer(ModelSerializer):
     """Serialize Audit Log Entries"""
     class Meta:
         model = RecordAuditLogEntry
+
+
+class RecordDuplicateSerializer(ModelSerializer):
+    record = serializers.RecordSerializer(required=False, allow_null=True)
+    duplicate_record = serializers.RecordSerializer(required=False, allow_null=True)
+
+    class Meta:
+        model = RecordDuplicate

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -35,9 +35,9 @@ from driver_auth.permissions import (IsAdminOrReadOnly,
                                      is_admin_or_writer)
 
 import filters
-from models import RecordAuditLogEntry
+from models import RecordAuditLogEntry, RecordDuplicate
 from serializers import (DetailsReadOnlyRecordSerializer, DetailsReadOnlyRecordSchemaSerializer,
-                         RecordAuditLogEntrySerializer)
+                         RecordAuditLogEntrySerializer, RecordDuplicateSerializer)
 import transformers
 from driver import mixins
 
@@ -229,3 +229,10 @@ class DriverRecordSchemaViewSet(RecordSchemaViewSet):
 
 class DriverBoundaryViewSet(BoundaryViewSet):
     permission_classes = (IsAdminOrReadOnly,)
+
+
+class DriverRecordDuplicateViewSet(viewsets.ModelViewSet):
+    queryset = RecordDuplicate.objects.all().order_by('record__occurred_to')
+    serializer_class = RecordDuplicateSerializer
+    permission_classes = (ReadersReadWritersWrite,)
+    filter_class = filters.RecordDuplicateFilter

--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -18,6 +18,7 @@ router.register('boundarypolygons', data_views.DriverBoundaryPolygonViewSet)
 router.register('records', data_views.DriverRecordViewSet)
 router.register('recordschemas', data_views.DriverRecordSchemaViewSet)
 router.register('recordtypes', data_views.DriverRecordTypeViewSet)
+router.register('duplicates', data_views.DriverRecordDuplicateViewSet)
 router.register('userfilters', filt_views.SavedFilterViewSet, base_name='userfilters')
 
 

--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -104,6 +104,7 @@
     <script src="scripts/navbar/navbar-directive.js"></script>
     <script src="scripts/resources/module.js"></script>
     <script src="scripts/resources/boundaries-service.js"></script>
+    <script src="scripts/resources/duplicates-service.js"></script>
     <script src="scripts/resources/polygons-service.js"></script>
     <script src="scripts/resources/records-service.js"></script>
     <script src="scripts/resources/query-builder-service.js"></script>
@@ -188,6 +189,9 @@
     <script src="scripts/views/dashboard/module.js"></script>
     <script src="scripts/views/dashboard/dashboard-controller.js"></script>
     <script src="scripts/views/dashboard/dashboard-directive.js"></script>
+    <script src="scripts/views/duplicates/module.js"></script>
+    <script src="scripts/views/duplicates/duplicates-list-controller.js"></script>
+    <script src="scripts/views/duplicates/duplicates-list-directive.js"></script>
     <script src="scripts/map-layers/module.js"></script>
     <script src="scripts/map-layers/tile-url-service.js"></script>
     <script src="scripts/map-layers/recent-events/module.js"></script>

--- a/web/app/scripts/app.js
+++ b/web/app/scripts/app.js
@@ -87,6 +87,7 @@
         'driver.views.dashboard',
         'driver.views.map',
         'driver.views.record',
+        'driver.views.duplicates',
         'ui.router',
         'LocalStorageModule'
     ])

--- a/web/app/scripts/navbar/navbar-partial.html
+++ b/web/app/scripts/navbar/navbar-partial.html
@@ -69,7 +69,7 @@
                     <ul class="dropdown-menu">
                         <li><a ng-click="ctl.navigateToStateName('account')">My Account</a></li>
                         <li><a ng-click="ctl.showAuditDownloadModal()">Download audit logs</a></li>
-                        <li><a> Manage Duplicate Records</a></li>
+                        <li><a ng-click="ctl.navigateToStateName('duplicates')">Manage Duplicate Records</a></li>
                         <li><a ng-click="ctl.onLogoutButtonClicked()">Log Out</a></li>
                     </ul>
                 </li>

--- a/web/app/scripts/resources/duplicates-service.js
+++ b/web/app/scripts/resources/duplicates-service.js
@@ -1,0 +1,25 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Duplicates($resource, WebConfig) {
+        return $resource(WebConfig.api.hostname + '/api/duplicates/:id/',
+                         {id: '@uuid', limit: 'all'}, {
+            get: {
+                method: 'GET'
+            },
+            query: {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data); },
+                isArray: false
+            },
+            update: {
+                method: 'PATCH'
+            }
+        });
+    }
+
+    angular.module('driver.resources')
+    .factory('Duplicates', Duplicates);
+
+})();

--- a/web/app/scripts/views/duplicates/duplicates-list-controller.js
+++ b/web/app/scripts/views/duplicates/duplicates-list-controller.js
@@ -1,0 +1,101 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DuplicatesListController($scope, $rootScope, $log, $modal, $state, AuthService,
+                                      InitialState, WebConfig, Duplicates, RecordState,
+                                      RecordSchemaState ) {
+        var ctl = this;
+        ctl.currentOffset = 0;
+        ctl.numDuplicatesPerPage = WebConfig.record.limit; //Just use the records limit
+        ctl.getPreviousDuplicates = getPreviousDuplicates;
+        ctl.getNextDuplicates = getNextDuplicates;
+        ctl.showResolveModal = showResolveModal;
+        ctl.userCanWrite = false;
+
+        InitialState.ready().then(init);
+
+        function init() {
+            ctl.isInitialized = false;
+            ctl.userCanWrite = AuthService.hasWriteAccess();
+
+            RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
+                .then(loadRecordSchema)
+                .then(loadDuplicates);
+        }
+
+        function loadRecordSchema() {
+            /* jshint camelcase: false */
+            var currentSchemaId = ctl.recordType.current_schema;
+            /* jshint camelcase: true */
+
+            return RecordSchemaState.get(currentSchemaId)
+                .then(function(recordSchema) {
+                    ctl.recordSchema = recordSchema;
+                });
+        }
+
+        /*
+         * Loads a page of duplicates from the API
+         * @param {int} offset Optional offset value, relative to current offset, used
+         *                     for pulling paginated results. May be positive or negative.
+         * @return {promise} Promise to load duplicates
+         */
+        function loadDuplicates(offset) {
+            var paramsOffset;
+            if (offset) {
+                ctl.currentOffset += offset;
+                if (ctl.currentOffset) {
+                    paramsOffset = ctl.currentOffset;
+                }
+            } else {
+                ctl.currentOffset = 0;
+                paramsOffset = 0;
+            }
+
+            /* jshint camelcase: false */
+            return Duplicates.query({record_type: ctl.recordType.uuid,
+                                     limit: ctl.numDuplicatesPerPage,
+                                     offset: paramsOffset}).$promise
+            /* jshint camelcase: true */
+                .then(function(duplicates) {
+                    ctl.duplicates = duplicates;
+                }
+            );
+        }
+
+        // Loads the previous page of paginated duplicates results
+        function getPreviousDuplicates() {
+            loadDuplicates(-ctl.numDuplicatesPerPage);
+        }
+
+        // Loads the next page of paginated duplicates results
+        function getNextDuplicates() {
+            loadDuplicates(ctl.numDuplicatesPerPage);
+        }
+
+        // Show a modal for resolving the given duplicate
+        function showResolveModal(duplicate) {
+            $modal.open({
+                templateUrl: 'scripts/views/duplicates/duplicate-modal-partial.html',
+                controller: 'ResolveDuplicateModalController as modal',
+                size: 'lg',
+                resolve: {
+                    duplicate: function() {
+                        return duplicate;
+                    },
+                    recordType: function() {
+                        return ctl.recordType;
+                    },
+                    recordSchema: function() {
+                        return ctl.recordSchema;
+                    },
+                }
+            });
+        }
+    }
+
+    angular.module('driver.views.duplicates')
+    .controller('DuplicatesListController', DuplicatesListController);
+
+})();

--- a/web/app/scripts/views/duplicates/duplicates-list-directive.js
+++ b/web/app/scripts/views/duplicates/duplicates-list-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DuplicatesList() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/duplicates/duplicates-list-partial.html',
+            controller: 'DuplicatesListController',
+            controllerAs: 'ctl',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('driver.views.duplicates')
+    .directive('driverDuplicatesList', DuplicatesList);
+
+})();

--- a/web/app/scripts/views/duplicates/duplicates-list-partial.html
+++ b/web/app/scripts/views/duplicates/duplicates-list-partial.html
@@ -1,0 +1,57 @@
+<div class="duplicates-title drop-shadow"><h3>Potential Duplicate Records</h3></div>
+<div class="table-view">
+    <div class="table-view-container">
+        <div class="overflow">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th class="date">Date &amp; Time</th>
+                        <th class="detail">Location</th>
+                        <th class="date">Date &amp; Time</th>
+                        <th class="detail">Location</th>
+                        <th>Status</th>
+                        <!-- Resolve link -->
+                        <th class="links"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="dup in ctl.duplicates.results">
+                        <td ng-repeat-start="record in [dup.record, dup.duplicate_record]" class="date">
+                            {{ ::record.occurred_to | localDateTime }}
+                        </td>
+                        <td ng-repeat-end class="detail">
+                            {{ ::record.location_text }}
+                        </td>
+                        <td>{{ dup.resolved ? 'Resolved' : 'Potential Duplicate' }}</td>
+
+                        <td class="links">
+                            <a ng-if="::ctl.userCanWrite" ng-click="ctl.showResolveModal(dup)">
+                                <span class="glyphicon glyphicon-pencil"></span> Resolve
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <nav>
+                <ul class="pager">
+                    <li class="previous" ng-if="ctl.duplicates.previous">
+                        <a type="button" class="btn btn-default" ng-click="ctl.getPreviousDuplicates()">
+                            <span aria-hidden="true">&larr;</span> Previous</a>
+                    </li>
+                    <li ng-if="ctl.duplicates.count" class="text-center">
+                        <i>
+                            Showing results
+                            {{ ctl.currentOffset + 1}} -
+                            {{ ctl.currentOffset + ctl.duplicates.results.length }} of
+                            {{ ctl.duplicates.count }}
+                        </i>
+                    </li>
+                    <li class="next" ng-if="ctl.duplicates.next">
+                        <a type="button" class="btn btn-default" ng-click="ctl.getNextDuplicates()">
+                            Next <span aria-hidden="true">&rarr;</span></a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>

--- a/web/app/scripts/views/duplicates/module.js
+++ b/web/app/scripts/views/duplicates/module.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function StateConfig($stateProvider) {
+        $stateProvider.state('duplicates', {
+            url: '/duplicates',
+            template: '<driver-duplicates-list></driver-duplicates-list>',
+            label: 'Potential Duplicates',
+            showInNavbar: false
+        });
+    }
+
+    angular.module('driver.views.duplicates', [
+        'ngSanitize',
+        'ase.auth',
+        'driver.config',
+        'driver.resources',
+        'driver.state',
+        'ui.bootstrap',
+        'ui.router',
+    ]).config(StateConfig);
+
+})();

--- a/web/app/styles/main.scss
+++ b/web/app/styles/main.scss
@@ -10,6 +10,7 @@ $icon-font-path: '../bower_components/bootstrap-sass-official/assets/fonts/boots
 @import 'variables';
 
 @import 'partials/add-new';
+@import 'partials/duplicates';
 @import 'partials/dashboard';
 @import 'partials/record-list';
 @import 'partials/field';

--- a/web/app/styles/partials/_duplicates.scss
+++ b/web/app/styles/partials/_duplicates.scss
@@ -1,0 +1,33 @@
+.duplicates-title {
+    width: 100%;
+    position: fixed;
+    z-index: 8;
+    top: 52px;
+    height: 50px !important;
+    padding: 0px 14px !important;
+    background: #f1f2f2;
+}
+
+driver-duplicates-list {
+    position: fixed;
+    top: 105px;
+    width: 100%;
+    bottom: 0;
+    overflow: scroll;
+
+    .modal-footer {
+        margin-top: 50px;
+        margin-bottom: 0;
+        padding-top: 10px;
+        padding-bottom: 0;
+    }
+    .links a {
+        cursor: pointer;
+    }
+    .links {
+        min-width: 105px;
+    }
+    .date {
+        min-width: 70px;
+    }
+}

--- a/web/test/karma.conf.js
+++ b/web/test/karma.conf.js
@@ -113,6 +113,8 @@ module.exports = function(config) {
       'app/scripts/views/login/**.js',
       'app/scripts/views/dashboard/module.js',
       'app/scripts/views/dashboard/**.js',
+      'app/scripts/views/duplicates/module.js',
+      'app/scripts/views/duplicates/**.js',
       'app/scripts/views/map/module.js',
       'app/scripts/views/map/**.js',
       'app/scripts/views/record/module.js',


### PR DESCRIPTION
Adds an API endpoint and a front-end view for record duplicates.

To test, use shell_plus to make a DedupeJob, find some records that match your current recordType, and create some RecordDuplicates like `RecordDuplicate.objects.create(job=DedupeJob.objects.first(), record=r[0], duplicate_record=r[1])`

The 'Resolve' button doesn't work.  That's the next card.  I'm also going to make tests for all of this as part of that card.