### PR TITLE
Feature/manage images

### DIFF
--- a/web/app/scripts/details/details-multiple-partial.html
+++ b/web/app/scripts/details/details-multiple-partial.html
@@ -1,5 +1,6 @@
 <div class="incident-report">
-    <div class="table">
+    <cube-grid-spinner ng-if="ctl.definition.pending"></cube-grid-spinner>
+    <div class="table" ng-if="!ctl.definition.pending">
         <div class="table-head">
             <div class="row">
                 <div class="col-sm-3" ng-repeat="property in ctl.properties | limitTo : ctl.maxDataColumns">

--- a/web/app/scripts/details/details-single-partial.html
+++ b/web/app/scripts/details/details-single-partial.html
@@ -1,8 +1,10 @@
+<cube-grid-spinner ng-if="ctl.definition.pending"></cube-grid-spinner>
+
 <driver-details-constants
      ng-if="ctl.definition.details" record="ctl.record">
 </driver-details-constants>
 
-<div ng-repeat="property in ctl.properties">
+<div ng-repeat="property in ctl.properties" ng-if="!ctl.definition.pending">
     <driver-details-field
        property="property" data="ctl.data[property.propertyName]" record="ctl.record">
     </driver-details-field>

--- a/web/app/scripts/details/details-tabs-controller.js
+++ b/web/app/scripts/details/details-tabs-controller.js
@@ -2,12 +2,39 @@
     'use strict';
 
     /* ngInject */
-    function DetailsTabsController() {
+    function DetailsTabsController(Records, $q, $rootScope, $scope) {
         var ctl = this;
-        ctl.sortedDefinitions = sortedDefinitions;
+        ctl.sortedDefinitions = sortDefinitions();
         ctl.sortedProperties = sortedProperties;
 
-        function sortedDefinitions() {
+        // Cancel pending record request, if any, when view closed
+        $scope.$on('$destroy', function() {
+            if ($rootScope.pendingRecordRequest) {
+                $rootScope.pendingRecordRequest.resolve();
+            }
+        });
+
+        function getFullRecord() {
+            // for users with full record access, go fetch all the other sections of the record
+            if (ctl.userCanWrite) {
+                // Promise that may be used to cancel the full record query.
+                // Kept on root scope so that it will still be present in scope's $destroy.
+                $rootScope.pendingRecordRequest = $q.defer();
+
+                Records.get({
+                    id: ctl.record.uuid,
+                    timeout: $rootScope.pendingRecordRequest.promise})
+                .$promise.then(function(record) {
+                    ctl.record = record;
+                    ctl.sortedDefinitions = _.map(ctl.sortedDefinitions, function(definition) {
+                        definition.pending = false;
+                        return definition;
+                    });
+                });
+            }
+        }
+
+        function sortDefinitions() {
             // get the section names, sorted by propertyOrder
             var ordering = _(ctl.recordSchema.schema.properties)
                 .sortBy(function(obj, key) {
@@ -19,13 +46,18 @@
                 })
                 .value();
 
+
             // get section definitions as sorted array, with added property for the section name
             var sorted = _.map(ordering, function(section) {
                 var definition = ctl.recordSchema.schema.definitions[section];
                 definition.propertyName = definition.title;
                 definition.propertyKey = section;
+                // only set to pending if not details section and user not public
+                definition.pending = !definition.details && ctl.userCanWrite;
                 return definition;
             });
+
+            getFullRecord();
             return sorted;
         }
 

--- a/web/app/scripts/details/details-tabs-directive.js
+++ b/web/app/scripts/details/details-tabs-directive.js
@@ -7,7 +7,8 @@
             restrict: 'AE',
             scope: {
                 recordSchema: '=',
-                record: '='
+                record: '=',
+                userCanWrite: '='
             },
             templateUrl: 'scripts/details/details-tabs-partial.html',
             bindToController: true,

--- a/web/app/scripts/details/details-tabs-partial.html
+++ b/web/app/scripts/details/details-tabs-partial.html
@@ -1,21 +1,21 @@
 <tabset>
-    <tab ng-repeat="definition in ctl.sortedDefinitions()"
+    <tab ng-repeat="definition in ctl.sortedDefinitions"
          heading="{{ definition.multiple ? definition.plural_title : definition.title }}"
-         ng-init="data = ctl.record.data[definition.propertyKey]; properties = ctl.sortedProperties(definition.properties)">
+         ng-init="properties = ctl.sortedProperties(definition.properties)">
 
         <driver-details-single
-            data="data"
-            properties="properties"
-            record="ctl.record"
-            definition="definition"
+            data="::ctl.record.data[definition.propertyKey]"
+            properties="::properties"
+            record="::ctl.record"
+            definition="::definition"
             ng-if="!definition.multiple">
         </driver-details-single>
 
         <driver-details-multiple
-            data="data"
-            properties="properties"
-            record="ctl.record"
-            definition="definition"
+            data="::ctl.record.data[definition.propertyKey]"
+            properties="::properties"
+            record="::ctl.record"
+            definition="::definition"
             ng-if="definition.multiple">
         </driver-details-multiple>
     </tab>

--- a/web/app/scripts/details/module.js
+++ b/web/app/scripts/details/module.js
@@ -2,6 +2,7 @@
     'use strict';
 
     angular.module('driver.details', [
+        'angular-spinkit',
         'driver.config',
         'driver.localization',
         'driver.weather',

--- a/web/app/scripts/details/module.js
+++ b/web/app/scripts/details/module.js
@@ -5,6 +5,7 @@
         'angular-spinkit',
         'driver.config',
         'driver.localization',
+        'driver.resources',
         'driver.weather',
         'ui.bootstrap',
         'ui.router',

--- a/web/app/scripts/resources/aggregate-query-service.js
+++ b/web/app/scripts/resources/aggregate-query-service.js
@@ -21,7 +21,7 @@
             extraParams = extraParams || {};
             doAttrFilters = doAttrFilters !== false;
             doJsonFilters = doJsonFilters !== false;
-            QueryBuilder.assembleParams(0, doAttrFilters, doJsonFilters).then( // 0 for offset
+            QueryBuilder.assembleParams(0, doAttrFilters, doJsonFilters, true).then( // 0 for offset
                 function(params) {
                     // toddow should never use a limit
                     params = _.extend(params, extraParams);
@@ -45,7 +45,7 @@
             extraParams = extraParams || {};
             doAttrFilters = doAttrFilters !== false;
             doJsonFilters = doJsonFilters !== false;
-            QueryBuilder.assembleParams(0, doAttrFilters, doJsonFilters).then( // 0 for offset
+            QueryBuilder.assembleParams(0, doAttrFilters, doJsonFilters, true).then( // 0 for offset
                 function(params) {
                 // stepwise should never use a limit
                 params = _.extend(params, extraParams);

--- a/web/app/scripts/resources/query-builder-service.js
+++ b/web/app/scripts/resources/query-builder-service.js
@@ -34,14 +34,18 @@
                                        from FilterState service.
          * @param {bool} doJsonFilters If true: Generate a filter on record data (i.e. jsonb fields)
                                        from FilterState service.
+         * @param {bool} detailsOnly   If true: Return only the Details section of the record
          */
-        function djangoQuery(offset, extraParams, doAttrFilters, doJsonFilters) {
+        function djangoQuery(offset, extraParams, doAttrFilters, doJsonFilters, detailsOnly) {
             var deferred = $q.defer();
             extraParams = extraParams || {};
             // Default to applying filters
             doAttrFilters = doAttrFilters !== false;
             doJsonFilters = doJsonFilters !== false;
-            assembleParams(offset, doAttrFilters, doJsonFilters).then(function(params) {
+            // Default to include only details in response
+            detailsOnly = detailsOnly !== false;
+
+            assembleParams(offset, doAttrFilters, doJsonFilters, detailsOnly).then(function(params) {
                 Records.get(_.extend(params, extraParams)).$promise.then(function(records) {
                     deferred.resolve(records);
                 });
@@ -106,9 +110,10 @@
          * @param {number} offset The offset to use for pagination of results
          * @param {bool} doAttrFilters Whether or not to include filters on record attributes
          * @param {bool} doJsonFilters Whether or not to include filters on record data (jsonb fields)
+         * @param {bool} detailsOnly   Whether or not to request only the Details section
          *
          */
-        function assembleParams(offset, doAttrFilters, doJsonFilters) {
+        function assembleParams(offset, doAttrFilters, doJsonFilters, detailsOnly) {
             var deferred = $q.defer();
             var paramObj = { limit: WebConfig.record.limit };
             var p1;
@@ -130,6 +135,12 @@
                         }
                     }
                 );
+            }
+
+            if (detailsOnly) {
+                paramObj = _.extend(paramObj, {
+                    details_only: 'True'
+                });
             }
 
             $q.when(p1).then(function() {

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -29,12 +29,12 @@
          * initialization
          */
         function init() {
-          selected = null;
-          gettingSelected = false;
-          gettingOptions = false;
-          options = [];
-          defaultParams = {'active': 'True'};
-          svc.updateOptions();
+            selected = null;
+            gettingSelected = false;
+            gettingOptions = false;
+            options = [];
+            defaultParams = {'active': 'True'};
+            svc.updateOptions();
         }
 
         /**
@@ -45,17 +45,17 @@
         function updateOptions(params) {
             var filterParams = angular.extend({}, params, defaultParams);
             return RecordTypes.query(filterParams).$promise.then(function(results) {
-                  options = results;
-                  $rootScope.$broadcast('driver.state.recordstate:options', options);
-                  if (!results.length) {
-                      $log.warn('No record types returned');
-                  } else {
-                      if (!selected && options[0]) {
-                          selected = svc.setSelected(options[0]);
-                      } else if (!_.includes(options, selected)) {
-                          svc.setSelected(selected);
-                      }
-                  }
+                options = results;
+                $rootScope.$broadcast('driver.state.recordstate:options', options);
+                if (!results.length) {
+                    $log.warn('No record types returned');
+                } else {
+                    if (!selected && options[0]) {
+                        selected = svc.setSelected(options[0]);
+                    } else if (!_.includes(options, selected)) {
+                        svc.setSelected(selected);
+                    }
+                }
             });
         }
 

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -418,17 +418,17 @@
          * when a new filter is applied, layer selection is preserved
          */
         function addLayerSwitcher() {
-            var overlays = angular.extend(
-                _.zipObject([
-                    /* jshint camelcase: false */
-                    [ctl.recordType.plural_label, ctl.primaryLayerGroup],
-                    [ctl.secondaryType.plural_label, ctl.secondaryLayerGroup],
-                    /* jshint camelcase: true */
-                    ['Heatmap', ctl.heatmapLayerGroup],
-                    ['Blackspots', ctl.blackspotLayerGroup],
-                ]),
-                ctl.boundariesLayerGroup
-            );
+            /* jshint camelcase: false */
+            var recordLayers = [[ctl.recordType.plural_label, ctl.primaryLayerGroup]];
+            if (ctl.secondaryType) {
+                recordLayers.push([ctl.secondaryType.plural_label, ctl.secondaryLayerGroup]);
+            }
+            /* jshint camelcase: true */
+
+            recordLayers.push(['Heatmap', ctl.heatmapLayerGroup]);
+            recordLayers.push(['Blackspots', ctl.blackspotLayerGroup]);
+            var overlays = angular.extend(_.zipObject(recordLayers), ctl.boundariesLayerGroup);
+
             ctl.bMaps.then(
                 function(baseMaps){
                     // only add the layer switcher once
@@ -493,6 +493,11 @@
          * click events and popup
          */
         function updateSecondaryLayer(recordsUrl, utfGridUrl){
+            if (!ctl.secondaryType) {
+                ctl.secondaryLayerGroup = null;
+                return;
+            }
+
             var recordsLayerOptions = angular.extend(defaultLayerOptions, {
                 zIndex: 9
             });
@@ -507,7 +512,12 @@
                     zIndex: 11
                 });
 
-            addGridRecordEvent(utfGridRecordsLayer, { label: ctl.secondaryType.label });
+            var secondaryParams = {};
+            if (ctl.secondaryType) {
+                secondaryParams = { label: ctl.secondaryType.label };
+            }
+
+            addGridRecordEvent(utfGridRecordsLayer, secondaryParams);
 
             if (!ctl.secondaryLayerGroup) {
                 ctl.secondaryLayerGroup = new L.layerGroup(

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -771,7 +771,7 @@
         }
 
         function getTilekeys() {
-            var primary = QueryBuilder.djangoQuery(0, getAdditionalParams()).then(
+            var primary = QueryBuilder.djangoQuery(0, getAdditionalParams(), true, true, false).then(
                 function(records) { ctl.tilekey = records.tilekey; }
             );
             var secondary = $q.resolve('');
@@ -780,7 +780,7 @@
                 /* jshint camelcase: false */
                 params.record_type = ctl.secondaryType.uuid;
                 /* jshint camelcase: true */
-                secondary = QueryBuilder.djangoQuery(0, params, true, false).then(
+                secondary = QueryBuilder.djangoQuery(0, params, true, false, false).then(
                     function(records) { ctl.secondaryTilekey = records.tilekey; }
                 );
             }

--- a/web/app/scripts/views/map/map-controller.js
+++ b/web/app/scripts/views/map/map-controller.js
@@ -27,9 +27,14 @@
                                 controller: 'RecordDetailsModalController as modal',
                                 size: 'lg',
                                 resolve: {
+                                    /* jshint camelcase: false */
                                     record: function() {
-                                        return Records.get({ id: recordUUID }).$promise;
+                                        return Records.get({
+                                            id: recordUUID,
+                                            details_only: 'True'
+                                        }).$promise;
                                     },
+                                    /* jshint camelcase: true */
                                     recordType: function () {
                                         return recordType;
                                     },

--- a/web/app/scripts/views/record/details-modal-partial.html
+++ b/web/app/scripts/views/record/details-modal-partial.html
@@ -21,7 +21,8 @@
         <driver-details-tabs
             class="modal-body"
             record-schema="modal.recordSchema"
-            record="modal.record">
+            record="modal.record"
+            user-can-write="modal.userCanWrite">
         </driver-details-tabs>
         <div class="modal-footer">
             <button class="btn btn-primary" ng-click="modal.close()">

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function RecordListController($scope, $rootScope, $log, $modal, $state, uuid4, AuthService,
                                   FilterState, InitialState, Notifications, RecordSchemaState,
-                                  RecordState, BoundaryState, QueryBuilder, WebConfig) {
+                                  Records, RecordState, BoundaryState, QueryBuilder, WebConfig) {
         var ctl = this;
         ctl.boundaryId = null;
         ctl.currentOffset = 0;
@@ -120,7 +120,12 @@
                 size: 'lg',
                 resolve: {
                     record: function() {
-                        return record;
+                        if (ctl.userCanWrite) {
+                            // for non-public users, go fetch all the other sections of the record
+                            return Records.get({ id: record.uuid }).$promise;
+                        } else {
+                            return record;
+                        }
                     },
                     recordType: function() {
                         return ctl.recordType;

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function RecordListController($scope, $rootScope, $log, $modal, $state, uuid4, AuthService,
                                   FilterState, InitialState, Notifications, RecordSchemaState,
-                                  Records, RecordState, BoundaryState, QueryBuilder, WebConfig) {
+                                  RecordState, BoundaryState, QueryBuilder, WebConfig) {
         var ctl = this;
         ctl.boundaryId = null;
         ctl.currentOffset = 0;
@@ -120,12 +120,7 @@
                 size: 'lg',
                 resolve: {
                     record: function() {
-                        if (ctl.userCanWrite) {
-                            // for non-public users, go fetch all the other sections of the record
-                            return Records.get({ id: record.uuid }).$promise;
-                        } else {
-                            return record;
-                        }
+                         return record;
                     },
                     recordType: function() {
                         return ctl.recordType;

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -68,7 +68,7 @@
             var params = ctl.boundaryId ? { polygon_id: ctl.boundaryId } : {};
             /* jshint camelcase: true */
 
-            return QueryBuilder.djangoQuery(newOffset, params)
+            return QueryBuilder.djangoQuery(newOffset, params, true, true, true)
             .then(function(records) {
                 ctl.records = records;
                 ctl.currentOffset = newOffset;

--- a/web/test/spec/details/details-tabs-controller.spec.js
+++ b/web/test/spec/details/details-tabs-controller.spec.js
@@ -2,21 +2,45 @@
 
 describe('driver.details: DetailsTabsController', function () {
 
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('driver.mock.resources'));
+    beforeEach(module('ase.templates'));
     beforeEach(module('driver.details'));
 
-    var $controller;
+    var $compile;
+    var $httpBackend;
+    var $q;
     var $rootScope;
-    var $scope;
-    var Controller;
+    var DriverResourcesMock;
+    var ResourcesMock;
 
-    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_) {
-        $controller = _$controller_;
+    beforeEach(inject(function (_$compile_, _$httpBackend_, _$q_, _$rootScope_,
+                                _DriverResourcesMock_, _ResourcesMock_) {
+        $compile = _$compile_;
+        $httpBackend = _$httpBackend_;
+        $q = _$q_;
         $rootScope = _$rootScope_;
-        $scope = $rootScope.$new();
+        DriverResourcesMock = _DriverResourcesMock_;
+        ResourcesMock = _ResourcesMock_;
     }));
 
     it('should pass this placeholder test', function () {
-        Controller = $controller('DetailsTabsController', { $scope: $scope });
-        $scope.$apply();
+        var scope = $rootScope.$new();
+        scope.record = DriverResourcesMock.RecordResponse.results[0];
+        scope.recordSchema = ResourcesMock.RecordSchemaResponse.results[0];
+
+        var recordUrl = /api\/records\//;
+        $httpBackend.expectGET(recordUrl).respond(200, DriverResourcesMock.RecordResponse.results[0]);
+
+        var element = $compile('<driver-details-tabs ' +
+                               'record-schema="recordSchema" record="record" user-can-write="true">' +
+                               '</driver-details-tabs>')(scope);
+        $rootScope.$apply();
+
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+
+        var controller = element.controller('driverDetailsTabs');
+        expect(controller).toBeDefined();
     });
 });

--- a/web/test/spec/details/details-tabs-directive.spec.js
+++ b/web/test/spec/details/details-tabs-directive.spec.js
@@ -11,6 +11,7 @@ describe('driver.details: DetailsTabs', function () {
     var $httpBackend;
     var $rootScope;
     var DriverResourcesMock;
+    var Records;
     var ResourcesMock;
 
     beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_,
@@ -24,14 +25,19 @@ describe('driver.details: DetailsTabs', function () {
 
     it('should render tabs item', function () {
         var scope = $rootScope.$new();
-
         scope.record = DriverResourcesMock.RecordResponse.results[0];
         scope.recordSchema = ResourcesMock.RecordSchemaResponse.results[0];
 
+        var recordUrl = /api\/records\//;
+        $httpBackend.expectGET(recordUrl).respond(200, DriverResourcesMock.RecordResponse.results[0]);
+
         var element = $compile('<driver-details-tabs ' +
-                               'record-schema="recordSchema" record="record">' +
+                               'record-schema="recordSchema" record="record" user-can-write="true">' +
                                '</driver-details-tabs>')(scope);
         $rootScope.$apply();
+
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
 
         expect(element.find('.tab-content').length).toEqual(1);
     });

--- a/web/test/spec/resources/query-builder-service-spec.js
+++ b/web/test/spec/resources/query-builder-service-spec.js
@@ -37,7 +37,7 @@ describe('driver.resources: QueryBuilder', function () {
 
     it('should result in a call out to determine the selected RecordType and use the date filtering on FilterState', function () {
         // 2015-10-05 is 2015-10-04T16:00:00.000Z in local Manila time
-        var recordsUrl = /\/api\/records\/\?archived=false&limit=50&occurred_min=2015-10-04T16:00:00.000Z&record_type=15460346-65d7-4f4d-944d-27324e224691/;
+        var recordsUrl = /\/api\/records\/\?archived=false&details_only=True&limit=50&occurred_min=2015-10-04T16:00:00.000Z&record_type=15460346-65d7-4f4d-944d-27324e224691/;
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
         var recordSchemaUrl = /\/api\/recordschemas/;
 

--- a/windshaft/driver.js
+++ b/windshaft/driver.js
@@ -115,7 +115,7 @@ function setRequestParameters(request, callback, redisClient) {
 
     if (params.tablename === 'ashlar_record') {
 
-        params.interactivity = 'uuid,occurred_from,data';
+        params.interactivity = 'uuid,occurred_from';
         params.style = eventsStyle;
 
         if (request.query.heatmap) {


### PR DESCRIPTION
Only load full record when user with access to full record goes to detail/edit view for the record. Reuses response transformer for public user that omits all but the `Details` section from the record information returned. This prevents potentially large amounts of data being loaded when image data exists on records.

Also fixes some Javascript errors when `secondaryType` is undefined in the map view, and fixes fetching the `Details` section for public users.