### PR TITLE
Add viewset for controlling CSV export jobs

### DIFF
--- a/app/data/tasks/export_csv.py
+++ b/app/data/tasks/export_csv.py
@@ -3,7 +3,9 @@ import os
 import tarfile
 import tempfile
 
+from celery import current_task
 from celery import shared_task
+from celery import states
 from celery.utils.log import get_task_logger
 
 from django_redis import get_redis_connection
@@ -13,7 +15,7 @@ from ashlar.models import Record
 logger = get_task_logger(__name__)
 
 
-@shared_task
+@shared_task(track_started=True)
 def export_csv(query_key):
     """Exports a set of records to a series of CSV files and places them in a compressed tarball
     :param query_key: A UUID corresponding to a cached SQL query which will be used to filter
@@ -55,7 +57,7 @@ def export_csv(query_key):
     # Cleanup
     record_writer.cleanup()
 
-    return archive.name
+    return os.path.basename(archive.name)
 
 
 def get_sql_string_by_key(key):

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -265,6 +265,9 @@ CELERY_ROUTES = {
     'data.tasks.remove_duplicates.remove_duplicates': {'queue': 'taskworker'},
     'data.tasks.export_csv.export_csv': {'queue': 'taskworker'},
 }
+# This needs to match the proxy configuration in nginx so that requests for files generated
+# by celery jobs go to the right place.
+CELERY_DOWNLOAD_PREFIX = '/download/'
 
 # Deduplication settings
 DEDUPE_TIME_RANGE_HOURS = 12

--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -15,6 +15,7 @@ router.register('blackspots', black_spot_views.BlackSpotViewSet, base_name='blac
 router.register('blackspotsets', black_spot_views.BlackSpotSetViewSet, base_name='blackspotsets')
 router.register('boundaries', data_views.DriverBoundaryViewSet)
 router.register('boundarypolygons', data_views.DriverBoundaryPolygonViewSet)
+router.register('csv-export', data_views.RecordCsvExportViewSet, base_name='csv-export')
 router.register('records', data_views.DriverRecordViewSet)
 router.register('recordschemas', data_views.DriverRecordSchemaViewSet)
 router.register('recordtypes', data_views.DriverRecordTypeViewSet)

--- a/deployment/ansible/celery.yml
+++ b/deployment/ansible/celery.yml
@@ -22,4 +22,4 @@
 
   roles:
     - { role: "driver.celery" }
-
+    - { role: "driver-celery.nginx" }

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -52,3 +52,5 @@ local_center_lat_lon: [12.375, 121.5]
 
 ## Forecast.io settings
 forecast_io_api_key: ''
+
+celery_host_address: "celery.service.driver.internal"

--- a/deployment/ansible/roles/driver-celery.nginx/defaults/main.yml
+++ b/deployment/ansible/roles/driver-celery.nginx/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+driver_user: "{{ ansible_ssh_user }}"
+root_www_dir: "/var/www"
+root_media_dir: "{{ root_www_dir }}/media"

--- a/deployment/ansible/roles/driver-celery.nginx/meta/main.yml
+++ b/deployment/ansible/roles/driver-celery.nginx/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.nginx", nginx_delete_default_site: True }

--- a/deployment/ansible/roles/driver-celery.nginx/tasks/main.yml
+++ b/deployment/ansible/roles/driver-celery.nginx/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Configure Nginx site
+  template: src=nginx-app.conf.j2
+            dest=/etc/nginx/sites-available/driver-celery.conf
+  notify:
+    - Restart Nginx
+
+- name: Enable Nginx site
+  file: src=/etc/nginx/sites-available/driver-celery.conf
+        dest=/etc/nginx/sites-enabled/driver-celery
+        state=link
+  notify:
+    - Restart Nginx
+
+- name: Configure Nginx log format
+  template: src=log-format.conf.j2
+            dest=/etc/nginx/conf.d/log-format.conf
+  notify:
+    - Restart Nginx

--- a/deployment/ansible/roles/driver-celery.nginx/templates/log-format.conf.j2
+++ b/deployment/ansible/roles/driver-celery.nginx/templates/log-format.conf.j2
@@ -1,0 +1,12 @@
+# Provide a custom log format that emits JSON
+log_format logstash_json '{ "@timestamp": "$time_iso8601", '
+                           '"@fields": { '
+                           '"remote_addr": "$remote_addr", '
+                           '"remote_user": "$remote_user", '
+                           '"body_bytes_sent": "$body_bytes_sent", '
+                           '"request_time": "$request_time", '
+                           '"status": "$status", '
+                           '"request": "$request", '
+                           '"request_method": "$request_method", '
+                           '"http_referrer": "$http_referer", '
+                           '"http_user_agent": "$http_user_agent" } }';

--- a/deployment/ansible/roles/driver-celery.nginx/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/driver-celery.nginx/templates/nginx-app.conf.j2
@@ -1,0 +1,12 @@
+server {
+    listen 80 default_server;
+
+    server_name _;
+    root {{ root_media_dir }};
+    index index.html;
+
+    access_log /var/log/nginx/driver-celery.access.log logstash_json;
+
+    client_max_body_size 10m;
+
+}

--- a/deployment/ansible/roles/driver.nginx/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/driver.nginx/templates/nginx-app.conf.j2
@@ -103,6 +103,17 @@ server {
         root {{ root_www_dir }}/;
     }
 
+    location /download/ {
+        proxy_pass http://{{ celery_host_address }}/;
+        proxy_read_timeout 40s;
+        proxy_redirect     off;
+        proxy_set_header   Host $http_host;
+        proxy_set_header   X-Forwarded-Host $host;
+        proxy_set_header   X-Forwarded-Server $host;
+        proxy_set_header   X-Real-IP        $remote_addr;
+        proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+    }
+
     location /tiles/ {
         proxy_pass http://localhost:5000;
         proxy_read_timeout 40s;


### PR DESCRIPTION
This sets up a viewset for kicking off and querying the status of CSV export jobs. It also sets up a proxy endpoint for downloading the results from the Celery worker. I'm not sure whether this will work on staging; if we've got internal DNS set up within the VPC then it should, otherwise it likely won't.

Aside from that, the biggest outstanding task is to clean up the exported files periodically so that they don't accumulate on the celery worker.

An export job can be started by POSTing to /csv-export/ with the
following JSON
{ "tilekey": "<tile-key-here>" }

The tilekey is the same used to ensure that Windshaft tiles match the UI filter settings.

If the endpoint is able to successfully start a Celery job, then it will return a unique UUID for the export job. Job status will then be available at `/csv-export/<UUID>/`. Note that because of the way Celery treats unknown job ids, accessing `/csv-export/<invalid job id>/` will return a status of PENDING, rather than a 404.

At the moment, it's not possible to cancel export jobs. However, it looks like if we switch to a database-based results backend, then it should be possible: http://docs.celeryproject.org/en/latest/reference/celery.contrib.abortable.html