### PR TITLE
Feature/intervention state2

### DIFF
--- a/schema_editor/test/mock/resources/resources-mocks.js
+++ b/schema_editor/test/mock/resources/resources-mocks.js
@@ -107,7 +107,7 @@
         };
 
         var RecordTypeResponse = {
-            'count': 2,
+            'count': 3,
             'next': null,
             'previous': null,
             'results': [
@@ -120,6 +120,16 @@
                     'plural_label':'Accidents',
                     'description':'An accident.',
                     'active':true
+                },
+                {
+                    'uuid': '99eeb841-31cf-4059-a408-070a0853c875',
+                    'current_schema': 'd71e6475-e328-41d3-8e1f-556ab4145129',
+                    'created': '2016-02-02T19:10:58.039863Z',
+                    'modified': '2016-02-02T19:10:58.039897Z',
+                    'label': 'Intervention',
+                    'plural_label': 'Interventions',
+                    'description': 'Actions to improve traffic safety',
+                    'active': true
                 },
                 {
                     'uuid':'1a8232f4-2fe8-4df0-9c78-786f666b3551',
@@ -135,6 +145,9 @@
         };
 
         var RecordType = RecordTypeResponse.results[0];
+
+        var SecondaryRecordType = RecordTypeResponse.results[1];
+
         var RecordSchemaRequest = angular.extend({}, RecordType, {
             definitions: {
                 'Accident Details': {
@@ -172,10 +185,10 @@
         };
 
         var UsersResponse = {
-            "count": 4,
-            "next": null,
-            "previous": null,
-            "results": [
+            'count': 4,
+            'next': null,
+            'previous': null,
+            'results': [
                 {
                     'id': 2,
                     'url': 'http://localhost:7000/api/users/2/',
@@ -205,6 +218,7 @@
             RecordSchemaResponse: RecordSchemaResponse,
             RecordSchemaRequest: RecordSchemaRequest,
             RecordType: RecordType,
+            SecondaryRecordType: SecondaryRecordType,
             RecordTypeResponse: RecordTypeResponse,
             UserInfoResponse: UserInfoResponse,
             AdminUserInfoResponse: AdminUserInfoResponse,

--- a/schema_editor/test/spec/resources/recordtypes-service.spec.js
+++ b/schema_editor/test/spec/resources/recordtypes-service.spec.js
@@ -19,7 +19,7 @@ describe('ase.resources: RecordTypes', function () {
         var requestUrl = /\/api\/recordtypes/;
         $httpBackend.whenGET(requestUrl).respond(ResourcesMock.RecordTypeResponse);
         RecordTypes.query({ active: 'True' }).$promise.then(function (data) {
-            expect(data.length).toBe(2);
+            expect(data.length).toBe(3);
 
             var recordType = data[0];
             expect(recordType.label).toEqual(jasmine.any(String));

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -115,6 +115,7 @@
                 selected = null;
             }
             localStorageService.set('recordtype.selected', selected);
+            localStorageService.set('secondaryrecordtype.selected', secondaryType);
             $rootScope.$broadcast('driver.state.recordstate:selected', selected);
             return selected;
         }

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -10,6 +10,7 @@
                          InitialState, RecordTypes, WebConfig) {
         var defaultParams,
             selected,
+            secondaryType,
             options,
             gettingSelected,
             selectedPromise,
@@ -85,11 +86,21 @@
                     selection = _.find(options, function(d) {
                         return d.label === WebConfig.recordType.primaryLabel;
                     });
+                    secondaryType = _.find(options, function(d) {
+                      return d.label === WebConfig.recordType.secondaryLabel;
+                    });
                 } else {
                     var oldRecordType = localStorageService.get('recordtype.selected');
                     if (oldRecordType) {
                         selection = _.find(options, function(d) {
                             return d.uuid === oldRecordType.uuid;
+                        });
+                    }
+
+                    var oldSecondaryType = localStorageService.get('secondaryrecordtype.selected');
+                    if (oldSecondaryType) {
+                        secondaryType = _.find(options, function(d) {
+                            return d.uuid === oldSecondaryType.uuid;
                         });
                     }
                 }

--- a/web/test/mock/resources/driver-resources-mocks.js
+++ b/web/test/mock/resources/driver-resources-mocks.js
@@ -55,26 +55,44 @@
                         'District': '14',
                         '_localId': '2382abab-0958-4aef-a1f6-ccca379ae9a4'
                     },
-                    'Vehicle': []
+                    'location_text': '',
+                    'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
+                }
+            },
+            {
+                "uuid": "80621b6f-4036-45c5-940b-796f23ea0185",
+                "data": {
+                    "interventionDetails": {
+                        "Type": "Intersection - Roundabout",
+                        "_localId": "dddb643b-18ae-4b3d-8eba-e3d59c7fb14f"
+                    }
                 },
-                'created': '2015-07-30T18:02:30.979249Z',
-                'modified': '2015-07-30T18:02:30.979305Z',
-                'occurred_from': '2015-07-30T18:02:30.944000Z',
-                'occurred_to': '2015-07-30T18:02:30.944000Z',
-                'geom': {
-                    'type': 'Point',
-                    'coordinates': [
-                        0.0,
-                        0.0
+                "created": "2016-02-02T19:11:00.479893Z",
+                "modified": "2016-02-02T19:11:00.479924Z",
+                "occurred_from": "2016-02-02T06:11:00.395264Z",
+                "occurred_to": "2016-02-02T06:11:00.395273Z",
+                "geom": {
+                    "type": "Point",
+                    "coordinates": [
+                        121.03756381620197,
+                        14.644203676970669
                     ]
                 },
-                'location_text': '',
-                'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
+                "location_text": null,
+                "city": null,
+                "city_district": null,
+                "county": null,
+                "neighborhood": null,
+                "road": null,
+                "state": null,
+                "weather": null,
+                "light": null,
+                "schema": "d71e6475-e328-41d3-8e1f-556ab4145129"
             }
         ];
 
         var RecordResponse = {
-            'count': 2,
+            'count': 3,
             'next': null,
             'previous': null,
             'results': RecordList

--- a/web/test/spec/resources/records-service.spec.js
+++ b/web/test/spec/resources/records-service.spec.js
@@ -19,7 +19,7 @@ describe('driver.resources: Records', function () {
         var requestUrl = /\/api\/records/;
         $httpBackend.whenGET(requestUrl).respond(DriverResourcesMock.RecordResponse);
         Records.query({ active: 'True' }).$promise.then(function (data) {
-            expect(data.length).toBe(2);
+            expect(data.length).toBe(3);
 
             var record = data[0];
             expect(record.schema).toEqual(jasmine.any(String));


### PR DESCRIPTION
Save intervention type to record state object and modifies mock data.

Doesn't pull in schema to the state object to be consistent with how accident data is handled (can be changed) and I think writing it goes hand in hand with the next step which is to put the data on the map. 
Intentionally titles interventions related variables as secondary records to maintain code reusability.