### PR TITLE
Revert "Backport kernel; fixes #412"; upgrade Docker

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -5,7 +5,7 @@ not_developing: "'development' not in group_names"
 staging: "'staging' in group_names"
 not_staging: "'staging' not in group_names"
 
-docker_version: "1.8.*"
+docker_version: "1.10.*"
 docker_py_version: "1.2.3"
 docker_options: "--storage-driver=aufs"
 

--- a/deployment/ansible/roles/driver.gradle/handlers/main.yml
+++ b/deployment/ansible/roles/driver.gradle/handlers/main.yml
@@ -1,6 +1,3 @@
 ---
 - name: Restart Gradle
   service: name=driver-gradle state=restarted
-
-- name: Restart Docker
-  service: name=docker state=restarted

--- a/deployment/ansible/roles/driver.gradle/tasks/main.yml
+++ b/deployment/ansible/roles/driver.gradle/tasks/main.yml
@@ -5,17 +5,6 @@
     - pollen
     - haveged
 
-# TODO: remove this workaround when fixed by kernel update
-- name: Install backported kernel for AUFS stability
-  apt: pkg={{ item }} state=present
-  with_items:
-    - linux-headers-3.19.0-39
-    - linux-headers-3.19.0-39-generic
-    - linux-image-3.19.0-39-generic
-    - linux-image-extra-3.19.0-39-generic
-  notify:
-    - Restart Docker
-
 - name: Ensure that gradle container mount directory exists
   file: path={{ gradle_dir }}/data
         recurse=yes


### PR DESCRIPTION
This reverts 17be608ab87ade814f15cde7f2ddfccfd3fe57f5. The kernel version that fixes the AUFS bug referenced in that commit is in the latest Ubuntu release AMI (3.13.0-79).

In addition, the Docker daemon have been upgraded to 1.10.x.

See also:

- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1533043
- https://bugzilla.kernel.org/show_bug.cgi?id=109971