### PR TITLE
Fix record property display in list view

### DIFF
--- a/web/app/scripts/details/details-tabs-controller.js
+++ b/web/app/scripts/details/details-tabs-controller.js
@@ -23,6 +23,7 @@
             var sorted = _.map(ordering, function(section) {
                 var definition = ctl.recordSchema.schema.definitions[section];
                 definition.propertyName = definition.title;
+                definition.propertyKey = section;
                 return definition;
             });
             return sorted;

--- a/web/app/scripts/details/details-tabs-controller.js
+++ b/web/app/scripts/details/details-tabs-controller.js
@@ -19,7 +19,6 @@
                 })
                 .value();
 
-
             // get section definitions as sorted array, with added property for the section name
             var sorted = _.map(ordering, function(section) {
                 var definition = ctl.recordSchema.schema.definitions[section];

--- a/web/app/scripts/details/details-tabs-partial.html
+++ b/web/app/scripts/details/details-tabs-partial.html
@@ -1,7 +1,7 @@
 <tabset>
     <tab ng-repeat="definition in ctl.sortedDefinitions()"
          heading="{{ definition.multiple ? definition.plural_title : definition.title }}"
-         ng-init="data = ctl.record.data[definition.propertyName]; properties = ctl.sortedProperties(definition.properties)">
+         ng-init="data = ctl.record.data[definition.propertyKey]; properties = ctl.sortedProperties(definition.properties)">
 
         <driver-details-single
             data="data"

--- a/web/app/scripts/views/dashboard/dashboard-controller.js
+++ b/web/app/scripts/views/dashboard/dashboard-controller.js
@@ -74,7 +74,6 @@
             var detailsDefinitions = _.filter(ctl.recordSchema.schema.definitions, 'details');
             ctl.propertiesKey = detailsDefinitions[0].properties;
             ctl.headerKeys = _.without(_.keys(ctl.propertiesKey), '_localId');
-            ctl.detailsProperty = detailsDefinitions[0].title;
         }
     }
 

--- a/web/app/scripts/views/duplicates/duplicates-list-controller.js
+++ b/web/app/scripts/views/duplicates/duplicates-list-controller.js
@@ -67,6 +67,7 @@
             var detailsDefinitions = _.filter(ctl.recordSchema.schema.definitions,
                 function(val, key) {
                     if (key.indexOf('Details') > -1) {
+                        ctl.detailsPropertyKey = key;
                         return val;
                     }
                 });
@@ -84,8 +85,6 @@
                 })
                 .sortBy('propertyOrder')
                 .value();
-
-            ctl.detailsProperty = detailsDefinitions[0].title;
         }
 
         // Loads the previous page of paginated duplicates results
@@ -111,7 +110,7 @@
                             recordType: ctl.recordType,
                             recordSchema: ctl.recordSchema,
                             properties: ctl.headerKeys,
-                            propertyName: ctl.detailsProperty
+                            propertyKey: ctl.detailsPropertyKey
                         };
                     }
                 }

--- a/web/app/scripts/views/duplicates/resolve-duplicate-modal-partial.html
+++ b/web/app/scripts/views/duplicates/resolve-duplicate-modal-partial.html
@@ -9,7 +9,7 @@
         <div class="duplicate-details"
              ng-repeat="record in [modal.params.duplicate.record, modal.params.duplicate.duplicate_record]">
             <driver-details-single
-                data="record.data[modal.params.propertyName]"
+                data="record.data[modal.params.propertyKey]"
                 properties="modal.params.properties"
                 record="record">
             </driver-details-single>

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -81,9 +81,7 @@
                     if (key.indexOf('Details') > -1) {
                         // keep the actual field name
                         // for lookup on ctl.recordSchema.schema.definitions
-                        /* jshint camelcase: false */
-                        ctl.detailsPropertyName = val.plural_title || val.title || key;
-                        /* jshint camelcase: true */
+                        ctl.detailsPropertyKey = key;
                         return val;
                     }
                 });
@@ -102,8 +100,6 @@
                 .sortBy('propertyOrder')
                 .map('propertyName')
                 .value();
-
-            ctl.detailsProperty = detailsDefinitions[0].title;
         }
 
         // Loads the previous page of paginated record results

--- a/web/app/scripts/views/record/list-partial.html
+++ b/web/app/scripts/views/record/list-partial.html
@@ -22,9 +22,9 @@
                         <td class="detail" ng-repeat="headerKey in ctl.headerKeys | limitTo : ctl.maxDataColumns">
                             <driver-details-field
                                 compact="true"
-                                data="::record.data[ctl.detailsPropertyName][headerKey]"
+                                data="::record.data[ctl.detailsPropertyKey][headerKey]"
                                 record="::record"
-                                property="::ctl.recordSchema.schema.definitions[ctl.detailsPropertyName].properties[headerKey]">
+                                property="::ctl.recordSchema.schema.definitions[ctl.detailsPropertyKey].properties[headerKey]">
                             </driver-details-field>
                         </td>
 


### PR DESCRIPTION
The fields in record list view had started breaking because PR #405 took
ctl.detailsPropertyName to be a title when in fact it's a key. This
changes it to ctl.detailsPropertyKey and changes ctl.detailsProperty,
which is the title, to get the plural title if defined.

Question: ctl.detailsProperty isn't actually used anywhere.  Delete it? Or keep it around on theory that if someone wants that title in the future it would be a bother for them to have to figure out how to get at it again?