### PR TITLE
Duplicate records front-end

### DIFF
--- a/app/data/filters.py
+++ b/app/data/filters.py
@@ -1,6 +1,6 @@
 import django_filters
 
-from models import RecordAuditLogEntry
+from models import RecordAuditLogEntry, RecordDuplicate
 
 
 class RecordAuditLogFilter(django_filters.FilterSet):
@@ -12,3 +12,18 @@ class RecordAuditLogFilter(django_filters.FilterSet):
     class Meta:
         model = RecordAuditLogEntry
         fields = ['user', 'username', 'record', 'record_uuid', 'action', 'min_date', 'max_date']
+
+
+class RecordDuplicateFilter(django_filters.FilterSet):
+    record_type = django_filters.MethodFilter(name='record_type', action='filter_record_type')
+
+    def filter_record_type(self, queryset, value):
+        """ Filter duplicates by the record type of their first record
+
+        e.g. /api/duplicates/?record_type=44a51b83-470f-4e3d-b71b-e3770ec79772
+        """
+        return queryset.filter(record__schema__record_type=value)
+
+    class Meta:
+        model = RecordDuplicate
+        fields = ['resolved', 'job', 'record_type']

--- a/app/data/models.py
+++ b/app/data/models.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.db import models
 from django.contrib.auth.models import User
+
 from ashlar.models import AshlarModel, Record
 
 

--- a/app/data/serializers.py
+++ b/app/data/serializers.py
@@ -3,7 +3,7 @@ from rest_framework.serializers import ModelSerializer
 from ashlar import serializers
 from ashlar import serializer_fields
 
-from models import RecordAuditLogEntry
+from models import RecordAuditLogEntry, RecordDuplicate
 
 from django.conf import settings
 
@@ -40,3 +40,11 @@ class RecordAuditLogEntrySerializer(ModelSerializer):
     """Serialize Audit Log Entries"""
     class Meta:
         model = RecordAuditLogEntry
+
+
+class RecordDuplicateSerializer(ModelSerializer):
+    record = serializers.RecordSerializer(required=False, allow_null=True)
+    duplicate_record = serializers.RecordSerializer(required=False, allow_null=True)
+
+    class Meta:
+        model = RecordDuplicate

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -35,9 +35,9 @@ from driver_auth.permissions import (IsAdminOrReadOnly,
                                      is_admin_or_writer)
 
 import filters
-from models import RecordAuditLogEntry
+from models import RecordAuditLogEntry, RecordDuplicate
 from serializers import (DetailsReadOnlyRecordSerializer, DetailsReadOnlyRecordSchemaSerializer,
-                         RecordAuditLogEntrySerializer)
+                         RecordAuditLogEntrySerializer, RecordDuplicateSerializer)
 import transformers
 from driver import mixins
 
@@ -229,3 +229,10 @@ class DriverRecordSchemaViewSet(RecordSchemaViewSet):
 
 class DriverBoundaryViewSet(BoundaryViewSet):
     permission_classes = (IsAdminOrReadOnly,)
+
+
+class DriverRecordDuplicateViewSet(viewsets.ModelViewSet):
+    queryset = RecordDuplicate.objects.all().order_by('record__occurred_to')
+    serializer_class = RecordDuplicateSerializer
+    permission_classes = (ReadersReadWritersWrite,)
+    filter_class = filters.RecordDuplicateFilter

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -9,11 +9,12 @@ from django.db.models import (Case,
                               IntegerField,
                               DateTimeField,
                               Value,
-                              Count)
+                              Count,
+                              Q)
 from django_redis import get_redis_connection
 
 from rest_framework import viewsets
-from rest_framework.decorators import list_route
+from rest_framework.decorators import list_route, detail_route
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework import serializers
@@ -236,3 +237,30 @@ class DriverRecordDuplicateViewSet(viewsets.ModelViewSet):
     serializer_class = RecordDuplicateSerializer
     permission_classes = (ReadersReadWritersWrite,)
     filter_class = filters.RecordDuplicateFilter
+
+    @detail_route(methods=['patch'])
+    def resolve(self, request, pk=None):
+        duplicate = self.queryset.get(pk=pk)
+        recordUUID = request.data.get('recordUUID', None)
+        if recordUUID is None:
+            # No record id means they want to keep both, so just resolve the duplicate
+            duplicate.resolved = True
+            duplicate.save()
+            resolved_ids = [duplicate.pk]
+        else:
+            # If they picked a record, archive the other one and resolve all duplicates involving it
+            # (which will include the current one)
+            if recordUUID == str(duplicate.record.uuid):
+                rejected_record = duplicate.duplicate_record
+            elif recordUUID == str(duplicate.duplicate_record.uuid):
+                rejected_record = duplicate.record
+            else:
+                raise Exception("Error: Trying to resolve a duplicate with an unconnected record.")
+            rejected_record.archived = True
+            rejected_record.save()
+            resolved_dup_qs = RecordDuplicate.objects.filter(Q(resolved=False),
+                                                             Q(record=rejected_record) |
+                                                             Q(duplicate_record=rejected_record))
+            resolved_ids = [str(uuid) for uuid in resolved_dup_qs.values_list('pk', flat=True)]
+            resolved_dup_qs.update(resolved=True)
+        return Response({'resolved': resolved_ids})

--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -18,6 +18,7 @@ router.register('boundarypolygons', data_views.DriverBoundaryPolygonViewSet)
 router.register('records', data_views.DriverRecordViewSet)
 router.register('recordschemas', data_views.DriverRecordSchemaViewSet)
 router.register('recordtypes', data_views.DriverRecordTypeViewSet)
+router.register('duplicates', data_views.DriverRecordDuplicateViewSet)
 router.register('userfilters', filt_views.SavedFilterViewSet, base_name='userfilters')
 
 

--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -104,6 +104,7 @@
     <script src="scripts/navbar/navbar-directive.js"></script>
     <script src="scripts/resources/module.js"></script>
     <script src="scripts/resources/boundaries-service.js"></script>
+    <script src="scripts/resources/duplicates-service.js"></script>
     <script src="scripts/resources/polygons-service.js"></script>
     <script src="scripts/resources/records-service.js"></script>
     <script src="scripts/resources/query-builder-service.js"></script>
@@ -188,6 +189,9 @@
     <script src="scripts/views/dashboard/module.js"></script>
     <script src="scripts/views/dashboard/dashboard-controller.js"></script>
     <script src="scripts/views/dashboard/dashboard-directive.js"></script>
+    <script src="scripts/views/duplicates/module.js"></script>
+    <script src="scripts/views/duplicates/duplicates-list-controller.js"></script>
+    <script src="scripts/views/duplicates/duplicates-list-directive.js"></script>
     <script src="scripts/map-layers/module.js"></script>
     <script src="scripts/map-layers/tile-url-service.js"></script>
     <script src="scripts/map-layers/recent-events/module.js"></script>

--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -192,6 +192,7 @@
     <script src="scripts/views/duplicates/module.js"></script>
     <script src="scripts/views/duplicates/duplicates-list-controller.js"></script>
     <script src="scripts/views/duplicates/duplicates-list-directive.js"></script>
+    <script src="scripts/views/duplicates/resolve-duplicate-modal-controller.js"></script>
     <script src="scripts/map-layers/module.js"></script>
     <script src="scripts/map-layers/tile-url-service.js"></script>
     <script src="scripts/map-layers/recent-events/module.js"></script>

--- a/web/app/scripts/app.js
+++ b/web/app/scripts/app.js
@@ -87,6 +87,7 @@
         'driver.views.dashboard',
         'driver.views.map',
         'driver.views.record',
+        'driver.views.duplicates',
         'ui.router',
         'LocalStorageModule'
     ])

--- a/web/app/scripts/details/details-tabs-controller.js
+++ b/web/app/scripts/details/details-tabs-controller.js
@@ -26,7 +26,6 @@
                 definition.propertyName = section;
                 return definition;
             });
-
             return sorted;
         }
 

--- a/web/app/scripts/navbar/navbar-controller.js
+++ b/web/app/scripts/navbar/navbar-controller.js
@@ -14,6 +14,7 @@
 
         ctl.onLogoutButtonClicked = AuthService.logout;
         ctl.authenticated = AuthService.isAuthenticated();
+        ctl.hasWriteAccess = AuthService.hasWriteAccess();
         ctl.onGeographySelected = onGeographySelected;
         ctl.onBoundarySelected = onBoundarySelected;
         ctl.onRecordTypeSelected = onRecordTypeSelected;

--- a/web/app/scripts/navbar/navbar-partial.html
+++ b/web/app/scripts/navbar/navbar-partial.html
@@ -69,7 +69,7 @@
                     <ul class="dropdown-menu">
                         <li><a ng-click="ctl.navigateToStateName('account')">My Account</a></li>
                         <li><a ng-click="ctl.showAuditDownloadModal()">Download audit logs</a></li>
-                        <li><a> Manage Duplicate Records</a></li>
+                        <li ng-if="ctl.hasWriteAccess"><a ng-click="ctl.navigateToStateName('duplicates')">Manage Duplicate Records</a></li>
                         <li><a ng-click="ctl.onLogoutButtonClicked()">Log Out</a></li>
                     </ul>
                 </li>

--- a/web/app/scripts/resources/duplicates-service.js
+++ b/web/app/scripts/resources/duplicates-service.js
@@ -1,0 +1,25 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Duplicates($resource, WebConfig) {
+        return $resource(WebConfig.api.hostname + '/api/duplicates/:id/',
+                         {id: '@uuid', limit: 'all'}, {
+            get: {
+                method: 'GET'
+            },
+            query: {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data); },
+                isArray: false
+            },
+            update: {
+                method: 'PATCH'
+            }
+        });
+    }
+
+    angular.module('driver.resources')
+    .factory('Duplicates', Duplicates);
+
+})();

--- a/web/app/scripts/resources/duplicates-service.js
+++ b/web/app/scripts/resources/duplicates-service.js
@@ -3,7 +3,8 @@
 
     /* ngInject */
     function Duplicates($resource, WebConfig) {
-        return $resource(WebConfig.api.hostname + '/api/duplicates/:id/',
+        var baseUrl = WebConfig.api.hostname + '/api/duplicates/:id/';
+        return $resource(baseUrl,
                          {id: '@uuid', limit: 'all'}, {
             get: {
                 method: 'GET'
@@ -15,6 +16,10 @@
             },
             update: {
                 method: 'PATCH'
+            },
+            resolve: {
+                method: 'PATCH',
+                url: baseUrl + 'resolve/'
             }
         });
     }

--- a/web/app/scripts/resources/records-service.js
+++ b/web/app/scripts/resources/records-service.js
@@ -3,7 +3,8 @@
 
     /* ngInject */
     function Records($resource, WebConfig) {
-        return $resource(WebConfig.api.hostname + '/api/records/:id/', {id: '@uuid'}, {
+        return $resource(WebConfig.api.hostname + '/api/records/:id/',
+                         {id: '@uuid', archived: false}, {
             create: {
                 method: 'POST'
             },

--- a/web/app/scripts/views/duplicates/duplicates-list-controller.js
+++ b/web/app/scripts/views/duplicates/duplicates-list-controller.js
@@ -1,0 +1,101 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DuplicatesListController($scope, $rootScope, $log, $modal, $state, AuthService,
+                                      InitialState, WebConfig, Duplicates, RecordState,
+                                      RecordSchemaState ) {
+        var ctl = this;
+        ctl.currentOffset = 0;
+        ctl.numDuplicatesPerPage = WebConfig.record.limit; //Just use the records limit
+        ctl.getPreviousDuplicates = getPreviousDuplicates;
+        ctl.getNextDuplicates = getNextDuplicates;
+        ctl.showResolveModal = showResolveModal;
+        ctl.userCanWrite = false;
+
+        InitialState.ready().then(init);
+
+        function init() {
+            ctl.isInitialized = false;
+            ctl.userCanWrite = AuthService.hasWriteAccess();
+
+            RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
+                .then(loadRecordSchema)
+                .then(loadDuplicates);
+        }
+
+        function loadRecordSchema() {
+            /* jshint camelcase: false */
+            var currentSchemaId = ctl.recordType.current_schema;
+            /* jshint camelcase: true */
+
+            return RecordSchemaState.get(currentSchemaId)
+                .then(function(recordSchema) {
+                    ctl.recordSchema = recordSchema;
+                });
+        }
+
+        /*
+         * Loads a page of duplicates from the API
+         * @param {int} offset Optional offset value, relative to current offset, used
+         *                     for pulling paginated results. May be positive or negative.
+         * @return {promise} Promise to load duplicates
+         */
+        function loadDuplicates(offset) {
+            var paramsOffset;
+            if (offset) {
+                ctl.currentOffset += offset;
+                if (ctl.currentOffset) {
+                    paramsOffset = ctl.currentOffset;
+                }
+            } else {
+                ctl.currentOffset = 0;
+                paramsOffset = 0;
+            }
+
+            /* jshint camelcase: false */
+            return Duplicates.query({record_type: ctl.recordType.uuid,
+                                     limit: ctl.numDuplicatesPerPage,
+                                     offset: paramsOffset}).$promise
+            /* jshint camelcase: true */
+                .then(function(duplicates) {
+                    ctl.duplicates = duplicates;
+                }
+            );
+        }
+
+        // Loads the previous page of paginated duplicates results
+        function getPreviousDuplicates() {
+            loadDuplicates(-ctl.numDuplicatesPerPage);
+        }
+
+        // Loads the next page of paginated duplicates results
+        function getNextDuplicates() {
+            loadDuplicates(ctl.numDuplicatesPerPage);
+        }
+
+        // Show a modal for resolving the given duplicate
+        function showResolveModal(duplicate) {
+            $modal.open({
+                templateUrl: 'scripts/views/duplicates/duplicate-modal-partial.html',
+                controller: 'ResolveDuplicateModalController as modal',
+                size: 'lg',
+                resolve: {
+                    duplicate: function() {
+                        return duplicate;
+                    },
+                    recordType: function() {
+                        return ctl.recordType;
+                    },
+                    recordSchema: function() {
+                        return ctl.recordSchema;
+                    },
+                }
+            });
+        }
+    }
+
+    angular.module('driver.views.duplicates')
+    .controller('DuplicatesListController', DuplicatesListController);
+
+})();

--- a/web/app/scripts/views/duplicates/duplicates-list-controller.js
+++ b/web/app/scripts/views/duplicates/duplicates-list-controller.js
@@ -42,24 +42,21 @@
          * @return {promise} Promise to load duplicates
          */
         function loadDuplicates(offset) {
-            var paramsOffset;
+            var newOffset;
             if (offset) {
-                ctl.currentOffset += offset;
-                if (ctl.currentOffset) {
-                    paramsOffset = ctl.currentOffset;
-                }
+                newOffset = ctl.currentOffset + offset;
             } else {
-                ctl.currentOffset = 0;
-                paramsOffset = 0;
+                newOffset = 0;
             }
 
             /* jshint camelcase: false */
             return Duplicates.query({record_type: ctl.recordType.uuid,
                                      limit: ctl.numDuplicatesPerPage,
-                                     offset: paramsOffset}).$promise
+                                     offset: newOffset}).$promise
             /* jshint camelcase: true */
                 .then(function(duplicates) {
                     ctl.duplicates = duplicates;
+                    ctl.currentOffset = newOffset;
                     onDuplicatesLoaded();
                 }
             );

--- a/web/app/scripts/views/duplicates/duplicates-list-controller.js
+++ b/web/app/scripts/views/duplicates/duplicates-list-controller.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /* ngInject */
-    function DuplicatesListController($scope, $rootScope, $log, $modal, $state, AuthService,
+    function DuplicatesListController($scope, $log, $modal, $state, AuthService,
                                       InitialState, WebConfig, Duplicates, RecordState,
                                       RecordSchemaState ) {
         var ctl = this;
@@ -16,7 +16,6 @@
         InitialState.ready().then(init);
 
         function init() {
-            ctl.isInitialized = false;
             ctl.userCanWrite = AuthService.hasWriteAccess();
 
             RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })

--- a/web/app/scripts/views/duplicates/duplicates-list-directive.js
+++ b/web/app/scripts/views/duplicates/duplicates-list-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DuplicatesList() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/duplicates/duplicates-list-partial.html',
+            controller: 'DuplicatesListController',
+            controllerAs: 'ctl',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('driver.views.duplicates')
+    .directive('driverDuplicatesList', DuplicatesList);
+
+})();

--- a/web/app/scripts/views/duplicates/duplicates-list-partial.html
+++ b/web/app/scripts/views/duplicates/duplicates-list-partial.html
@@ -25,7 +25,8 @@
                         <td>{{ dup.resolved ? 'Resolved' : 'Potential Duplicate' }}</td>
 
                         <td class="links">
-                            <a ng-if="::ctl.userCanWrite" ng-click="ctl.showResolveModal(dup)">
+                            <a ng-if="ctl.userCanWrite &amp;&amp; !dup.resolved"
+                               ng-click="ctl.showResolveModal(dup)">
                                 <span class="glyphicon glyphicon-pencil"></span> Resolve
                             </a>
                         </td>

--- a/web/app/scripts/views/duplicates/duplicates-list-partial.html
+++ b/web/app/scripts/views/duplicates/duplicates-list-partial.html
@@ -1,0 +1,57 @@
+<div class="duplicates-title drop-shadow"><h3>Potential Duplicate Records</h3></div>
+<div class="table-view">
+    <div class="table-view-container">
+        <div class="overflow">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th class="date">Date &amp; Time</th>
+                        <th class="detail">Location</th>
+                        <th class="date">Date &amp; Time</th>
+                        <th class="detail">Location</th>
+                        <th>Status</th>
+                        <!-- Resolve link -->
+                        <th class="links"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="dup in ctl.duplicates.results">
+                        <td ng-repeat-start="record in [dup.record, dup.duplicate_record]" class="date">
+                            {{ ::record.occurred_to | localDateTime }}
+                        </td>
+                        <td ng-repeat-end class="detail">
+                            {{ ::record.location_text }}
+                        </td>
+                        <td>{{ dup.resolved ? 'Resolved' : 'Potential Duplicate' }}</td>
+
+                        <td class="links">
+                            <a ng-if="::ctl.userCanWrite" ng-click="ctl.showResolveModal(dup)">
+                                <span class="glyphicon glyphicon-pencil"></span> Resolve
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <nav>
+                <ul class="pager">
+                    <li class="previous" ng-if="ctl.duplicates.previous">
+                        <a type="button" class="btn btn-default" ng-click="ctl.getPreviousDuplicates()">
+                            <span aria-hidden="true">&larr;</span> Previous</a>
+                    </li>
+                    <li ng-if="ctl.duplicates.count" class="text-center">
+                        <i>
+                            Showing results
+                            {{ ctl.currentOffset + 1}} -
+                            {{ ctl.currentOffset + ctl.duplicates.results.length }} of
+                            {{ ctl.duplicates.count }}
+                        </i>
+                    </li>
+                    <li class="next" ng-if="ctl.duplicates.next">
+                        <a type="button" class="btn btn-default" ng-click="ctl.getNextDuplicates()">
+                            Next <span aria-hidden="true">&rarr;</span></a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>

--- a/web/app/scripts/views/duplicates/module.js
+++ b/web/app/scripts/views/duplicates/module.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function StateConfig($stateProvider) {
+        $stateProvider.state('duplicates', {
+            url: '/duplicates',
+            template: '<driver-duplicates-list></driver-duplicates-list>',
+            label: 'Potential Duplicates',
+            showInNavbar: false
+        });
+    }
+
+    angular.module('driver.views.duplicates', [
+        'ngSanitize',
+        'ase.auth',
+        'driver.config',
+        'driver.resources',
+        'driver.state',
+        'ui.bootstrap',
+        'ui.router',
+    ]).config(StateConfig);
+
+})();

--- a/web/app/scripts/views/duplicates/resolve-duplicate-modal-controller.js
+++ b/web/app/scripts/views/duplicates/resolve-duplicate-modal-controller.js
@@ -1,0 +1,45 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function ResolveDuplicateModalController($modalInstance, Duplicates, Records, params) {
+        var ctl = this;
+        ctl.params = params;
+        ctl.selectRecord = selectRecord;
+        ctl.keepBoth = keepBoth;
+        ctl.close = close;
+
+        function selectRecord (recordUUID) {
+            Duplicates.resolve({uuid: ctl.params.duplicate.uuid, recordUUID: recordUUID}).$promise.then(
+                function (result) {
+                    // Since resolving one duplicate can cause others to be resolved, search the
+                    // list and update any that were resolved (including the intended one).
+                    _.forEach(ctl.params.duplicatesList, function (dup) {
+                        if (_.any(result.resolved, function (resolvedUUID) {
+                                return resolvedUUID === dup.uuid; } )) {
+                            dup.resolved = true;
+                        }
+                    });
+                    ctl.close();
+                }
+            );
+        }
+
+        function keepBoth () {
+            Duplicates.resolve({uuid: ctl.params.duplicate.uuid}).$promise.then(
+                function () {
+                    ctl.params.duplicate.resolved = true;
+                    ctl.close();
+                }
+            );
+        }
+
+        ctl.close = function () {
+            $modalInstance.close();
+        };
+    }
+
+    angular.module('driver.views.duplicates')
+    .controller('ResolveDuplicateModalController', ResolveDuplicateModalController);
+
+})();

--- a/web/app/scripts/views/duplicates/resolve-duplicate-modal-partial.html
+++ b/web/app/scripts/views/duplicates/resolve-duplicate-modal-partial.html
@@ -1,0 +1,29 @@
+<div class="duplicate-modal">
+    <div class="close" ng-click="modal.close()">
+        &times;
+    </div>
+    <div class="modal-header">
+        <h3>Resolve duplicate entries</h3>
+    </div>
+    <div class="modal-body">
+        <div class="duplicate-details"
+             ng-repeat="record in [modal.params.duplicate.record, modal.params.duplicate.duplicate_record]">
+            <driver-details-single
+                data="record.data[modal.params.propertyName]"
+                properties="modal.params.properties"
+                record="record">
+            </driver-details-single>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <div class="select-record" ng-click="modal.selectRecord(modal.params.duplicate.record.uuid)">
+            Use this record
+        </div>
+        <div class="select-record" ng-click="modal.selectRecord(modal.params.duplicate.duplicate_record.uuid)">
+            Use this record
+        </div>
+        <div class="keep-both" ng-click="modal.keepBoth()">
+          Keep both unique records
+        </div>
+    </div>
+</div>

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -57,24 +57,21 @@
          * @return {promise} Promise to load records
          */
         function loadRecords(offset) {
-            var paramsOffset;
+            var newOffset;
             if (offset) {
-                ctl.currentOffset += offset;
-                if (ctl.currentOffset) {
-                    paramsOffset = ctl.currentOffset;
-                }
+                newOffset = ctl.currentOffset + offset;
             } else {
-                ctl.currentOffset = 0;
-                paramsOffset = 0;
+                newOffset = 0;
             }
 
             /* jshint camelcase: false */
             var params = ctl.boundaryId ? { polygon_id: ctl.boundaryId } : {};
             /* jshint camelcase: true */
 
-            return QueryBuilder.djangoQuery(true, paramsOffset, params)
+            return QueryBuilder.djangoQuery(true, newOffset, params)
             .then(function(records) {
                 ctl.records = records;
+                ctl.currentOffset = newOffset;
             });
         }
 

--- a/web/app/styles/_mixins.scss
+++ b/web/app/styles/_mixins.scss
@@ -1,0 +1,22 @@
+@mixin close-modal {
+    position: absolute;
+    right: -15px;
+    top: -15px;
+    background: white;
+    padding: 8px;
+    opacity: 1;
+    box-shadow: 0 0 5px rgba(0,0,0,0.25);
+    width: 30px;
+    height: 30px;
+    line-height: 0.6;
+    text-align: center;
+    border-radius: 999px;
+    color: #999;
+    transition: 0.5s all;
+
+    &:hover {
+        color: #000;
+        box-shadow: 0 0 5px rgba(0,0,0,0.45);
+    }
+}
+

--- a/web/app/styles/main.scss
+++ b/web/app/styles/main.scss
@@ -10,6 +10,7 @@ $icon-font-path: '../bower_components/bootstrap-sass-official/assets/fonts/boots
 @import 'variables';
 
 @import 'partials/add-new';
+@import 'partials/duplicates';
 @import 'partials/dashboard';
 @import 'partials/record-list';
 @import 'partials/field';

--- a/web/app/styles/main.scss
+++ b/web/app/styles/main.scss
@@ -8,6 +8,7 @@ $icon-font-path: '../bower_components/bootstrap-sass-official/assets/fonts/boots
 @import 'layout';
 @import 'typography';
 @import 'variables';
+@import 'mixins';
 
 @import 'partials/add-new';
 @import 'partials/duplicates';

--- a/web/app/styles/partials/_duplicates.scss
+++ b/web/app/styles/partials/_duplicates.scss
@@ -15,12 +15,6 @@ driver-duplicates-list {
     bottom: 0;
     overflow: scroll;
 
-    .modal-footer {
-        margin-top: 50px;
-        margin-bottom: 0;
-        padding-top: 10px;
-        padding-bottom: 0;
-    }
     .links a {
         cursor: pointer;
     }
@@ -29,5 +23,60 @@ driver-duplicates-list {
     }
     .date {
         min-width: 70px;
+    }
+}
+
+.duplicate-modal {
+    &.modal {
+        background: rgba(0,0,0,0.5);
+    }
+    .modal-content {
+        border-radius: 0;
+        border: none;
+        padding: 15px;
+    }
+    .close {
+        @include close-modal();
+    }
+    .modal-body {
+        width: 100%;
+        padding: 0px;
+    }
+
+    .duplicate-details {
+        width: 50%;
+        display: inline-block;
+        border: 1px solid #e5e5e5;
+        padding: 20px 15px 30px;
+    }
+
+    .modal-footer {
+        margin-top: -5px;
+        margin-bottom: 0;
+        padding: 0px;
+        padding-bottom: 0;
+        text-align: center;
+    }
+    .select-record {
+        width: 50%;
+        float: left;
+        padding: 10px;
+        text-transform: uppercase;
+        cursor: pointer;
+        background: #ddd;
+        &:hover {
+            background: #888;
+            color: #fff;
+        }
+    }
+
+    .keep-both {
+        clear: both;
+        padding: 10px;
+        text-transform: uppercase;
+        cursor: pointer;
+        &:hover {
+            background: #efefef;
+        }
     }
 }

--- a/web/app/styles/partials/_duplicates.scss
+++ b/web/app/styles/partials/_duplicates.scss
@@ -46,8 +46,10 @@ driver-duplicates-list {
     .duplicate-details {
         width: 50%;
         display: inline-block;
-        border: 1px solid #e5e5e5;
+        border-right: 1px solid #e5e5e5;
+        border-left: 1px solid #e5e5e5;
         padding: 20px 15px 30px;
+        vertical-align: top;
     }
 
     .modal-footer {

--- a/web/app/styles/partials/_duplicates.scss
+++ b/web/app/styles/partials/_duplicates.scss
@@ -1,0 +1,33 @@
+.duplicates-title {
+    width: 100%;
+    position: fixed;
+    z-index: 8;
+    top: 52px;
+    height: 50px !important;
+    padding: 0px 14px !important;
+    background: #f1f2f2;
+}
+
+driver-duplicates-list {
+    position: fixed;
+    top: 105px;
+    width: 100%;
+    bottom: 0;
+    overflow: scroll;
+
+    .modal-footer {
+        margin-top: 50px;
+        margin-bottom: 0;
+        padding-top: 10px;
+        padding-bottom: 0;
+    }
+    .links a {
+        cursor: pointer;
+    }
+    .links {
+        min-width: 105px;
+    }
+    .date {
+        min-width: 70px;
+    }
+}

--- a/web/app/styles/partials/_filterbar.scss
+++ b/web/app/styles/partials/_filterbar.scss
@@ -67,25 +67,7 @@
         padding: 15px;
     }
     .close {
-        position: absolute;
-        right: -15px;
-        top: -15px;
-        background: white;
-        padding: 8px;
-        opacity: 1;
-        box-shadow: 0 0 5px rgba(0,0,0,0.25);
-        width: 30px;
-        height: 30px;
-        line-height: 0.6;
-        text-align: center;
-        border-radius: 999px;
-        color: #999;
-        transition: 0.5s all;
-
-        &:hover {
-            color: #000;
-            box-shadow: 0 0 5px rgba(0,0,0,0.45);
-        }
+        @include close-modal();
     }
     form {
         background-color: white;

--- a/web/app/styles/partials/_incident-report.scss
+++ b/web/app/styles/partials/_incident-report.scss
@@ -69,25 +69,7 @@
         .glyphicon { font-size: 12px; margin-right: 3px; }
     }
     .close {
-        position: absolute;
-        right: -15px;
-        top: -15px;
-        background: white;
-        padding: 8px;
-        opacity: 1;
-        box-shadow: 0 0 5px rgba(0,0,0,0.25);
-        width: 30px;
-        height: 30px;
-        line-height: 0.6;
-        text-align: center;
-        border-radius: 999px;
-        color: #999;
-        transition: 0.5s all;
-
-        &:hover {
-            color: #000;
-            box-shadow: 0 0 5px rgba(0,0,0,0.45);
-        }
+        @include close-modal();
     }
     .alert {
         margin: 15px 0 0;

--- a/web/test/karma.conf.js
+++ b/web/test/karma.conf.js
@@ -113,6 +113,8 @@ module.exports = function(config) {
       'app/scripts/views/login/**.js',
       'app/scripts/views/dashboard/module.js',
       'app/scripts/views/dashboard/**.js',
+      'app/scripts/views/duplicates/module.js',
+      'app/scripts/views/duplicates/**.js',
       'app/scripts/views/map/module.js',
       'app/scripts/views/map/**.js',
       'app/scripts/views/record/module.js',

--- a/web/test/mock/resources/driver-resources-mocks.js
+++ b/web/test/mock/resources/driver-resources-mocks.js
@@ -3,77 +3,81 @@
 
     function DriverResourcesMock () {
 
+        var RecordList = [
+            {
+                'uuid': '35d74ce1-7b08-486b-b791-da9bc1e93cfb',
+                'archived': false,
+                'data': {
+                    'Person': [],
+                    'Crime Details': {
+                        'County': 'Philadelphia',
+                        'Description': 'First test',
+                        'District': '13',
+                        '_localId': 'e116f30b-e493-4d57-9797-a901abddf7d5'
+                    },
+                    'Vehicle': []
+                },
+                'created': '2015-07-30T17:36:29.483160Z',
+                'modified': '2015-07-30T17:36:29.483206Z',
+                'occurred_from': '2015-07-30T17:36:29.263000Z',
+                'occurred_to': '2015-07-30T17:36:29.263000Z',
+                'geom': {
+                    'type': 'Point',
+                    'coordinates': [
+                        25.0,
+                        75.0
+                    ]
+                },
+                'location_text': '',
+                'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
+            },
+            {
+                'uuid': '57dd6700-6e87-4110-ab11-dc7eefc50c96',
+                'archived': false,
+                'data': {
+                    'Person': [
+                        {
+                            'Last name': 'John',
+                            'First name': 'Smith',
+                            'Street address': '3 Test St.',
+                            '_localId': '4cde1cc9-2cd2-487b-983d-ae1de1d6198c'
+                        },
+                        {
+                            'Last name': 'Jane',
+                            'First name': 'Doe',
+                            'Street address': '4 Test Ln.',
+                            '_localId': 'b383cf8c-95f2-46de-aaed-d05115db8d4d'
+                        }
+                    ],
+                    'Crime Details': {
+                        'County': 'Philadelphia',
+                        'Description': 'Second test',
+                        'District': '14',
+                        '_localId': '2382abab-0958-4aef-a1f6-ccca379ae9a4'
+                    },
+                    'Vehicle': []
+                },
+                'created': '2015-07-30T18:02:30.979249Z',
+                'modified': '2015-07-30T18:02:30.979305Z',
+                'occurred_from': '2015-07-30T18:02:30.944000Z',
+                'occurred_to': '2015-07-30T18:02:30.944000Z',
+                'geom': {
+                    'type': 'Point',
+                    'coordinates': [
+                        0.0,
+                        0.0
+                    ]
+                },
+                'location_text': '',
+                'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
+            }
+        ];
+
         var RecordResponse = {
             'count': 2,
             'next': null,
             'previous': null,
-            'results': [
-                {
-                    'uuid': '35d74ce1-7b08-486b-b791-da9bc1e93cfb',
-                    'data': {
-                        'Person': [],
-                        'Crime Details': {
-                            'County': 'Philadelphia',
-                            'Description': 'First test',
-                            'District': '13',
-                            '_localId': 'e116f30b-e493-4d57-9797-a901abddf7d5'
-                        },
-                        'Vehicle': []
-                    },
-                    'created': '2015-07-30T17:36:29.483160Z',
-                    'modified': '2015-07-30T17:36:29.483206Z',
-                    'occurred_from': '2015-07-30T17:36:29.263000Z',
-                    'occurred_to': '2015-07-30T17:36:29.263000Z',
-                    'geom': {
-                        'type': 'Point',
-                        'coordinates': [
-                            25.0,
-                            75.0
-                        ]
-                    },
-                    'location_text': '',
-                    'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
-                },
-                {
-                    'uuid': '57dd6700-6e87-4110-ab11-dc7eefc50c96',
-                    'data': {
-                        'Person': [
-                            {
-                                'Last name': 'John',
-                                'First name': 'Smith',
-                                'Street address': '3 Test St.',
-                                '_localId': '4cde1cc9-2cd2-487b-983d-ae1de1d6198c'
-                            },
-                            {
-                                'Last name': 'Jane',
-                                'First name': 'Doe',
-                                'Street address': '4 Test Ln.',
-                                '_localId': 'b383cf8c-95f2-46de-aaed-d05115db8d4d'
-                            }
-                        ],
-                        'Crime Details': {
-                            'County': 'Philadelphia',
-                            'Description': 'Second test',
-                            'District': '14',
-                            '_localId': '2382abab-0958-4aef-a1f6-ccca379ae9a4'
-                        },
-                        'Vehicle': []
-                    },
-                    'created': '2015-07-30T18:02:30.979249Z',
-                    'modified': '2015-07-30T18:02:30.979305Z',
-                    'occurred_from': '2015-07-30T18:02:30.944000Z',
-                    'occurred_to': '2015-07-30T18:02:30.944000Z',
-                    'geom': {
-                        'type': 'Point',
-                        'coordinates': [
-                            0.0,
-                            0.0
-                        ]
-                    },
-                    'location_text': '',
-                    'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
-                }
-            ]
+            'results': RecordList
         };
 
         var BoundaryResponse = {
@@ -369,6 +373,25 @@
                 num_severe: 'num_severe'
             }]
         };
+
+        var DuplicatesResponse = {
+            'count': 1,
+            'next': null,
+            'previous': null,
+            'results': [
+                {
+                    uuid: '0cf5604a-a743-4c30-9fc2-a8820d543fd8',
+                    created: '2016-02-03T19:20:31.266354Z',
+                    modified: '2016-02-08T14:51:51.169961Z',
+                    score: 0.0,
+                    resolved: true,
+                    job: '05b59583-2776-458c-835d-b7747a82b7d9',
+                    record: RecordList[0],
+                    duplicate_record: RecordList[1]
+                }
+            ]
+        };
+
         return {
             BoundaryResponse: BoundaryResponse,
             PolygonResponse: PolygonResponse,
@@ -376,7 +399,8 @@
             SavedFiltersResponse: SavedFiltersResponse,
             SSOClientsResponse: SSOClientsResponse,
             BlackspotSetResponse: BlackspotSetResponse,
-            BlackspotResponse: BlackspotResponse
+            BlackspotResponse: BlackspotResponse,
+            DuplicatesResponse: DuplicatesResponse
         };
     }
 

--- a/web/test/spec/resources/query-builder-service-spec.js
+++ b/web/test/spec/resources/query-builder-service-spec.js
@@ -37,7 +37,7 @@ describe('driver.resources: QueryBuilder', function () {
 
     it('should result in a call out to determine the selected RecordType and use the date filtering on FilterState', function () {
         // 2015-10-05 is 2015-10-04T16:00:00.000Z in local Manila time
-        var recordsUrl = /\/api\/records\/\?limit=50&occurred_min=2015-10-04T16:00:00.000Z&record_type=15460346-65d7-4f4d-944d-27324e224691/;
+        var recordsUrl = /\/api\/records\/\?archived=false&limit=50&occurred_min=2015-10-04T16:00:00.000Z&record_type=15460346-65d7-4f4d-944d-27324e224691/;
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
         var recordSchemaUrl = /\/api\/recordschemas/;
 

--- a/web/test/spec/views/duplicates/duplicates-list-controller.spec.js
+++ b/web/test/spec/views/duplicates/duplicates-list-controller.spec.js
@@ -1,0 +1,136 @@
+'use strict';
+
+describe('driver.views.duplicates: DuplicatesListController', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('driver.mock.resources'));
+    beforeEach(module('driver.views.duplicates'));
+
+    var $controller;
+    var $httpBackend;
+    var $rootScope;
+    var $scope;
+    var Controller;
+    var ModalController;
+    var DriverResourcesMock;
+    var ResourcesMock;
+    var InitialState;
+
+    // Initialize the controller and a mock scope
+    beforeEach(function () {
+        inject(function (_$controller_, _$httpBackend_, _$rootScope_,
+                                _DriverResourcesMock_, _ResourcesMock_, _InitialState_) {
+            $controller = _$controller_;
+            $httpBackend = _$httpBackend_;
+            $rootScope = _$rootScope_;
+            $scope = $rootScope.$new();
+            DriverResourcesMock = _DriverResourcesMock_;
+            ResourcesMock = _ResourcesMock_;
+            InitialState = _InitialState_;
+
+            InitialState.setRecordTypeInitialized();
+            InitialState.setBoundaryInitialized();
+            InitialState.setGeographyInitialized();
+
+            var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
+
+            var recordSchema = ResourcesMock.RecordSchema;
+            var recordSchemaId = recordSchema.uuid;
+            var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchemaId);
+
+            var recordType = ResourcesMock.RecordType;
+            var recordTypeId = recordType.uuid;
+
+            $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+            $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+            $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
+
+            Controller = $controller('DuplicatesListController', {
+                $scope: $scope,
+            });
+
+            var duplicatesOffsetUrl = /api\/duplicates\//;
+            $httpBackend.expectGET(duplicatesOffsetUrl).respond(200, DriverResourcesMock.DuplicatesResponse);
+            $httpBackend.flush();
+            $httpBackend.verifyNoOutstandingRequest();
+        });
+    });
+
+    it('should have header keys', function () {
+        expect(Controller.headerKeys.length).toBeGreaterThan(0);
+    });
+
+    it('should make offset requests for pagination', function () {
+        var duplicatesOffsetUrl = new RegExp('api/duplicates/\\?.*limit=50.*');
+        Controller.getNextDuplicates();
+        duplicatesOffsetUrl = duplicatesOffsetUrl = new RegExp('api/duplicates/\\?.*limit=50.*offset=50.*');
+        $httpBackend.expectGET(duplicatesOffsetUrl).respond(200, DriverResourcesMock.DuplicatesResponse);
+        $httpBackend.flush();
+
+        Controller.getPreviousDuplicates();
+        duplicatesOffsetUrl = new RegExp('api/duplicates/\\?.*limit=50.*');
+        $httpBackend.expectGET(duplicatesOffsetUrl).respond(200, DriverResourcesMock.DuplicatesResponse);
+        $httpBackend.flush();
+
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    describe('driver.views.duplicates: ResolveDuplicateModalController', function () {
+        var ModalInstance;
+
+        beforeEach(function () {
+            ModalInstance = {
+                close: jasmine.createSpy('ModalInstance.close')
+            };
+            ModalController = $controller('ResolveDuplicateModalController', {
+                $scope: $scope,
+                $modalInstance: ModalInstance,
+                params: {
+                    duplicate: DriverResourcesMock.DuplicatesResponse.results[0],
+                    duplicatesList: DriverResourcesMock.DuplicatesResponse.results,
+                    recordType: Controller.recordType,
+                    recordSchema: Controller.recordSchema,
+                    properties: Controller.headerKeys,
+                    propertyName: Controller.detailsProperty
+                }
+            });
+            $scope.$apply();
+
+            ModalController.params.duplicate.resolved = false;
+        });
+
+        it('should initialize the modal controller and be able to close it', function () {
+            expect(ModalController.params.duplicate.record).toEqual(
+                DriverResourcesMock.DuplicatesResponse.results[0].record);
+
+            ModalController.close();
+            expect(ModalInstance.close).toHaveBeenCalled();
+            expect(ModalController.params.duplicate.resolved).toBe(false);
+        });
+
+        it('should call resolve when "keep both" is chosen', function () {
+            var dupID = ModalController.params.duplicate.uuid;
+            var resolveDuplicateUrl = new RegExp('api/duplicates/' + dupID + '/resolve/');
+            ModalController.keepBoth();
+            $httpBackend.expectPATCH(resolveDuplicateUrl, { uuid: dupID })
+                .respond(200, { resolved: [dupID] });
+            $httpBackend.flush();
+            $httpBackend.verifyNoOutstandingRequest();
+            expect(ModalController.params.duplicate.resolved).toBe(true);
+            expect(ModalInstance.close).toHaveBeenCalled();
+        });
+
+        it('should call resolve with a record ID when one is chosen', function () {
+            var dupID = ModalController.params.duplicate.uuid;
+            var recordID = ModalController.params.duplicate.record.uuid;
+            var resolveDuplicateUrl = new RegExp('api/duplicates/' + dupID + '/resolve/');
+            ModalController.selectRecord(recordID);
+            $httpBackend.expectPATCH(resolveDuplicateUrl, { uuid: dupID, recordUUID: recordID })
+                .respond(200, { resolved: [dupID] });
+            $httpBackend.flush();
+            $httpBackend.verifyNoOutstandingRequest();
+            expect(ModalController.params.duplicate.resolved).toBe(true);
+            expect(ModalInstance.close).toHaveBeenCalled();
+        });
+    });
+});

--- a/web/test/spec/views/duplicates/duplicates-list-controller.spec.js
+++ b/web/test/spec/views/duplicates/duplicates-list-controller.spec.js
@@ -17,44 +17,42 @@ describe('driver.views.duplicates: DuplicatesListController', function () {
     var InitialState;
 
     // Initialize the controller and a mock scope
-    beforeEach(function () {
-        inject(function (_$controller_, _$httpBackend_, _$rootScope_,
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_,
                                 _DriverResourcesMock_, _ResourcesMock_, _InitialState_) {
-            $controller = _$controller_;
-            $httpBackend = _$httpBackend_;
-            $rootScope = _$rootScope_;
-            $scope = $rootScope.$new();
-            DriverResourcesMock = _DriverResourcesMock_;
-            ResourcesMock = _ResourcesMock_;
-            InitialState = _InitialState_;
+        $controller = _$controller_;
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        DriverResourcesMock = _DriverResourcesMock_;
+        ResourcesMock = _ResourcesMock_;
+        InitialState = _InitialState_;
 
-            InitialState.setRecordTypeInitialized();
-            InitialState.setBoundaryInitialized();
-            InitialState.setGeographyInitialized();
+        InitialState.setRecordTypeInitialized();
+        InitialState.setBoundaryInitialized();
+        InitialState.setGeographyInitialized();
 
-            var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
+        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
 
-            var recordSchema = ResourcesMock.RecordSchema;
-            var recordSchemaId = recordSchema.uuid;
-            var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchemaId);
+        var recordSchema = ResourcesMock.RecordSchema;
+        var recordSchemaId = recordSchema.uuid;
+        var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchemaId);
 
-            var recordType = ResourcesMock.RecordType;
-            var recordTypeId = recordType.uuid;
+        var recordType = ResourcesMock.RecordType;
+        var recordTypeId = recordType.uuid;
 
-            $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-            $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-            $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 
-            Controller = $controller('DuplicatesListController', {
-                $scope: $scope,
-            });
-
-            var duplicatesOffsetUrl = /api\/duplicates\//;
-            $httpBackend.expectGET(duplicatesOffsetUrl).respond(200, DriverResourcesMock.DuplicatesResponse);
-            $httpBackend.flush();
-            $httpBackend.verifyNoOutstandingRequest();
+        Controller = $controller('DuplicatesListController', {
+            $scope: $scope,
         });
-    });
+
+        var duplicatesOffsetUrl = /api\/duplicates\//;
+        $httpBackend.expectGET(duplicatesOffsetUrl).respond(200, DriverResourcesMock.DuplicatesResponse);
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    }));
 
     it('should have header keys', function () {
         expect(Controller.headerKeys.length).toBeGreaterThan(0);

--- a/web/test/spec/views/duplicates/duplicates-list-directive.spec.js
+++ b/web/test/spec/views/duplicates/duplicates-list-directive.spec.js
@@ -1,0 +1,58 @@
+'use strict';
+
+describe('driver.views.duplicates: Duplicates List Directive', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('driver.mock.resources'));
+    beforeEach(module('ase.templates'));
+    beforeEach(module('driver.views.duplicates'));
+    beforeEach(module('driver.views.record'));
+
+    var $compile;
+    var $httpBackend;
+    var $rootScope;
+    var $scope;
+    var DriverResourcesMock;
+    var ResourcesMock;
+    var InitialState;
+
+    var Element;
+
+    beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_,
+                                _DriverResourcesMock_, _ResourcesMock_, _InitialState_) {
+        $compile = _$compile_;
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+        DriverResourcesMock = _DriverResourcesMock_;
+        ResourcesMock = _ResourcesMock_;
+        InitialState = _InitialState_;
+
+        InitialState.setRecordTypeInitialized();
+        InitialState.setBoundaryInitialized();
+        InitialState.setGeographyInitialized();
+
+        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
+
+        var recordSchema = ResourcesMock.RecordSchema;
+        var recordSchemaId = recordSchema.uuid;
+        var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchemaId);
+
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
+
+        $scope = $rootScope.$new();
+        Element = $compile('<driver-duplicates-list></driver-duplicates-list>')($scope);
+        $rootScope.$apply();
+
+        var duplicatesOffsetUrl = /api\/duplicates\//;
+        $httpBackend.expectGET(duplicatesOffsetUrl).respond(200, DriverResourcesMock.DuplicatesResponse);
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    }));
+
+    it('should load directive', function () {
+        expect(Element.find('.duplicates-title').length).toBe(1);
+        expect(Element.find('tbody tr').length).toBe(1);
+    });
+});

--- a/web/test/spec/views/record/list-controller.spec.js
+++ b/web/test/spec/views/record/list-controller.spec.js
@@ -88,7 +88,7 @@ describe('driver.views.record: ListController', function () {
         $httpBackend.flush();
 
         $rootScope.$broadcast('driver.filterbar:changed', {});
-        var recordOffsetUrl = new RegExp('api/records/\\?limit=50.*');
+        var recordOffsetUrl = new RegExp('api/records/\\?.*limit=50.*');
         $httpBackend.expectGET(recordOffsetUrl).respond(200, DriverResourcesMock.RecordResponse);
         $httpBackend.flush();
 
@@ -98,7 +98,7 @@ describe('driver.views.record: ListController', function () {
         $httpBackend.flush();
 
         Controller.getPreviousRecords();
-        recordOffsetUrl = new RegExp('api/records/\\?limit=50.*');
+        recordOffsetUrl = new RegExp('api/records/\\?.*limit=50.*');
         $httpBackend.expectGET(recordOffsetUrl).respond(200, DriverResourcesMock.RecordResponse);
         $httpBackend.flush();
 

--- a/web/test/spec/views/record/list-controller.spec.js
+++ b/web/test/spec/views/record/list-controller.spec.js
@@ -93,7 +93,7 @@ describe('driver.views.record: ListController', function () {
         $httpBackend.flush();
 
         Controller.getNextRecords();
-        recordOffsetUrl = recordOffsetUrl = new RegExp('api/records/\\?limit=50.*offset=50.*');
+        recordOffsetUrl = recordOffsetUrl = new RegExp('api/records/\\?.*limit=50.*offset=50.*');
         $httpBackend.expectGET(recordOffsetUrl).respond(200, DriverResourcesMock.RecordResponse);
         $httpBackend.flush();
 


### PR DESCRIPTION
This includes the changes from PR #389 (duplicates API endpoints and list view) and adds tests for that stuff plus the modal to display duplicate records side-by-side and resolve the duplicate.

~~As noted in a comment on PR #391 (https://github.com/WorldBank-Transport/DRIVER/pull/391#issuecomment-179874866), when there are multiple duplicates of a record (AB, AC, BC) and the user chooses one of the duplicate records as better (e.g. resolves AB with B) the other duplicates for that record (i.e. AC) also also get resolved. But resolving a duplicate with the first record doesn't have that effect (choosing A for AB doesn't affect BC).~~

The query isn't filtering by resolved status.  Probably it should, but I wasn't sure what the ideal interaction would look like--I don't think we want resolved duplicates to disappear instantly, but I don't know if we want an explicit filter setting, a refresh button, or just to clear duplicates when they refresh the page or use the next and previous links.  So I thought maybe that would be a later task with design input.

This depends on the feature/add-record-archived-property branch of Ashlar. I changed dev-requirements.txt accordingly for testing, but will throw that change away before merging.