### PR TITLE
Add support for Ansible 2.0

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -27,7 +27,7 @@ echo "keystore_password: \"${DRIVER_KEYSTORE_PASSWORD}\"" \
     >> deployment/ansible/group_vars/all
 set -x
 
-ansible-galaxy install -f -r deployment/ansible/roles.txt -p deployment/ansible/roles
+ansible-galaxy install -f -r deployment/ansible/roles.yml -p deployment/ansible/roles
 
 chmod 0600 deployment/driver.pem
 

--- a/deployment/ansible/app.yml
+++ b/deployment/ansible/app.yml
@@ -11,7 +11,7 @@
 
 - hosts: app-servers
 
-  sudo: True
+  become: True
 
   pre_tasks:
     - name: Update APT cache
@@ -24,7 +24,7 @@
 
 - hosts: database-servers
 
-  sudo: True
+  become: True
 
   roles:
     - { role: "driver.access" }

--- a/deployment/ansible/celery.yml
+++ b/deployment/ansible/celery.yml
@@ -11,7 +11,7 @@
 
 - hosts: celery-servers
 
-  sudo: True
+  become: True
 
   vars:
     celery: True

--- a/deployment/ansible/database.yml
+++ b/deployment/ansible/database.yml
@@ -10,7 +10,7 @@
 
 - hosts: database-servers
 
-  sudo: yes
+  become: True
 
   pre_tasks:
     - name: Update APT cache

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,7 +1,0 @@
-azavea.postgresql,0.3.3
-azavea.postgresql-support,0.2.2
-azavea.postgis,0.2.1
-azavea.nginx,0.2.1
-azavea.docker,1.0.2
-azavea.pip,0.1.1
-azavea.redis,0.1.0

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,0 +1,14 @@
+- src: azavea.postgresql
+  version: 0.3.4
+- src: azavea.postgresql-support
+  version: 0.3.0
+- src: azavea.postgis
+  version: 0.3.0
+- src: azavea.nginx
+  version: 0.2.1
+- src: azavea.docker
+  version: 1.0.2
+- src: azavea.pip
+  version: 0.1.1
+- src: azavea.redis
+  version: 0.1.0

--- a/deployment/ansible/roles/driver.access/tasks/main.yml
+++ b/deployment/ansible/roles/driver.access/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Set table-level access privileges for Windshaft DB role
-  sudo_user: postgres
+  become_user: postgres
   postgresql_privs: >
     state=present
     type=table

--- a/deployment/ansible/roles/driver.database/tasks/main.yml
+++ b/deployment/ansible/roles/driver.database/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 
 - name: Create PostgreSQL super user
-  sudo_user: postgres
+  become_user: postgres
   postgresql_user: name="{{ postgresql_username }}"
                    password="{{ postgresql_password }}"
                    role_attr_flags=SUPERUSER
                    state=present
 
 - name: Create PostgreSQL database
-  sudo_user: postgres
+  become_user: postgres
   postgresql_db: name="{{ postgresql_database }}"
                  owner="{{ postgresql_username }}"
 
 - name: Add PostGIS extension
-  sudo_user: postgres
+  become_user: postgres
   command: psql {{ postgresql_database }} -c "CREATE EXTENSION postgis"
   register: psql_result
   failed_when: >
@@ -21,7 +21,7 @@
   changed_when: "psql_result.rc == 0"
 
 - name: Create PostgreSQL user for Windshaft
-  sudo_user: postgres
+  become_user: postgres
   postgresql_user: name="{{ windshaft_db_username }}"
                    password="{{ windshaft_db_password }}"
                    role_attr_flags=LOGIN

--- a/deployment/ansible/roles/driver.web/tasks/main.yml
+++ b/deployment/ansible/roles/driver.web/tasks/main.yml
@@ -2,18 +2,17 @@
 - name: Copy web index.html to web -- for google analytics ID
   template: src=index.html.j2
             dest="{{ web_dir}}/app/index.html"
-  sudo: no
+  become: False
 
 - name: Copy web JS config to scripts dir
   template: src=web-config-js.j2
             dest="{{ web_scripts_dir}}/config.js"
-  sudo: no
+  become: False
 
 - name: Copy editor JS config to scripts dir
   template: src=editor-config-js.j2
             dest="{{ editor_scripts_dir}}/config.js"
-  sudo: no
+  become: False
 
 - { include: development.yml, when: developing }
 - { include: staging.yml, when: staging }
-

--- a/deployment/ansible/roles/driver.windshaft/tasks/main.yml
+++ b/deployment/ansible/roles/driver.windshaft/tasks/main.yml
@@ -8,7 +8,7 @@
                copy_links=no
                src="../../windshaft/"
                dest="/opt/windshaft"
-  sudo: False
+  become: False
   when: staging
   notify:
     - Restart Windshaft

--- a/vagrant/ansible_galaxy_helper.rb
+++ b/vagrant/ansible_galaxy_helper.rb
@@ -12,18 +12,19 @@ module AnsibleGalaxyHelper
     end
   end
 
-  # Uses the contents of roles.txt to ensure that ansible-galaxy is run
+  # Uses the contents of roles.yml to ensure that ansible-galaxy is run
   # if any dependencies are missing
   def self.install_dependent_roles(ansible_directory)
-    ansible_roles_txt = File.join(ansible_directory, "roles.txt")
+    ansible_roles_spec = File.join(ansible_directory, "roles.yml")
 
-    File.foreach(ansible_roles_txt) do |line|
-      role_name, role_version = line.split(",")
+    YAML.load_file(ansible_roles_spec).each do |role|
+      role_name = role["src"]
+      role_version = role["version"]
       role_path = File.join(ansible_directory, "roles", role_name)
       galaxy_metadata = galaxy_install_info(role_path)
 
       if galaxy_metadata["version"] != role_version.strip
-        unless system("ansible-galaxy install -f -r #{ansible_roles_txt} -p #{File.dirname(role_path)}")
+        unless system("ansible-galaxy install -f -r #{ansible_roles_spec} -p #{File.dirname(role_path)}")
           $stderr.puts "\nERROR: An attempt to install Ansible role dependencies failed."
           exit(1)
         end


### PR DESCRIPTION
Mostly removing a handful of deprecation warnings and upgrading to versions of Ansible roles that work for Ansible 2.0. The role specification itself has changed from a comma-delimited file to YAML.