### PR TITLE
Add Export tool tab and CSV export interaction

### DIFF
--- a/app/data/tasks/export_csv.py
+++ b/app/data/tasks/export_csv.py
@@ -27,7 +27,10 @@ def export_csv(query_key):
     records = get_queryset_by_key(query_key)
     # Get the most recent Schema for the Records' RecordType
     # This assumes that all of the Records have the same RecordType.
-    schema = records[0].schema.record_type.get_current_schema()
+    try:
+        schema = records[0].schema.record_type.get_current_schema()
+    except IndexError:
+        raise Exception('Filter includes no records')
     # Create files and CSV Writers from Schema
     record_writer = AshlarRecordExporter(schema)
 

--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -105,6 +105,7 @@
     <script src="scripts/resources/module.js"></script>
     <script src="scripts/resources/boundaries-service.js"></script>
     <script src="scripts/resources/duplicates-service.js"></script>
+    <script src="scripts/resources/exports-service.js"></script>
     <script src="scripts/resources/polygons-service.js"></script>
     <script src="scripts/resources/records-service.js"></script>
     <script src="scripts/resources/query-builder-service.js"></script>
@@ -209,6 +210,9 @@
     <script src="scripts/charts/module.js"></script>
     <script src="scripts/charts/charts-controller.js"></script>
     <script src="scripts/charts/charts-directive.js"></script>
+    <script src="scripts/export/module.js"></script>
+    <script src="scripts/export/export-controller.js"></script>
+    <script src="scripts/export/export-directive.js"></script>
     <script src="scripts/weather/module.js"></script>
     <script src="scripts/weather/weather-label.js"></script>
     <script src="scripts/weather/weather-service.js"></script>

--- a/web/app/scripts/charts/charts-controller.js
+++ b/web/app/scripts/charts/charts-controller.js
@@ -2,7 +2,23 @@
     'use strict';
 
     /* ngInject */
-    function ChartsController() {
+    function ChartsController($rootScope, $scope) {
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            ctl.isOpen = false;
+            ctl.toggle = toggle;
+        }
+
+        function toggle() {
+            ctl.isOpen = !ctl.isOpen;
+            if (ctl.isOpen) {
+                $rootScope.$broadcast('driver.charts.open');
+            }
+        }
+
+        $scope.$on('driver.export.open', function () { ctl.isOpen = false; });
     }
 
     angular.module('driver.charts')

--- a/web/app/scripts/charts/charts-partial.html
+++ b/web/app/scripts/charts/charts-partial.html
@@ -1,9 +1,9 @@
-<div class="tool graphs" ng-init="open = false" ng-class="{ 'open': open }">
-    <div class="tool-tab" ng-click="open = !open" >
+<div class="tool graphs" ng-class="{ 'open': ctl.isOpen }">
+    <div class="tool-tab" ng-click="ctl.toggle()" >
         <span class="glyphicon glyphicon-list-alt"></span> Graphs
     </div>
     <div class="tool-content" ng-init="activeChart = 'toddow'">
-        <div class="graph-header">
+        <div class="tool-header">
             <span class="pull-right">
                 <span class="graph-selector glyphicon glyphicon-th"
                       ng-click="activeChart = 'toddow'"
@@ -18,7 +18,7 @@
             <h4>Graphs</h4>
         </div>
         <hr />
-        <div class="graph-content">
+        <div class="tool-body">
             <driver-toddow chart-data="ctl.toddow"
                            ng-show="activeChart === 'toddow'">
             </driver-toddow>

--- a/web/app/scripts/export/export-controller.js
+++ b/web/app/scripts/export/export-controller.js
@@ -1,0 +1,92 @@
+(function () {
+    'use strict';
+
+    /**
+     * Handles the interaction for CSV exports.
+     * Makes a request to start an export job then polls for the result and provides the link.
+     * Uses filter query parameters provided by MapController.
+     */
+
+    /* ngInject */
+    function ExportController($rootScope, $scope, $interval, Exports, InitialState, QueryBuilder) {
+        var ctl = this;
+        var pollingInterval;
+        var POLLING_INTERVAL_MS = 1500;
+        var MAX_POLLING_TIME_S = 100;
+
+        InitialState.ready().then(initialize);
+
+        function initialize() {
+            ctl.isOpen = false;
+            ctl.pending = false;
+            ctl.downloadURL = null;
+            ctl.error = null;
+
+            ctl.toggle = toggle;
+            ctl.exportCSV = exportCSV;
+        }
+
+        function toggle() {
+            ctl.isOpen = !ctl.isOpen;
+            if (ctl.isOpen) {
+                $rootScope.$broadcast('driver.export.open');
+            }
+        }
+
+        function exportCSV() {
+            cancelPolling();
+            ctl.error = null;
+            ctl.downloadURL = null;
+
+            var params = _.extend({ tilekey: true, limit: 0 }, ctl.recordQueryParams);
+            // Get a tilekey then trigger an export
+            QueryBuilder.djangoQuery(true, 0, params).then(function(records) {
+                Exports.create({ tilekey: records.tilekey },
+                    function (result) {pollForDownload(result.taskid); },
+                    function () { ctl.error = 'Error initializing export.'; }
+                );
+            });
+        }
+
+        function pollForDownload(taskID) {
+            ctl.pending = true;
+            pollingInterval = $interval(function () {
+                    Exports.get({ id: taskID }).$promise.then(function (response) {
+                        switch (response.status) {
+                            case 'PENDING':
+                            case 'STARTED':
+                                break;
+                            case 'FAILURE':
+                                ctl.error = response.error;
+                                cancelPolling();
+                                break;
+                            case 'SUCCESS':
+                                ctl.downloadURL = response.result;
+                                cancelPolling();
+                                break;
+                        }
+                    });
+                },
+                POLLING_INTERVAL_MS,
+                MAX_POLLING_TIME_S * 1000 / POLLING_INTERVAL_MS
+            );
+            // The interval's promise resolves if it hits the limit without being cancelled
+            pollingInterval.then(function () {
+                cancelPolling();
+                ctl.error = 'Export request timed out.';
+            });
+        }
+
+        function cancelPolling() {
+            ctl.pending = false;
+            $interval.cancel(pollingInterval);
+        }
+
+        $scope.$on('driver.charts.open', function () { ctl.isOpen = false; });
+        $scope.$on('$destroy', cancelPolling);
+    }
+
+    angular.module('driver.export')
+    .controller('ExportController', ExportController);
+
+})();

--- a/web/app/scripts/export/export-directive.js
+++ b/web/app/scripts/export/export-directive.js
@@ -1,0 +1,23 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Export() {
+        var module = {
+            restrict: 'AE',
+            templateUrl: 'scripts/export/export-partial.html',
+            controller: 'ExportController',
+            controllerAs: 'ctl',
+            bindToController: true,
+            scope: {
+                recordQueryParams: '=params'
+            },
+        };
+        return module;
+
+    }
+
+    angular.module('driver.export')
+    .directive('driverExport', Export);
+
+})();

--- a/web/app/scripts/export/export-partial.html
+++ b/web/app/scripts/export/export-partial.html
@@ -1,0 +1,34 @@
+<div class="tool export" ng-class="{ 'open': ctl.isOpen }">
+    <div class="tool-tab" ng-click="ctl.toggle()" >
+        <span class="glyphicon glyphicon-share"
+              ng-if="ctl.isOpen || (!ctl.pending && !ctl.downloadURL)"></span>
+        <cube-grid-spinner ng-if="!ctl.isOpen && ctl.pending"></cube-grid-spinner>
+        <span class="glyphicon glyphicon-download-alt"
+              ng-if="!ctl.isOpen && ctl.downloadURL && !ctl.pending"></span>
+        Export
+    </div>
+    <div class="tool-content">
+        <div class="tool-body">
+            <div class="export-item">
+                <span class="glyphicon glyphicon-th-list"></span>
+                Custom Report
+            </div>
+            <div class="export-item" ng-class="{ 'clickable': !ctl.pending }">
+                <div ng-if="!ctl.pending" ng-click="ctl.exportCSV()">
+                    <span class="glyphicon glyphicon-export"></span>
+                    <span ng-if="!ctl.downloadURL">Export CSV</span>
+                    <span ng-if="ctl.downloadURL">Export New CSV</span>
+                </div>
+                <div ng-if="ctl.pending">
+                    <cube-grid-spinner></cube-grid-spinner>
+                    Exporting CSV
+                </div>
+                <div class="error" ng-if="ctl.error">{{ ctl.error }}</div>
+            </div>
+            <div class="export-item" ng-if="ctl.downloadURL && !ctl.pending">
+                <span class="glyphicon glyphicon-download-alt"></span>
+                <a href="{{ ctl.downloadURL }}" download>Download CSV</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/web/app/scripts/export/module.js
+++ b/web/app/scripts/export/module.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    angular.module('driver.export', [
+        'ui.bootstrap',
+        'ui.router',
+        'driver.resources',
+        'angular-spinkit',
+    ]);
+
+})();

--- a/web/app/scripts/resources/exports-service.js
+++ b/web/app/scripts/resources/exports-service.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Exports($resource, WebConfig) {
+        return $resource(WebConfig.api.hostname + '/api/csv-export/:id/', {id: '@uuid'}, {
+            create: {
+                method: 'POST'
+            },
+            get: {
+                method: 'GET'
+            },
+        });
+    }
+
+    angular.module('driver.resources')
+    .factory('Exports', Exports);
+
+})();

--- a/web/app/scripts/views/map/map-controller.js
+++ b/web/app/scripts/views/map/map-controller.js
@@ -79,6 +79,7 @@
         function loadRecords() {
             /* jshint camelcase: false */
             var params = {};
+
             if (ctl.boundaryId) {
                 params.polygon_id = ctl.boundaryId;
             }
@@ -87,6 +88,8 @@
             if (userDrawnPoly) {
                 params.polygon = userDrawnPoly;
             }
+
+            ctl.recordQueryParams = params;
 
             RecordAggregates.stepwise(true, params).then(function(stepwiseData) {
                 // minDate and maxDate are important for determining where the barchart begins/ends

--- a/web/app/scripts/views/map/map-partial.html
+++ b/web/app/scripts/views/map/map-partial.html
@@ -6,5 +6,6 @@
                        max-date="ctl.maxDate"
                        toddow="ctl.toddow">
         </driver-charts>
+        <driver-export params="ctl.recordQueryParams"></driver-export>
     </div>
 </main>

--- a/web/app/scripts/views/map/module.js
+++ b/web/app/scripts/views/map/module.js
@@ -17,6 +17,7 @@
         'ui.bootstrap',
         'Leaflet',
         'driver.charts',
+        'driver.export',
         'driver.config',
         'driver.localization',
         'driver.map-layers',

--- a/web/app/styles/partials/_map-view.scss
+++ b/web/app/styles/partials/_map-view.scss
@@ -36,9 +36,37 @@
                     max-height: 300px;
                 }
             }
+            .tool-tab {
+                background: white;
+                padding: 16px 20px 16px;
+                position: relative;
+                bottom: -2px;
+                transition: 0.5s all;
+                cursor: pointer;
+            }
+            .tool-content {
+                width: 600px;
+                background: white;
+                max-height: 0;
+                bottom: 50px;
+                overflow: hidden;
+                position: absolute;
+                transition: 0.5s all;
+            }
+            .tool-header {
+                margin: 20px 15px 0 15px;
+            }
+            .tool-body {
+            }
+
             &.graphs {
                 .tool-content {
                     width: 600px;
+                }
+                .tool-body {
+                    margin: 25px 15px 20px 15px;
+                    height: 300px;
+                    padding: 0px;
                 }
             }
             &.interventions {
@@ -53,34 +81,33 @@
             }
             &.export {
                 .tool-content {
-                    width: 220px;
+                    width: 200px;
+                }
+                .export-item {
+                    padding: 15px;
+                    border-bottom: 1px solid #eeeeee;
+                    &.clickable {
+                        cursor: pointer;
+                    }
+                    a {
+                        color: inherit;
+                    }
+                }
+                .cube-grid-spinner {
+                    width: 15px;
+                    height: 15px;
+                    margin: 0px 0px -2px 0px;
+                    display: inline-block;
                 }
             }
 
-            .tool-tab {
-                background: white;
-                padding: 16px 20px 16px;
-                position: relative;
-                bottom: -2px;
-                transition: 0.5s all;
-                cursor: pointer;
+            .error {
+                background-color: #EF6055;
+                padding: 5px;
+                margin-top: 5px;
+                cursor: default;
             }
-            .tool-content {
-                width: 600px;
-                background: white;
-                max-height: 0;
-                height: 300px;
-                bottom: 50px;
-                overflow: hidden;
-                position: absolute;
-                transition: 0.5s all;
-            }
-            .graph-header {
-                margin: 20px 15px 0 15px;
-            }
-            .graph-content {
-                margin: 25px 15px 0 15px;
-            }
+
             .graph-selector {
                 cursor: pointer;
                 color: lightgrey;

--- a/web/test/karma.conf.js
+++ b/web/test/karma.conf.js
@@ -105,6 +105,8 @@ module.exports = function(config) {
       'app/scripts/stepwise/**.js',
       'app/scripts/charts/module.js',
       'app/scripts/charts/**.js',
+      'app/scripts/export/module.js',
+      'app/scripts/export/**.js',
       'app/scripts/weather/module.js',
       'app/scripts/weather/**.js',
       'app/scripts/views/account/module.js',

--- a/web/test/spec/export/export-controller.spec.js
+++ b/web/test/spec/export/export-controller.spec.js
@@ -1,0 +1,135 @@
+'use strict';
+
+describe('driver.export: ExportController', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('driver.mock.resources'));
+    beforeEach(module('driver.export'));
+
+    var $controller;
+    var $httpBackend;
+    var $scope;
+    var $interval;
+    var $rootScope;
+    var Controller;
+    var DriverResourcesMock;
+    var ResourcesMock;
+    var InitialState;
+
+    var ExportsMock = {
+        tilekeyResponse: { 'tilekey': 'valid-tilekey' },
+        taskID: 'this_is_a_task_id',
+        taskResponse: { 'taskid': 'this_is_a_task_id', 'success': true },
+        taskErrorResponse: { 'errors': {} },
+        startedResponse: { 'status': "STARTED", 'info': {} },
+        successResponse: { 'status': "SUCCESS", 'result': "http://localhost:7000/download/this_is_a_task_id" },
+        failureResponse: { 'status': 'FAILURE', 'error': 'The export job went kablooey.' },
+    };
+
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_, _$interval_,
+                                _DriverResourcesMock_, _ResourcesMock_, _InitialState_) {
+        $controller = _$controller_;
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        $interval = _$interval_;
+        DriverResourcesMock = _DriverResourcesMock_;
+        ResourcesMock = _ResourcesMock_;
+        InitialState = _InitialState_;
+
+        InitialState.setRecordTypeInitialized();
+        InitialState.setBoundaryInitialized();
+        InitialState.setGeographyInitialized();
+
+        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        var recordSchemaUrl = /\/api\/recordschemas\/\?limit=all/;
+        $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchemaResponse);
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+
+        $scope.recordQueryParams = {};
+        Controller = $controller('ExportController', { $scope: $scope });
+        $scope.$apply();
+    }));
+
+    it('should set an error message if the task creation call fails', function () {
+        expect(Controller.error).toBe(null);
+        var recordUrl = /\/api\/records\/\?.*tilekey=true/;
+        $httpBackend.expectGET(recordUrl).respond(200, ExportsMock.tilekeyResponse);
+        var startExportURL = new RegExp('/api/csv-export/');
+        $httpBackend.expectPOST(startExportURL).respond(400, ExportsMock.taskErrorResponse);
+        Controller.exportCSV();
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+        $scope.$apply();
+
+        expect(Controller.error).not.toBe(null);
+        expect(Controller.pending).toBe(false);
+    });
+
+    describe('driver.export: ExportController.pollForDownload', function () {
+        var statusURL;
+
+        beforeEach(function () {
+            var recordUrl = /\/api\/records\/\?.*tilekey=true/;
+            $httpBackend.expectGET(recordUrl).respond(ExportsMock.tilekeyResponse);
+
+            var startExportURL = new RegExp('/api/csv-export/');
+            $httpBackend.expectPOST(startExportURL).respond(201, ExportsMock.taskResponse);
+
+            Controller.exportCSV();
+
+            $httpBackend.flush();
+            $httpBackend.verifyNoOutstandingRequest();
+            $scope.$apply();
+
+            statusURL = new RegExp('/api/csv-export/' + ExportsMock.taskResponse.taskid + '/');
+
+            spyOn($interval, 'cancel').and.callThrough();
+        });
+
+        it('should call task creation API and start polling for status on success', function () {
+            // This tests the initial step. The actual work is done in the beforeEach.
+            expect(Controller.error).toBe(null);
+            expect(Controller.pending).toBe(true);
+        });
+
+        it('should poll for export status and save the download link on success', function () {
+            $httpBackend.expectGET(statusURL).respond(200, ExportsMock.startedResponse);
+            $interval.flush(1600);
+            $httpBackend.expectGET(statusURL).respond(200, ExportsMock.startedResponse);
+            $interval.flush(1500);
+            $httpBackend.expectGET(statusURL).respond(200, ExportsMock.successResponse);
+            $interval.flush(1500);
+            $httpBackend.flush();
+            $httpBackend.verifyNoOutstandingRequest();
+
+            expect($interval.cancel).toHaveBeenCalled();
+            expect(Controller.pending).toBe(false);
+            expect(Controller.downloadURL).toEqual(ExportsMock.successResponse.result);
+        });
+
+        it('should set an error message on failed export status', function () {
+            $httpBackend.expectGET(statusURL).respond(200, ExportsMock.failureResponse);
+            $interval.flush(1600);
+            $httpBackend.flush();
+            $httpBackend.verifyNoOutstandingRequest();
+
+            expect($interval.cancel).toHaveBeenCalled();
+            expect(Controller.pending).toBe(false);
+            expect(Controller.error).not.toBe(null);
+            expect(Controller.downloadURL).toBe(null);
+        });
+
+        it('should cancel polling and set an error when it times out', function () {
+            $httpBackend.whenGET(statusURL).respond(200, ExportsMock.startedResponse);
+            $interval.flush(1000000);
+            expect($interval.cancel).toHaveBeenCalled();
+            expect(Controller.pending).toBe(false);
+            expect(Controller.error).not.toBe(null);
+            expect(Controller.downloadURL).toBe(null);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Adds the 'Export' tab at the bottom of the map and makes the 'Export CSV' button work.  Clicking it hits the API to create a celery export job, then it polls that job until it succeeds (displaying "Exporting CSV" with an animation) and turns into a link to download it.

There's no model backing these exports and they're tied to tilekey, so hitting the export button gets you an export for your current filters, and if you change your filters it resets the tool.

The answer to the $interval testing mystery was that I needed to call $scope.$apply() again after flushing $httpBackend to resolve the job creation call so that the interval, which is a promise called inside the initial request's callback, would get processed.