### PR TITLE
Correct for field-name drift in read-only fields

### DIFF
--- a/app/data/serializers.py
+++ b/app/data/serializers.py
@@ -1,3 +1,5 @@
+import re
+
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
 from ashlar import serializers
@@ -14,7 +16,7 @@ class DetailsReadOnlyRecordSerializer(serializers.RecordSerializer):
 
     def filter_details_only(self, key, value):
         """Return only the details object and no other related info"""
-        if key in settings.READ_ONLY_FIELDS:
+        if re.search(settings.READ_ONLY_FIELDS_REGEX, key):
             return key, value
         else:
             raise serializer_fields.DropJsonKeyException
@@ -31,7 +33,7 @@ class DetailsReadOnlyRecordSchemaSerializer(serializers.RecordSchemaSerializer):
         # If we're looking at properties/definitions, remove everything that isn't read-only
         new_value = {}
         for k in value.viewkeys():
-            if k in settings.READ_ONLY_FIELDS:
+            if re.search(settings.READ_ONLY_FIELDS_REGEX, k):
                 new_value[k] = value[k]
         return key, new_value
 

--- a/app/data/tests/test_serializers.py
+++ b/app/data/tests/test_serializers.py
@@ -15,9 +15,9 @@ class DetailsReadOnlyRecordSerializerTestCase(TestCase):
     def test_filter_details_only(self):
         """Test that non-read-only fields are dropped"""
         with self.assertRaises(serializer_fields.DropJsonKeyException):
-            self.serializer.filter_details_only('Definitely Not Details', {})
-        for field_name in settings.READ_ONLY_FIELDS:
-            self.assertEqual((field_name, {}), self.serializer.filter_details_only(field_name, {}))
+            self.serializer.filter_details_only('Hidden Secrets', {})
+        self.assertEqual(('Visible Details', {}),
+                         self.serializer.filter_details_only('Visible Details', {}))
 
 
 class DetailsReadOnlyRecordSchemaSerializerTestCase(TestCase):

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -394,4 +394,4 @@ if len(GOOGLE_OAUTH_CLIENT_ID) > 0:
     }
 
 # These fields will be visible to read-only users
-READ_ONLY_FIELDS = ['Accident Details']
+READ_ONLY_FIELDS_REGEX = r'Details$'


### PR DESCRIPTION
This makes the read-only record details view work again.

It sticks with the approach in PR #345 but adjusts for the drift that has occurred since then ('Accident Details' -> 'accidentDetails') and makes it a tiny bit more robust by using a regex.

Seems like the more complete and flexible solution would be to add metadata to the schema itself, but that would be a battle for another day.