### PR TITLE
Isolate Linux specific NFS options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,11 @@ ANSIBLE_GROUPS = {
   "database-servers" => [ "database" ],
   "celery-servers" => [ "celery" ]
 }
+MOUNT_OPTIONS = if Vagrant::Util::Platform.linux? then
+                  ['rw', 'vers=4', 'tcp', 'nolock']
+                else
+                  ['vers=3', 'udp']
+                end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
@@ -81,11 +86,11 @@ Vagrant.configure("2") do |config|
     # Disable because this will not get used.
     app.vm.synced_folder ".", "/vagrant", disabled: true
 
-    app.vm.synced_folder "./app", "/opt/app", type: "nfs"
-    app.vm.synced_folder "./web", "/opt/web", type: "nfs"
-    app.vm.synced_folder "./windshaft", "/opt/windshaft", type: "nfs"
-    app.vm.synced_folder "./schema_editor", "/opt/schema_editor", type: "nfs"
-    app.vm.synced_folder "../ashlar", "/opt/ashlar", type: "nfs"
+    app.vm.synced_folder "./app", "/opt/app", type: "nfs", mount_options: MOUNT_OPTIONS
+    app.vm.synced_folder "./web", "/opt/web", type: "nfs", mount_options: MOUNT_OPTIONS
+    app.vm.synced_folder "./windshaft", "/opt/windshaft", type: "nfs", mount_options: MOUNT_OPTIONS
+    app.vm.synced_folder "./schema_editor", "/opt/schema_editor", type: "nfs", mount_options: MOUNT_OPTIONS
+    app.vm.synced_folder "../ashlar", "/opt/ashlar", type: "nfs", mount_options: MOUNT_OPTIONS
 
     # nginx
     app.vm.network "forwarded_port", guest: 80, host: Integer(ENV.fetch("DRIVER_WEB_PORT_80", 7000))
@@ -125,15 +130,12 @@ Vagrant.configure("2") do |config|
     # Disable because this will not get used.
     celery.vm.synced_folder ".", "/vagrant", disabled: true
 
-    celery.vm.synced_folder "./app", "/opt/app", type: "nfs", mount_options: ['rw', 'vers=4', 'tcp', 'nolock']
-    celery.vm.synced_folder "./web", "/opt/web", type: "nfs", mount_options: ['rw', 'vers=4', 'tcp', 'nolock']
-    celery.vm.synced_folder "./schema_editor", "/opt/schema_editor", type: "nfs", mount_options: ['rw', 'vers=4', 'tcp', 'nolock']
-    celery.vm.synced_folder "../ashlar", "/opt/ashlar", type: "nfs", mount_options: ['rw', 'vers=4', 'tcp', 'nolock']
-
+    celery.vm.synced_folder "./app", "/opt/app", type: "nfs", mount_options: MOUNT_OPTIONS
+    celery.vm.synced_folder "./web", "/opt/web", type: "nfs", mount_options: MOUNT_OPTIONS
+    celery.vm.synced_folder "./schema_editor", "/opt/schema_editor", type: "nfs", mount_options: MOUNT_OPTIONS
+    celery.vm.synced_folder "../ashlar", "/opt/ashlar", type: "nfs", mount_options: MOUNT_OPTIONS
     # jar build task on celery vm
-    celery.vm.synced_folder "./gradle", "/opt/gradle",
-      :nfs => true,
-      :mount_options => ['rw', 'vers=4', 'tcp', 'nolock']
+    celery.vm.synced_folder "./gradle", "/opt/gradle", type: "nfs", mount_options: MOUNT_OPTIONS
 
     # Docker
     celery.vm.network "forwarded_port", guest: 2375, host: 2376


### PR DESCRIPTION
NFSv4 specific options have been isolated to target Linux based Vagrant virtual machine hosts. Other hosts, such has Macs, will just inherit the defaults Vagrant provides.