### PR TITLE
Add conf modal and remove resolved dups from the list

### DIFF
--- a/web/app/scripts/resources/duplicates-service.js
+++ b/web/app/scripts/resources/duplicates-service.js
@@ -5,7 +5,7 @@
     function Duplicates($resource, WebConfig) {
         var baseUrl = WebConfig.api.hostname + '/api/duplicates/:id/';
         return $resource(baseUrl,
-                         {id: '@uuid', limit: 'all'}, {
+                         {id: '@uuid', limit: 'all', resolved: 'False'}, {
             get: {
                 method: 'GET'
             },

--- a/web/app/scripts/views/duplicates/duplicates-list-controller.js
+++ b/web/app/scripts/views/duplicates/duplicates-list-controller.js
@@ -44,8 +44,10 @@
             var newOffset;
             if (offset) {
                 newOffset = ctl.currentOffset + offset;
-            } else {
+            } else if (offset === 0) {
                 newOffset = 0;
+            } else {
+                newOffset = ctl.currentOffset;
             }
 
             /* jshint camelcase: false */
@@ -106,7 +108,6 @@
                     params: function() {
                         return {
                             duplicate: duplicate,
-                            duplicatesList: ctl.duplicates.results,
                             recordType: ctl.recordType,
                             recordSchema: ctl.recordSchema,
                             properties: ctl.headerKeys,
@@ -114,6 +115,8 @@
                         };
                     }
                 }
+            }).result.then(function () {
+                loadDuplicates();
             });
         }
     }

--- a/web/app/scripts/views/duplicates/duplicates-list-partial.html
+++ b/web/app/scripts/views/duplicates/duplicates-list-partial.html
@@ -9,7 +9,6 @@
                         <th class="detail">Location</th>
                         <th class="date">Date &amp; Time</th>
                         <th class="detail">Location</th>
-                        <th>Status</th>
                         <!-- Resolve link -->
                         <th class="links"></th>
                     </tr>
@@ -22,8 +21,6 @@
                         <td ng-repeat-end class="detail">
                             {{ ::record.location_text }}
                         </td>
-                        <td>{{ dup.resolved ? 'Resolved' : 'Potential Duplicate' }}</td>
-
                         <td class="links">
                             <a ng-if="ctl.userCanWrite &amp;&amp; !dup.resolved"
                                ng-click="ctl.showResolveModal(dup)">

--- a/web/app/scripts/views/duplicates/resolve-duplicate-confirmation-modal-partial.html
+++ b/web/app/scripts/views/duplicates/resolve-duplicate-confirmation-modal-partial.html
@@ -1,0 +1,10 @@
+<div class="confirmation-modal">
+    <div class="modal-body">
+        Are you sure you want to use this record, and archive the other record's data?
+        The other record will be retained for the future.
+    </div>
+    <div class="modal-footer">
+        <div class="select confirm" ng-click="$close()">Yes</div>
+        <div class="select dismiss" ng-click="$dismiss('cancel')">No</div>
+    </div>
+</div>

--- a/web/app/scripts/views/duplicates/resolve-duplicate-modal-partial.html
+++ b/web/app/scripts/views/duplicates/resolve-duplicate-modal-partial.html
@@ -1,5 +1,5 @@
 <div class="duplicate-modal">
-    <div class="close" ng-click="modal.close()">
+    <div class="close" ng-click="modal.dismiss()">
         &times;
     </div>
     <div class="modal-header">

--- a/web/app/styles/main.scss
+++ b/web/app/styles/main.scss
@@ -12,6 +12,7 @@ $icon-font-path: '../bower_components/bootstrap-sass-official/assets/fonts/boots
 
 @import 'partials/add-new';
 @import 'partials/duplicates';
+@import 'partials/confirmation_modal';
 @import 'partials/dashboard';
 @import 'partials/record-list';
 @import 'partials/field';

--- a/web/app/styles/partials/_confirmation_modal.scss
+++ b/web/app/styles/partials/_confirmation_modal.scss
@@ -1,0 +1,35 @@
+.confirmation-modal {
+    top: 175px;
+
+    .modal-content {
+        border-radius: 0;
+        border: none;
+    }
+
+    .modal-body {
+        width: 100%;
+        padding: 20px;
+    }
+
+    .modal-footer {
+        margin-top: -5px;
+        margin-bottom: 0;
+        padding: 0px;
+        padding-bottom: 0;
+        text-align: center;
+    }
+
+    .select {
+        width: 50%;
+        float: left;
+        padding: 10px;
+        text-transform: uppercase;
+        cursor: pointer;
+        border-right: 1px solid #e5e5e5;
+        color: #999;
+        font-weight: 700;
+        &:hover {
+            color: #000;
+        }
+    }
+}

--- a/web/app/styles/partials/_duplicates.scss
+++ b/web/app/styles/partials/_duplicates.scss
@@ -66,6 +66,8 @@ driver-duplicates-list {
         text-transform: uppercase;
         cursor: pointer;
         background: #ddd;
+        color: #999;
+        font-weight: 700;
         &:hover {
             background: #888;
             color: #fff;

--- a/web/test/mock/resources/driver-resources-mocks.js
+++ b/web/test/mock/resources/driver-resources-mocks.js
@@ -402,7 +402,7 @@
                     created: '2016-02-03T19:20:31.266354Z',
                     modified: '2016-02-08T14:51:51.169961Z',
                     score: 0.0,
-                    resolved: true,
+                    resolved: false,
                     job: '05b59583-2776-458c-835d-b7747a82b7d9',
                     record: RecordList[0],
                     duplicate_record: RecordList[1]

--- a/web/test/spec/views/duplicates/duplicates-list-controller.spec.js
+++ b/web/test/spec/views/duplicates/duplicates-list-controller.spec.js
@@ -11,7 +11,6 @@ describe('driver.views.duplicates: DuplicatesListController', function () {
     var $rootScope;
     var $scope;
     var Controller;
-    var ModalController;
     var DriverResourcesMock;
     var ResourcesMock;
     var InitialState;
@@ -36,9 +35,6 @@ describe('driver.views.duplicates: DuplicatesListController', function () {
         var recordSchema = ResourcesMock.RecordSchema;
         var recordSchemaId = recordSchema.uuid;
         var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchemaId);
-
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
 
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
@@ -71,64 +67,5 @@ describe('driver.views.duplicates: DuplicatesListController', function () {
         $httpBackend.flush();
 
         $httpBackend.verifyNoOutstandingRequest();
-    });
-
-    describe('driver.views.duplicates: ResolveDuplicateModalController', function () {
-        var ModalInstance;
-
-        beforeEach(function () {
-            ModalInstance = {
-                close: jasmine.createSpy('ModalInstance.close')
-            };
-            ModalController = $controller('ResolveDuplicateModalController', {
-                $scope: $scope,
-                $modalInstance: ModalInstance,
-                params: {
-                    duplicate: DriverResourcesMock.DuplicatesResponse.results[0],
-                    duplicatesList: DriverResourcesMock.DuplicatesResponse.results,
-                    recordType: Controller.recordType,
-                    recordSchema: Controller.recordSchema,
-                    properties: Controller.headerKeys,
-                    propertyName: Controller.detailsProperty
-                }
-            });
-            $scope.$apply();
-
-            ModalController.params.duplicate.resolved = false;
-        });
-
-        it('should initialize the modal controller and be able to close it', function () {
-            expect(ModalController.params.duplicate.record).toEqual(
-                DriverResourcesMock.DuplicatesResponse.results[0].record);
-
-            ModalController.close();
-            expect(ModalInstance.close).toHaveBeenCalled();
-            expect(ModalController.params.duplicate.resolved).toBe(false);
-        });
-
-        it('should call resolve when "keep both" is chosen', function () {
-            var dupID = ModalController.params.duplicate.uuid;
-            var resolveDuplicateUrl = new RegExp('api/duplicates/' + dupID + '/resolve/');
-            ModalController.keepBoth();
-            $httpBackend.expectPATCH(resolveDuplicateUrl, { uuid: dupID })
-                .respond(200, { resolved: [dupID] });
-            $httpBackend.flush();
-            $httpBackend.verifyNoOutstandingRequest();
-            expect(ModalController.params.duplicate.resolved).toBe(true);
-            expect(ModalInstance.close).toHaveBeenCalled();
-        });
-
-        it('should call resolve with a record ID when one is chosen', function () {
-            var dupID = ModalController.params.duplicate.uuid;
-            var recordID = ModalController.params.duplicate.record.uuid;
-            var resolveDuplicateUrl = new RegExp('api/duplicates/' + dupID + '/resolve/');
-            ModalController.selectRecord(recordID);
-            $httpBackend.expectPATCH(resolveDuplicateUrl, { uuid: dupID, recordUUID: recordID })
-                .respond(200, { resolved: [dupID] });
-            $httpBackend.flush();
-            $httpBackend.verifyNoOutstandingRequest();
-            expect(ModalController.params.duplicate.resolved).toBe(true);
-            expect(ModalInstance.close).toHaveBeenCalled();
-        });
     });
 });

--- a/web/test/spec/views/duplicates/resolve-duplicate-modal-controller.spec.js
+++ b/web/test/spec/views/duplicates/resolve-duplicate-modal-controller.spec.js
@@ -1,0 +1,90 @@
+'use strict';
+
+describe('driver.views.duplicates: ResolveDuplicateController', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('driver.mock.resources'));
+    beforeEach(module('ase.templates'));
+    beforeEach(module('driver.views.duplicates'));
+
+    var $controller;
+    var $httpBackend;
+    var $rootScope;
+    var $scope;
+    var $modal;
+    var Controller;
+    var ModalInstance;
+    var DriverResourcesMock;
+    var ResourcesMock;
+
+    // Initialize the controller and a mock scope
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_, _$modal_,
+                                _DriverResourcesMock_, _ResourcesMock_) {
+        $controller = _$controller_;
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        $modal = _$modal_;
+        DriverResourcesMock = _DriverResourcesMock_;
+        ResourcesMock = _ResourcesMock_;
+
+        var mockConfModal = {
+            result: {
+                then: function(confirmCallback) {
+                    return confirmCallback();
+                }
+            },
+        };
+
+        spyOn($modal, 'open').and.returnValue(mockConfModal);
+
+        ModalInstance = {
+            close: jasmine.createSpy('ModalInstance.close'),
+            dismiss: jasmine.createSpy('ModalInstance.dismiss')
+        };
+        Controller = $controller('ResolveDuplicateModalController', {
+            $scope: $scope,
+            $modalInstance: ModalInstance,
+            params: {
+                duplicate: DriverResourcesMock.DuplicatesResponse.results[0],
+                recordType: ResourcesMock.RecordType,
+                recordSchema: ResourcesMock.RecordSchema,
+                properties: {},
+                propertyName: 'Accident Details'
+            }
+        });
+        $scope.$apply();
+    }));
+
+    it('should initialize the modal controller and be able to close it', function () {
+        expect(Controller.params.duplicate.record).toEqual(
+            DriverResourcesMock.DuplicatesResponse.results[0].record);
+
+        Controller.dismiss();
+        expect(ModalInstance.dismiss).toHaveBeenCalled();
+    });
+
+    it('should call resolve when "keep both" is chosen', function () {
+        var dupID = Controller.params.duplicate.uuid;
+        var resolveDuplicateUrl = new RegExp('api/duplicates/' + dupID + '/resolve/');
+        Controller.keepBoth();
+        $httpBackend.expectPATCH(resolveDuplicateUrl, { uuid: dupID })
+            .respond(200, { resolved: [dupID] });
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+        expect(ModalInstance.close).toHaveBeenCalled();
+    });
+
+    it('should call resolve with a record ID when one is chosen', function () {
+        var dupID = Controller.params.duplicate.uuid;
+        var recordID = Controller.params.duplicate.record.uuid;
+        var resolveDuplicateUrl = new RegExp('api/duplicates/' + dupID + '/resolve/');
+        $httpBackend.expectPATCH(resolveDuplicateUrl, { uuid: dupID, recordUUID: recordID })
+            .respond(200, { resolved: [dupID] });
+        Controller.selectRecord(recordID);
+        expect($modal.open).toHaveBeenCalled();
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+        expect(ModalInstance.close).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
* Adds a confirmation when resolving a duplicate by picking a record
* Moves the post-resolution logic into the list controller
* Changes the post-resolution action from just showing 'Resolved' to
  reloading the list.
* Removes the 'Status' column from the list view, since it's not
  informative if we aren't showing resolved duplicates.