### PR TITLE
Allow members of admin group to edit users

### DIFF
--- a/app/driver_auth/views.py
+++ b/app/driver_auth/views.py
@@ -82,7 +82,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Limit non-admin users to only see their own info"""
         user = self.request.user
-        if user.is_staff:
+        if is_admin(user):
             return self.queryset
         else:
             return self.queryset.filter(id=user.id)


### PR DESCRIPTION
Previously the `UserViewSet` relied on the built-in 'is_staff' flag, so users in
the 'admin' group could not see a list of all users. This switches it to use the `is_admin` function used elsewhere.