### PR TITLE
Interventions: map layer and detail view

### DIFF
--- a/web/app/scripts/export/export-controller.js
+++ b/web/app/scripts/export/export-controller.js
@@ -40,7 +40,7 @@
 
             var params = _.extend({ tilekey: true, limit: 0 }, ctl.recordQueryParams);
             // Get a tilekey then trigger an export
-            QueryBuilder.djangoQuery(true, 0, params).then(function(records) {
+            QueryBuilder.djangoQuery(0, params).then(function(records) {
                 Exports.create({ tilekey: records.tilekey },
                     function (result) {pollForDownload(result.taskid); },
                     function () { ctl.error = 'Error initializing export.'; }

--- a/web/app/scripts/map-layers/tile-url-service.js
+++ b/web/app/scripts/map-layers/tile-url-service.js
@@ -6,6 +6,7 @@
     function TileUrlService($q, WebConfig) {
         var allRecordsUrl = (WebConfig.windshaft.hostname +
             '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.png');
+        var secondaryRecordsUrl = allRecordsUrl + '?secondary=true';
         var allRecordsUtfGridUrl = (WebConfig.windshaft.hostname +
             '/tiles/table/ashlar_record/id/ALL/{z}/{x}/{y}.grid.json');
         var positronUrl = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
@@ -19,6 +20,7 @@
 
         var module = {
             recTilesUrl: recordsTilesUrlForType,
+            secondaryTilesUrl: secondaryTilesUrlForType,
             recUtfGridTilesUrl: recordsUtfGridTilesUrlForType,
             recHeatmapUrl: recordsHeatmapTilesUrl,
             boundaryTilesUrl: boundaryTilesUrl,
@@ -30,6 +32,10 @@
 
         function recordsTilesUrlForType(typeUuid) {
             return _insertIdAtALL(allRecordsUrl, typeUuid);
+        }
+
+        function secondaryTilesUrlForType(typeUuid) {
+            return _insertIdAtALL(secondaryRecordsUrl, typeUuid);
         }
 
         function recordsUtfGridTilesUrlForType(typeUuid) {

--- a/web/app/scripts/resources/aggregate-query-service.js
+++ b/web/app/scripts/resources/aggregate-query-service.js
@@ -16,32 +16,37 @@
         /**
          * Retrieve TODDOW data - API mirroring the query builder service
          */
-        function toddow(doFilter, extraParams) {
+        function toddow(extraParams, doAttrFilters, doJsonFilters) {
             var deferred = $q.defer();
             extraParams = extraParams || {};
-            doFilter = doFilter === undefined ? true : doFilter;
-            QueryBuilder.assembleParams(doFilter, 0).then(function(params) {  // 0 for offset
-                // toddow should never use a limit
-                params = _.extend(params, extraParams);
-                if (params.limit) {
-                    delete params.limit;
-                }
+            doAttrFilters = doAttrFilters !== false;
+            doJsonFilters = doJsonFilters !== false;
+            QueryBuilder.assembleParams(0, doAttrFilters, doJsonFilters).then( // 0 for offset
+                function(params) {
+                    // toddow should never use a limit
+                    params = _.extend(params, extraParams);
+                    if (params.limit) {
+                        delete params.limit;
+                    }
 
-                Records.toddow(params).$promise.then(function(toddowData) {
-                    deferred.resolve(toddowData);
-                });
-            });
+                    Records.toddow(params).$promise.then(function(toddowData) {
+                        deferred.resolve(toddowData);
+                    });
+                }
+            );
             return deferred.promise;
         }
 
         /**
          * Retrieve stepwise data - API mirroring the query builder service
          */
-        function stepwise(doFilter, extraParams) {
+        function stepwise(extraParams, doAttrFilters, doJsonFilters) {
             var deferred = $q.defer();
             extraParams = extraParams || {};
-            doFilter = doFilter === undefined ? true : doFilter;
-            QueryBuilder.assembleParams(doFilter, 0).then(function(params) {  // 0 for offset
+            doAttrFilters = doAttrFilters !== false;
+            doJsonFilters = doJsonFilters !== false;
+            QueryBuilder.assembleParams(0, doAttrFilters, doJsonFilters).then( // 0 for offset
+                function(params) {
                 // stepwise should never use a limit
                 params = _.extend(params, extraParams);
                 if (params.limit) {

--- a/web/app/scripts/state/recordschemastate-service.js
+++ b/web/app/scripts/state/recordschemastate-service.js
@@ -67,17 +67,22 @@
          * Wrapper (with super simple caching) for getting the record schema
          *
          * @param schemaID {string} The Schema UUID for which filterables are sought
+         *                          If called without schemaID, returns the last one loaded.
          */
         function get(schemaID) {
+            if (!schemaID) {
+                schemaID = lastChosen;
+            }
+
             if (!gettingSelected || schemaID !== lastChosen) {
                 gettingSelected = true;
+                lastChosen = schemaID;
             } else {
                 return selectedPromise;
             }
-            lastChosen = schemaID;
 
             var deferred = $q.defer();
-            if (!selected) {
+            if (!selected || selected.uuid !== schemaID) {
                 RecordSchemas.get({ id: schemaID }).$promise.then(function(schema) {
                     selected = schema;
                     deferred.resolve(schema);

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -22,6 +22,7 @@
         svc.getOptions = getOptions;
         svc.setSelected = setSelected;
         svc.getSelected = getSelected;
+        svc.getSecondary = getSecondary;
         init();
 
         /**
@@ -86,9 +87,6 @@
                     selection = _.find(options, function(d) {
                         return d.label === WebConfig.recordType.primaryLabel;
                     });
-                    secondaryType = _.find(options, function(d) {
-                      return d.label === WebConfig.recordType.secondaryLabel;
-                    });
                 } else {
                     var oldRecordType = localStorageService.get('recordtype.selected');
                     if (oldRecordType) {
@@ -96,16 +94,8 @@
                             return d.uuid === oldRecordType.uuid;
                         });
                     }
-
-                    var oldSecondaryType = localStorageService.get('secondaryrecordtype.selected');
-                    if (oldSecondaryType) {
-                        secondaryType = _.find(options, function(d) {
-                            return d.uuid === oldSecondaryType.uuid;
-                        });
-                    }
                 }
-                initialized = true;
-                InitialState.setRecordTypeInitialized();
+                initializeSecondary();
             }
             if (_.find(options, function(d) { return d.uuid === selection.uuid; })) {
                 selected = selection;
@@ -115,9 +105,19 @@
                 selected = null;
             }
             localStorageService.set('recordtype.selected', selected);
-            localStorageService.set('secondaryrecordtype.selected', secondaryType);
             $rootScope.$broadcast('driver.state.recordstate:selected', selected);
+            if (!initialized) {
+                initialized = true;
+                InitialState.setRecordTypeInitialized();
+            }
             return selected;
+        }
+
+        function initializeSecondary() {
+            secondaryType = _.find(options, function(d) {
+                return d.label === WebConfig.recordType.secondaryLabel;
+            });
+            localStorageService.set('secondaryrecordtype.selected', secondaryType);
         }
 
         function getSelected() {
@@ -139,6 +139,14 @@
 
             selectedPromise.then(function() { gettingSelected = false; });
             return selectedPromise;
+        }
+
+        function getSecondary() {
+            if (initialized) {
+                return secondaryType;
+            } else {
+                return getSelected().then(function () { return secondaryType; });
+            }
         }
 
         return svc;

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -11,8 +11,13 @@
         var localDateTimeFilter = $filter('localDateTime');
         var dateFormat = 'M/D/YYYY, h:mm:ss A';
 
-        ctl.recordType = 'ALL';
-        ctl.recordTypeLabel = 'Record';
+        /* jshint camelcase: false */
+        ctl.recordType = {
+            uuid: 'ALL',
+            label: 'Record',
+            plural_label: 'Records'
+        };
+        /* jshint camelcase: true */
         ctl.layerSwitcher = null;
         ctl.drawControl = null;
         ctl.map = null;
@@ -24,7 +29,7 @@
         ctl.editLayers = null;
         ctl.tilekey = null;
         ctl.userCanWrite = false;
-        ctl.eventLayerGroup = null;
+        ctl.primaryLayerGroup = null;
         ctl.secondaryLayerGroup = null;
         ctl.heatmapLayerGroup = null;
         ctl.blackspotLayerGroup = null;
@@ -75,20 +80,20 @@
             RecordState.getSelected().then(function(selected) {
                 if (selected && selected.uuid) {
                     /* jshint camelcase: false */
-                    ctl.recordType = selected.uuid;
-                    ctl.recordTypeLabel = selected.label;
+                    ctl.recordType = selected;
                     RecordSchemaState.getFilterables(selected.current_schema)
                         .then(function(filterables) {
                             ctl.recordSchemaFilterables = filterables;
                         });
-                    var secondary = RecordState.getSecondary();
-                    ctl.secondaryType = secondary.uuid;
-                    ctl.secondaryTypeLabel = secondary.label;
-                    /* jshint camelcase: true */
+                    ctl.secondaryType = RecordState.getSecondary();
                 } else {
                     ctl.recordSchemaFilterables = [];
-                    ctl.recordType = 'ALL';
-                    ctl.recordTypeLabel = 'Record';
+                    ctl.recordType = {
+                        uuid: 'ALL',
+                        label: 'Record',
+                        plural_label: 'Records'
+                    };
+                    /* jshint camelcase: true */
                     ctl.secondaryType = null;
                 }
             }).then(function() {
@@ -210,10 +215,9 @@
             });
 
             $scope.$on('driver.state.recordstate:selected', function(event, selected) {
-                if (ctl.recordType !== selected && selected && selected.uuid) {
+                if (selected && selected.uuid && ctl.recordType.uuid !== selected.uuid) {
                     /* jshint camelcase: false */
-                    ctl.recordType = selected.uuid;
-                    ctl.recordTypeLabel = selected.label;
+                    ctl.recordType = selected;
                     RecordSchemaState.getFilterables(selected.current_schema)
                         .then(function(filterables) {
                             ctl.recordSchemaFilterables = filterables;
@@ -299,13 +303,13 @@
             if (polygon) {
               return BlackspotSets.query({
                 'efffective_at': FilterState.getDateFilter().maxDate,
-                'record_type': ctl.recordType,
+                'record_type': ctl.recordType.uuid,
                 'polygon': polygon
               }).$promise;
             }
             return BlackspotSets.query({
                 'effective_at': FilterState.getDateFilter().maxDate,
-                'record_type': ctl.recordType
+                'record_type': ctl.recordType.uuid
             }).$promise;
         }
 
@@ -331,15 +335,15 @@
             var secondaryRecordsUrl = $q.when('');
             var secondaryUtfGridUrl = $q.when('');
             if (ctl.secondaryType) {
-                secondaryRecordsUrl = TileUrlService.secondaryTilesUrl(ctl.secondaryType);
-                secondaryUtfGridUrl = TileUrlService.recUtfGridTilesUrl(ctl.secondaryType);
+                secondaryRecordsUrl = TileUrlService.secondaryTilesUrl(ctl.secondaryType.uuid);
+                secondaryUtfGridUrl = TileUrlService.recUtfGridTilesUrl(ctl.secondaryType.uuid);
             }
 
             return $q.all(
                 {
-                    baseRecordsUrl:       TileUrlService.recTilesUrl(ctl.recordType),
-                    baseUtfGridUrl:       TileUrlService.recUtfGridTilesUrl(ctl.recordType),
-                    baseHeatmapUrl:       TileUrlService.recHeatmapUrl(ctl.recordType),
+                    primaryRecordsUrl:    TileUrlService.recTilesUrl(ctl.recordType.uuid),
+                    primaryUtfGridUrl:    TileUrlService.recUtfGridTilesUrl(ctl.recordType.uuid),
+                    primaryHeatmapUrl:    TileUrlService.recHeatmapUrl(ctl.recordType),
                     blackspotsUrl:        blackspotUrl,
                     blackspotsUtfGridUrl: blackspotUtfUrl,
                     blackspotTileKey:     blackspotTileKey,
@@ -362,8 +366,8 @@
             updateBlackspotLayer(urls.blackspotsUrl, urls.blackspotsUtfGridUrl,
                                  urls.blackspotTileKey);
             updateSecondaryLayer(urls.secondaryRecordsUrl, urls.secondaryUtfGridUrl);
-            updateEventLayer(urls.baseRecordsUrl, urls.baseUtfGridUrl);
-            updateHeatmapLayer(urls.baseHeatmapUrl);
+            updatePrimaryLayer(urls.primaryRecordsUrl, urls.primaryUtfGridUrl);
+            updateHeatmapLayer(urls.primaryHeatmapUrl);
         }
 
         /**
@@ -415,12 +419,14 @@
          */
         function addLayerSwitcher() {
             var overlays = angular.extend(
-                {
-                    Events: ctl.eventLayerGroup,
-                    Interventions: ctl.secondaryLayerGroup,
-                    Heatmap: ctl.heatmapLayerGroup,
-                    Blackspots: ctl.blackspotLayerGroup
-                },
+                _.zipObject([
+                    /* jshint camelcase: false */
+                    [ctl.recordType.plural_label, ctl.primaryLayerGroup],
+                    [ctl.secondaryType.plural_label, ctl.secondaryLayerGroup],
+                    /* jshint camelcase: true */
+                    ['Heatmap', ctl.heatmapLayerGroup],
+                    ['Blackspots', ctl.blackspotLayerGroup],
+                ]),
                 ctl.boundariesLayerGroup
             );
             ctl.bMaps.then(
@@ -442,41 +448,41 @@
         }
 
         /**
-         * Updates the event layer group
-         * The event layer group is composed of the records layer for the actual
+         * Updates the primary layer group
+         * The primary layer group is composed of the records layer for the actual
          * records on the map, and the utfGridRecords layer which is for the
          * click events and popup
          */
-        function updateEventLayer(baseRecordsUrl, baseUtfGridUrl){
+        function updatePrimaryLayer(primaryRecordsUrl, primaryUtfGridUrl){
             var recordsLayerOptions = angular.extend(defaultLayerOptions, {
                 zIndex: 5
             });
 
             var recordsLayer = new L.tileLayer(
-                ctl.getFilterQuery(baseRecordsUrl, ctl.tilekey),
+                ctl.getFilterQuery(primaryRecordsUrl, ctl.tilekey),
                 recordsLayerOptions);
 
             var utfGridRecordsLayer = new L.UtfGrid(
-                ctl.getFilterQuery(baseUtfGridUrl, ctl.tilekey), {
+                ctl.getFilterQuery(primaryUtfGridUrl, ctl.tilekey), {
                     useJsonP: false,
                     zIndex: 7
                 });
 
-            addGridRecordEvent(utfGridRecordsLayer, { label: ctl.recordTypeLabel });
+            addGridRecordEvent(utfGridRecordsLayer, { label: ctl.recordType.label });
 
-            if (!ctl.eventLayerGroup) {
-                ctl.eventLayerGroup = new L.layerGroup(
+            if (!ctl.primaryLayerGroup) {
+                ctl.primaryLayerGroup = new L.layerGroup(
                     [recordsLayer, utfGridRecordsLayer]);
-                ctl.map.addLayer(ctl.eventLayerGroup);
+                ctl.map.addLayer(ctl.primaryLayerGroup);
             } else {
-                _.forEach(ctl.eventLayerGroup._layers,function(layer) {
+                _.forEach(ctl.primaryLayerGroup._layers,function(layer) {
                     if (typeof layer.off === 'function') {
                         layer.off('click');
                     }
-                    ctl.eventLayerGroup.removeLayer(layer);
+                    ctl.primaryLayerGroup.removeLayer(layer);
                 });
-                ctl.eventLayerGroup.addLayer(recordsLayer);
-                ctl.eventLayerGroup.addLayer(utfGridRecordsLayer);
+                ctl.primaryLayerGroup.addLayer(recordsLayer);
+                ctl.primaryLayerGroup.addLayer(utfGridRecordsLayer);
             }
         }
 
@@ -501,7 +507,7 @@
                     zIndex: 11
                 });
 
-            addGridRecordEvent(utfGridRecordsLayer, { label: ctl.secondaryTypeLabel });
+            addGridRecordEvent(utfGridRecordsLayer, { label: ctl.secondaryType.label });
 
             if (!ctl.secondaryLayerGroup) {
                 ctl.secondaryLayerGroup = new L.layerGroup(
@@ -552,12 +558,12 @@
          * heatmap layer and adds a new one to the layer group with
          * the updated URL
          */
-        function updateHeatmapLayer(baseHeatmapUrl) {
+        function updateHeatmapLayer(primaryHeatmapUrl) {
             var heatmapOptions = angular.extend(defaultLayerOptions, {
                 zIndex: 6
             });
             var heatmapLayer = new L.tileLayer(
-                ctl.getFilterQuery(baseHeatmapUrl, ctl.tilekey),
+                ctl.getFilterQuery(primaryHeatmapUrl, ctl.tilekey),
                 heatmapOptions);
 
             if (ctl.heatmapLayerGroup) {
@@ -653,7 +659,7 @@
         /**
          * Build popup content from blackspot data
          *
-         * @param {Object} UTFGrid interactivity data from interation event object
+         * @param {Object} UTFGrid interactivity data from interaction event object
          * @returns {String} HTML snippet for a Leaflet popup
          */
         ctl.buildBlackspotPopup = function(blackspot) {
@@ -674,7 +680,7 @@
          * @returns {String} HTML snippet for a Leaflet popup.
          */
         ctl.buildRecordPopup = function(record, popupParams) {
-            // add header with event date constant field
+            // add header with record date constant field
             /* jshint camelcase: false */
             // DateTimes come back from Windshaft without tz information, but they're all UTC
             var occurredStr = localDateTimeFilter(moment.utc(record.occurred_from), dateFormat);
@@ -772,7 +778,7 @@
             if (ctl.secondaryType) {
                 var params = getAdditionalParams();
                 /* jshint camelcase: false */
-                params.record_type = ctl.secondaryType;
+                params.record_type = ctl.secondaryType.uuid;
                 /* jshint camelcase: true */
                 secondary = QueryBuilder.djangoQuery(0, params, true, false).then(
                     function(records) { ctl.secondaryTilekey = records.tilekey; }

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function RecordAddEditController($log, $scope, $state, $stateParams, $window, uuid4,
                                      AuthService, Nominatim, Notifications, Records,
-                                     RecordSchemaState, RecordState, WeatherService, WebConfig) {
+                                     RecordSchemaState, RecordTypes, WeatherService, WebConfig) {
         var ctl = this;
         var editorData = null;
         var bbox = null;
@@ -93,8 +93,7 @@
             });
 
             var recordPromise = $stateParams.recorduuid ? loadRecord() : null;
-            (recordPromise ? recordPromise.then(loadRecordType) : loadRecordType())
-                .then(loadRecordSchema)
+            (recordPromise ? recordPromise.then(loadRecordSchema) : loadRecordSchema())
                 .then(onSchemaReady);
         }
 
@@ -170,21 +169,14 @@
                 });
         }
 
-        function loadRecordType() {
-            return RecordState.getSelected()
-                .then(function(recordType) {
-                    ctl.recordType = recordType;
-                });
-        }
-
         function loadRecordSchema() {
-            /* jshint camelcase: false */
-            var currentSchemaId = ctl.recordType.current_schema;
-            /* jshint camelcase: true */
-
-            return RecordSchemaState.get(currentSchemaId)
-                .then(function(recordSchema) {
-                    ctl.recordSchema = recordSchema;
+            return RecordTypes.query({ record: $stateParams.recorduuid }).$promise
+                .then(function (result) {
+                    ctl.recordType = result[0];
+                    /* jshint camelcase: false */
+                    return RecordSchemaState.get(ctl.recordType.current_schema)
+                    /* jshint camelcase: true */
+                        .then(function(recordSchema) { ctl.recordSchema = recordSchema; });
                 });
         }
 

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -328,7 +328,6 @@
         }
 
         function onSaveClicked() {
-
             var validationErrorMessage = constantFieldsValidationErrors();
 
             if (ctl.editor.errors.length > 0) {

--- a/web/app/scripts/views/record/details-controller.js
+++ b/web/app/scripts/views/record/details-controller.js
@@ -2,14 +2,12 @@
     'use strict';
 
     /* ngInject */
-    function RecordDetailsController($stateParams,
-                                     Records, RecordSchemaState, RecordState) {
+    function RecordDetailsController($stateParams, Records, RecordSchemaState, RecordTypes) {
         var ctl = this;
         initialize();
 
         function initialize() {
             loadRecord()
-                .then(loadRecordType)
                 .then(loadRecordSchema);
         }
 
@@ -20,21 +18,14 @@
                 });
         }
 
-        function loadRecordType () {
-            return RecordState.getSelected()
-                .then(function(recordType) {
-                    ctl.recordType = recordType;
-                });
-        }
-
         function loadRecordSchema() {
-            /* jshint camelcase: false */
-            var currentSchemaId = ctl.recordType.current_schema;
-            /* jshint camelcase: true */
-
-            return RecordSchemaState.get(currentSchemaId)
-                .then(function(recordSchema) {
-                    ctl.recordSchema = recordSchema;
+            return RecordTypes.query({ record: $stateParams.recorduuid }).$promise
+                .then(function (result) {
+                    ctl.recordType = result[0];
+                    /* jshint camelcase: false */
+                    return RecordSchemaState.get(ctl.recordType.current_schema)
+                    /* jshint camelcase: true */
+                        .then(function(recordSchema) { ctl.recordSchema = recordSchema; });
                 });
         }
     }

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -68,7 +68,7 @@
             var params = ctl.boundaryId ? { polygon_id: ctl.boundaryId } : {};
             /* jshint camelcase: true */
 
-            return QueryBuilder.djangoQuery(true, newOffset, params)
+            return QueryBuilder.djangoQuery(newOffset, params)
             .then(function(records) {
                 ctl.records = records;
                 ctl.currentOffset = newOffset;

--- a/web/app/styles/_layout.scss
+++ b/web/app/styles/_layout.scss
@@ -36,6 +36,17 @@ label {
     }
 }
 
+.jse-MultiCheckboxControl {
+    label {
+        text-transform: initial;
+    }
+    input {
+        // margin-bottom: 3px;
+        margin-top: 3px;
+        margin-right: 2px
+    }
+}
+
 .checkbox label {
 	text-transform: initial;
 	margin-top: 5px;

--- a/web/app/styles/partials/_modals.scss
+++ b/web/app/styles/partials/_modals.scss
@@ -7,6 +7,10 @@
     }
 }
 
+.modal-footer {
+    clear: both;
+}
+
 .confirmation-modal {
     top: 175px;
 

--- a/web/test/spec/export/export-controller.spec.js
+++ b/web/test/spec/export/export-controller.spec.js
@@ -45,7 +45,6 @@ describe('driver.export: ExportController', function () {
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         var recordSchemaUrl = /\/api\/recordschemas\/\?limit=all/;
         $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchemaResponse);
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
 
         $scope.recordQueryParams = {};
         Controller = $controller('ExportController', { $scope: $scope });

--- a/web/test/spec/map-layers/recent-events/recent-events-layer-directive.spec.js
+++ b/web/test/spec/map-layers/recent-events/recent-events-layer-directive.spec.js
@@ -30,7 +30,6 @@ describe('driver.map-layers.recent-events: Recent Events Layer Directive', funct
         $httpBackend.whenGET(/\/api\/boundaries/).respond(DriverResourcesMock.BoundaryResponse);
         $httpBackend.expectGET(/\/api\/boundarypolygons/)
             .respond(ResourcesMock.BoundaryNoGeomResponse);
-        $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchema);
         $httpBackend.expectGET(/\api\/records/).respond(200, ResourcesMock.RecordResponse);
 
         $rootScope.$digest();

--- a/web/test/spec/resources/query-builder-service-spec.js
+++ b/web/test/spec/resources/query-builder-service-spec.js
@@ -45,7 +45,6 @@ describe('driver.resources: QueryBuilder', function () {
 
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchema);
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordsUrl).respond(200, DriverResourcesMock.RecordResponse);
 
         $rootScope.$apply();

--- a/web/test/spec/views/map/layers-controller.spec.js
+++ b/web/test/spec/views/map/layers-controller.spec.js
@@ -57,8 +57,9 @@ describe('driver.views.map: Layers Controller', function () {
         var recordTypeUrl = /\/api\/recordtypes\//;
         var boundaryUrl = /\/api\/boundaries\//;
         var boundaryPolygonsUrl = /api\/boundarypolygons/;
-        var recordsUrl = /\/api\/records\//;
-        var recordSchemaUrl = /\/api\/recordschemas/;
+        // var recordsUrl = /\/api\/records\/.*record_type/;
+        var tilekeyUrl = /\/api\/records\/\?.*tilekey=true/;
+        var recordSchemaUrl = /\/api\/recordschemas\/[a-e0-9-]+/;
         var blackspotUrl = /\/api\/blackspotsets/;
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(boundaryUrl).respond(200, DriverResourcesMock.BoundaryResponse);
@@ -66,10 +67,14 @@ describe('driver.views.map: Layers Controller', function () {
         $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchema);
         $httpBackend.expectGET(blackspotUrl).respond(200, ResourcesMock.BlackspotResponse);
         $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
-        $httpBackend.expectGET(blackspotUrl).respond(200, ResourcesMock.BlackspotResponse);
-        $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchema);
-        $httpBackend.expectGET(recordsUrl).respond(200, '{"tilekey": "xxx"}');
-        $httpBackend.expectGET(recordsUrl).respond(200, '{"tilekey": "xxx"}');
+
+        // Two record layers (primary and secondary), each gets called once on init then once
+        // triggered by the filterbar loading
+        $httpBackend.expectGET(tilekeyUrl).respond(200, '{"tilekey": "xxx"}');
+        $httpBackend.expectGET(tilekeyUrl).respond(200, '{"tilekey": "xxx"}');
+        $httpBackend.expectGET(tilekeyUrl).respond(200, '{"tilekey": "xxx"}');
+        $httpBackend.expectGET(tilekeyUrl).respond(200, '{"tilekey": "xxx"}');
+
         $httpBackend.expectGET(blackspotUrl).respond(200, ResourcesMock.BlackspotResponse);
 
         Element = $compile('<div leaflet-map driver-map-layers></div>')($scope);
@@ -93,7 +98,7 @@ describe('driver.views.map: Layers Controller', function () {
 
         var expected = '<div id="record-popup" class="record-popup"><div><h5>Accident Details</h5><h3>7/31/2015, 1:36:29 AM</h3><a ng-click="showDetailsModal(\'35d74ce1-7b08-486b-b791-da9bc1e93cfb\')"><span class="glyphicon glyphicon-log-in"></span> View</a></div></div>';
 
-        var popup = Controller.buildRecordPopup(record);
+        var popup = Controller.buildRecordPopup(record, { label: Controller.recordType.label });
         expect(popup).toEqual(expected);
     });
 
@@ -112,7 +117,7 @@ describe('driver.views.map: Layers Controller', function () {
 
     it('should listen for record type change', function() {
         spyOn(Controller, 'setRecordLayers');
-        RecordState.setSelected({uuid: 'foo'});
+        RecordState.setSelected(ResourcesMock.RecordTypeResponse.results[2]);
         expect(Controller.setRecordLayers).toHaveBeenCalled();
     });
 

--- a/web/test/spec/views/map/layers-directive.spec.js
+++ b/web/test/spec/views/map/layers-directive.spec.js
@@ -55,7 +55,6 @@ describe('driver.views.map: Layers Directive', function () {
         var blackspotUrl = /\/api\/blackspotsets/;
         $httpBackend.expectGET(blackspotUrl).respond(200, ResourcesMock.BlackspotResponse);
         $httpBackend.expectGET(blackspotUrl).respond(200, ResourcesMock.BlackspotResponse);
-        $httpBackend.expectGET(blackspotUrl).respond(200, ResourcesMock.BlackspotResponse);
 
         Element = $compile('<div leaflet-map driver-map-layers></div>')($rootScope);
         $rootScope.$apply();

--- a/web/test/spec/views/record/details-controller.spec.js
+++ b/web/test/spec/views/record/details-controller.spec.js
@@ -10,35 +10,34 @@ describe('driver.views.record: DetailsController', function () {
     var $httpBackend;
     var $rootScope;
     var $scope;
+    var $stateParams;
     var Controller;
     var DriverResourcesMock;
     var ResourcesMock;
 
     // Initialize the controller and a mock scope
-    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_,
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_, _$stateParams_,
                                 _DriverResourcesMock_, _ResourcesMock_) {
         $controller = _$controller_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
         $scope = $rootScope.$new();
+        $stateParams = _$stateParams_;
         DriverResourcesMock = _DriverResourcesMock_;
         ResourcesMock = _ResourcesMock_;
     }));
 
     it('should load the record', function () {
-        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        var recordUrl = /\/api\/records/;
-
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
-        var recordTypeIdUrl = new RegExp('api/recordtypes/' + recordTypeId);
-
+        var recordId = DriverResourcesMock.RecordResponse.results[0].uuid;
+        $stateParams.recorduuid = recordId;
         var recordSchema = ResourcesMock.RecordSchema;
-        var recordSchemaId = recordSchema.uuid;
-        var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchemaId);
 
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        var recordTypeUrl = new RegExp('api/recordtypes/.*record=' + recordId);
+        var recordUrl = new RegExp('api/records/' + recordId);
+        var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchema.uuid);
+
         $httpBackend.expectGET(recordUrl).respond(200, DriverResourcesMock.RecordResponse);
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 
         Controller = $controller('RecordDetailsController', {

--- a/web/test/spec/views/record/details-directive.spec.js
+++ b/web/test/spec/views/record/details-directive.spec.js
@@ -11,28 +11,34 @@ describe('driver.views.record: RecordDetails', function () {
     var $compile;
     var $httpBackend;
     var $rootScope;
+    var $stateParams;
     var RecordTypes;
     var DriverResourcesMock;
     var ResourcesMock;
 
-    beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_,
+    beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_, _$stateParams_,
                                 _DriverResourcesMock_, _RecordTypes_, _ResourcesMock_) {
         $compile = _$compile_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
+        $stateParams = _$stateParams_;
         DriverResourcesMock = _DriverResourcesMock_;
         RecordTypes = _RecordTypes_;
         ResourcesMock = _ResourcesMock_;
     }));
 
     it('should load directive', function () {
-        var recordUrl = /\/api\/records/;
-        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        var recordSchemaUrl = /\/api\/recordschemas/;
+        var recordId = DriverResourcesMock.RecordResponse.results[0].uuid;
+        $stateParams.recorduuid = recordId;
+        var recordSchema = ResourcesMock.RecordSchema;
 
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        var recordTypeUrl = new RegExp('api/recordtypes/.*record=' + recordId);
+        var recordUrl = new RegExp('api/records/' + recordId);
+        var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchema.uuid);
+
         $httpBackend.expectGET(recordUrl).respond(200, DriverResourcesMock.RecordResponse);
-        $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchema);
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 
         var scope = $rootScope.$new();
         var element = $compile('<driver-record-details></driver-record-details>')(scope);

--- a/web/test/spec/views/record/list-controller.spec.js
+++ b/web/test/spec/views/record/list-controller.spec.js
@@ -26,17 +26,11 @@ describe('driver.views.record: ListController', function () {
         ResourcesMock = _ResourcesMock_;
         FilterState = _FilterState_;
         FilterState.reset();
-    }));
 
-    it('should have header keys', function () {
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
 
         var recordSchema = ResourcesMock.RecordSchema;
-        var recordSchemaId = recordSchema.uuid;
-        var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchemaId);
-
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
+        var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchema.uuid);
 
         var boundariesUrl = /api\/boundaries/;
         var boundaryPolygonsUrl = /api\/boundarypolygons/;
@@ -54,6 +48,11 @@ describe('driver.views.record: ListController', function () {
         $scope.$apply();
 
         $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    }));
+
+    it('should have header keys', function () {
+
         $rootScope.$broadcast('driver.filterbar:changed', {});
         var recordOffsetUrl = /api\/records\//;
         $httpBackend.expectGET(recordOffsetUrl).respond(200, DriverResourcesMock.RecordResponse);
@@ -64,29 +63,6 @@ describe('driver.views.record: ListController', function () {
     });
 
     it('should make offset requests for pagination', function () {
-        var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-
-        var recordSchema = ResourcesMock.RecordSchema;
-        var recordSchemaId = recordSchema.uuid;
-        var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchemaId);
-
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
-
-        var boundariesUrl = /api\/boundaries/;
-        var boundaryPolygonsUrl = /api\/boundarypolygons/;
-
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
-        $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
-        $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
-
-        Controller = $controller('RecordListController', {
-            $scope: $scope
-        });
-        $scope.$apply();
-        $httpBackend.flush();
-
         $rootScope.$broadcast('driver.filterbar:changed', {});
         var recordOffsetUrl = new RegExp('api/records/\\?.*limit=50.*');
         $httpBackend.expectGET(recordOffsetUrl).respond(200, DriverResourcesMock.RecordResponse);


### PR DESCRIPTION
1. Adds an interventions layer to the map.
2. Changes the record detail view (modal and page) to load record type and schema based on the record rather than using the primary selected type/schema, so that they'll work for interventions (i.e. for records that are not of the primary type).  The edit page also works but needs some attention, which will come in a separate PR.
3. Refactors QueryBuilder.djangoQuery a bit to make it possible to filter on record attributes (date, location, etc) but not on schema attributes (this lets the date and boundary filters work for interventions and keeps the json filters, which would be false since they're for the wrong record type, from eliminating them all).

Also:
* Fixes a situation where RecordSchemaState.get() was being called with no schemaID, which was resulting in the cached schema being cleared until something else called it properly, which I believe was causing issue #394.
* Depends on https://github.com/azavea/ashlar/pull/72.