### PR TITLE
Hide Audit Logs dropdown if user not admin

### DIFF
--- a/app/driver_auth/views.py
+++ b/app/driver_auth/views.py
@@ -17,12 +17,14 @@ from djangooidc.views import CLIENTS
 from ashlar.pagination import OptionalLimitOffsetPagination
 
 from driver_auth.serializers import UserSerializer, GroupSerializer
-from driver_auth.permissions import IsAdminOrReadSelfOnly, IsAdminOrReadOnly, is_admin_or_writer
+from driver_auth.permissions import (IsAdminOrReadSelfOnly, IsAdminOrReadOnly, is_admin_or_writer,
+                                     is_admin)
 
 # match what auth-service.js looks for
 USER_ID_COOKIE = 'AuthService.userId'
 TOKEN_COOKIE = 'AuthService.token'
 CAN_WRITE_COOKIE = 'AuthService.canWrite'
+ADMIN_COOKIE = 'AuthService.isAdmin'
 
 
 def authz_cb(request):
@@ -49,6 +51,8 @@ def authz_cb(request):
             # set cookie for frontend write access (will be false by default)
             if is_admin_or_writer(user):
                 response.set_cookie(CAN_WRITE_COOKIE, 'true')
+            if is_admin(user):
+                response.set_cookie(ADMIN_COOKIE, 'true')
             response.set_cookie(TOKEN_COOKIE, quote('"' + token.key + '"', safe=''))
             return response
         else:

--- a/web/app/scripts/navbar/navbar-controller.js
+++ b/web/app/scripts/navbar/navbar-controller.js
@@ -15,6 +15,7 @@
         ctl.onLogoutButtonClicked = AuthService.logout;
         ctl.authenticated = AuthService.isAuthenticated();
         ctl.hasWriteAccess = AuthService.hasWriteAccess();
+        ctl.isAdmin = AuthService.isAdmin();
         ctl.onGeographySelected = onGeographySelected;
         ctl.onBoundarySelected = onBoundarySelected;
         ctl.onRecordTypeSelected = onRecordTypeSelected;

--- a/web/app/scripts/navbar/navbar-partial.html
+++ b/web/app/scripts/navbar/navbar-partial.html
@@ -63,12 +63,12 @@
 
             </ul>
 
-            <ul class="nav navbar-nav navbar-right">
+            <ul ng-if="ctl.authenticated" class="nav navbar-nav navbar-right">
                 <li class="dropdown">
                     <a class="dropdown-toggle" data-toggle="dropdown" role="button">{{ ctl.userEmail }} <span class="glyphicon glyphicon-option-vertical"></span></a>
                     <ul class="dropdown-menu">
                         <li><a ng-click="ctl.navigateToStateName('account')">My Account</a></li>
-                        <li><a ng-click="ctl.showAuditDownloadModal()">Download audit logs</a></li>
+                        <li ng-if="ctl.isAdmin"><a ng-click="ctl.showAuditDownloadModal()">Download audit logs</a></li>
                         <li ng-if="ctl.hasWriteAccess"><a ng-click="ctl.navigateToStateName('duplicates')">Manage Duplicate Records</a></li>
                         <li><a ng-click="ctl.onLogoutButtonClicked()">Log Out</a></li>
                     </ul>

--- a/web/test/spec/navbar/navbar-directive.spec.js
+++ b/web/test/spec/navbar/navbar-directive.spec.js
@@ -69,6 +69,7 @@ describe('driver.navbar: Navbar', function () {
         // log in first
         $httpBackend.expectPOST(/\/api-token-auth\//).respond({user: 1, token: 'gotatoken'});
         $httpBackend.expectGET(userInfoUrl).respond(200, ResourcesMock.UserInfoResponse);
+        $httpBackend.expectGET(userInfoUrl).respond(200, ResourcesMock.UserInfoResponse);
         AuthService.authenticate({username: 'foo', password: 'foo'});
         $httpBackend.flush();
         $httpBackend.verifyNoOutstandingRequest();


### PR DESCRIPTION
- Adds an "isAdmin" cookie that specifies whether a user is an administrator or not.
- Hides the My Account dropdown for unauthenticated users
- Hides the Audit Log download option from the My Account dropdown for non-admin users.