### PR TITLE
Make add/edit view work for interventions

### DIFF
--- a/web/app/scripts/details/details-constants-partial.html
+++ b/web/app/scripts/details/details-constants-partial.html
@@ -4,6 +4,9 @@
     </label>
     <div class="value constant date occurred">
         {{ ::ctl.record.occurred_from | localDateTime : ctl.dateFormat }}
+        <span ng-if="::ctl.record.isSecondary && ctl.record.occurred_to">
+         - {{ ::ctl.record.occurred_to | localDateTime : ctl.dateFormat }}
+        </span>
     </div>
 </div>
 <div class="col-sm-6">
@@ -44,7 +47,7 @@
         {{ ::ctl.record.geom.coordinates[0] | number:5 }}
     </div>
 </div>
-<div class="col-sm-6">
+<div ng-if="::!ctl.record.isSecondary" class="col-sm-6">
     <label>
         Weather
     </label>
@@ -58,7 +61,7 @@
         Powered by Forecast
     </a>
 </div>
-<div class="col-sm-6">
+<div ng-if="::!ctl.record.isSecondary" class="col-sm-6">
     <label>
         Light
     </label>

--- a/web/app/scripts/details/details-selectlist-controller.js
+++ b/web/app/scripts/details/details-selectlist-controller.js
@@ -3,6 +3,14 @@
 
     /* ngInject */
     function DetailsSelectlistController() {
+        var ctl = this;
+        init();
+
+        function init() {
+            if (Array.isArray(ctl.data)) {
+                ctl.data = ctl.data.join('; ');
+            }
+        }
     }
 
     angular.module('driver.details')

--- a/web/app/scripts/details/details-tabs-partial.html
+++ b/web/app/scripts/details/details-tabs-partial.html
@@ -4,19 +4,19 @@
          ng-init="properties = ctl.sortedProperties(definition.properties)">
 
         <driver-details-single
+            ng-if="!definition.multiple"
             data="::ctl.record.data[definition.propertyKey]"
             properties="::properties"
             record="::ctl.record"
-            definition="::definition"
-            ng-if="!definition.multiple">
+            definition="::definition">
         </driver-details-single>
 
         <driver-details-multiple
+            ng-if="definition.multiple"
             data="::ctl.record.data[definition.propertyKey]"
             properties="::properties"
             record="::ctl.record"
-            definition="::definition"
-            ng-if="definition.multiple">
+            definition="::definition">
         </driver-details-multiple>
     </tab>
 </tabset>

--- a/web/app/scripts/state/recordstate-service.js
+++ b/web/app/scripts/state/recordstate-service.js
@@ -143,7 +143,7 @@
 
         function getSecondary() {
             if (initialized) {
-                return secondaryType;
+                return $q.resolve(secondaryType);
             } else {
                 return getSelected().then(function () { return secondaryType; });
             }

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -85,7 +85,9 @@
                         .then(function(filterables) {
                             ctl.recordSchemaFilterables = filterables;
                         });
-                    ctl.secondaryType = RecordState.getSecondary();
+                    RecordState.getSecondary().then(function (secondaryType) {
+                        ctl.secondaryType = secondaryType;
+                    });
                 } else {
                     ctl.recordSchemaFilterables = [];
                     ctl.recordType = {

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -2,8 +2,8 @@
     'use strict';
 
     /* ngInject */
-    function RecordAddEditController($log, $scope, $state, $stateParams, $window, uuid4,
-                                     AuthService, Nominatim, Notifications, Records,
+    function RecordAddEditController($log, $scope, $state, $stateParams, $window, $q, uuid4,
+                                     AuthService, Nominatim, Notifications, Records, RecordState,
                                      RecordSchemaState, RecordTypes, WeatherService, WebConfig) {
         var ctl = this;
         var editorData = null;
@@ -19,20 +19,16 @@
             ctl.goBack = goBack;
             ctl.onDataChange = onDataChange;
             ctl.onSaveClicked = onSaveClicked;
-            ctl.occurredFromChanged = occurredFromChanged;
+            ctl.onDateChanged = onDateChanged;
             ctl.onGeomChanged = onGeomChanged;
             ctl.nominatimLookup = nominatimLookup;
             ctl.nominatimSelect = nominatimSelect;
+            ctl.openOccurredDatePicker = openOccurredDatePicker;
 
             ctl.userCanWrite = AuthService.hasWriteAccess();
 
-            ctl.openOccurredDatePicker = openOccurredDatePicker;
-
-            // Weather
-            ctl.lightValues = WeatherService.lightValues;
-            ctl.weatherValues = WeatherService.weatherValues;
-            ctl.weather = '';
-            ctl.light = '';
+            // This state attribute will be true when adding secondary records
+            ctl.secondary = $state.current.secondary;
 
             // Only location text is currently being displayed in the UI. The other nominatim
             // values are only being stored. The variables have been placed on the controller
@@ -92,9 +88,25 @@
                 }
             });
 
-            var recordPromise = $stateParams.recorduuid ? loadRecord() : null;
-            (recordPromise ? recordPromise.then(loadRecordSchema) : loadRecordSchema())
-                .then(onSchemaReady);
+            // If there's a record, load it first then get its schema.
+            var schemaPromise;
+            if ($stateParams.recorduuid) {
+                schemaPromise = loadRecord().then(loadRecordSchema);
+            } else {
+                schemaPromise = loadRecordSchema();
+            }
+
+            schemaPromise.then(function () {
+                // Suppress light and weather for Interventions
+                if (!ctl.secondary) {
+                    // Weather
+                    ctl.lightValues = WeatherService.lightValues;
+                    ctl.weatherValues = WeatherService.weatherValues;
+                    ctl.weather = '';
+                    ctl.light = '';
+                }
+                onSchemaReady();
+            });
         }
 
         // Called when calendar icon of occurred date picker is pressed
@@ -124,20 +136,26 @@
          * @param {object} record The record object where occurred_to resides
          * @param {bool} reverse True if the fix is being reversed out of for saving purposes
          */
-        function fixOccurredDTForPickers(record, reverse) {
+        function fixOccurredDTForPickers(reverse) {
             /* jshint camelcase: false */
-            var occurredDT = new Date(record.occurred_from);
-            var browserTZOffset = occurredDT.getTimezoneOffset();
-            var configuredTZOffset = moment(occurredDT).tz(timeZone)._offset;
-
+            var occurredFromDT = new Date(ctl.occurred_from);
+            var browserTZOffset = occurredFromDT.getTimezoneOffset();
+            var configuredTZOffset = moment(occurredFromDT).tz(timeZone)._offset;
             // Note that the native js getTimezoneOffset returns the opposite of what
             // you'd expect: i.e. EST which is UTC-5 gets returned as positive 5.
             // The `moment` method of returning the offset would return this as a -5.
             // Therefore if the browser tz is the same as the configured local tz,
             // the following offset will cancel out and return zero.
             var offset = (browserTZOffset + configuredTZOffset) * (reverse ? -1 : +1);
-            occurredDT.setMinutes(occurredDT.getMinutes() + offset);
-            record.occurred_from = occurredDT;
+
+            occurredFromDT.setMinutes(occurredFromDT.getMinutes() + offset);
+            ctl.occurred_from = occurredFromDT;
+
+            if (ctl.occurred_to) {
+                var occurredToDT = new Date(ctl.occurred_to);
+                occurredToDT.setMinutes(occurredToDT.getMinutes() + offset);
+                ctl.occurred_to = occurredToDT;
+            }
             /* jshint camelcase: true */
         }
 
@@ -145,11 +163,14 @@
         function loadRecord() {
             return Records.get({ id: $stateParams.recorduuid })
                 .$promise.then(function(record) {
-                    // Prep the occurred_from datetime for use with pickers
-                    fixOccurredDTForPickers(record, false);
-
                     ctl.record = record;
+
                     /* jshint camelcase: false */
+                    ctl.occurred_from = ctl.record.occurred_from;
+                    ctl.occurred_to = ctl.record.occurred_to;
+                    // Prep the occurred_from datetime for use with pickers
+                    fixOccurredDTForPickers(false);
+
                     // set lat/lng array into bind-able object
                     ctl.geom.lat = ctl.record.geom.coordinates[1];
                     ctl.geom.lng = ctl.record.geom.coordinates[0];
@@ -169,18 +190,47 @@
                 });
         }
 
+        /* Loads the right schema:
+         * -If there's a record, loads the latest schema for the record's type, checking whether
+         *  it matches the secondary type and setting ctl.secondary to true if so.
+         * -Othersise, loads either the latest schema for either the primary or the secondary
+         *  record type, depending on whether ctl.secondary is true.
+         * If no record type loads (e.g. if someone is trying to add a secondary record but has
+         * no secondary recordType), sets an error and returns a rejected promise.
+         */
         function loadRecordSchema() {
-            return RecordTypes.query({ record: $stateParams.recorduuid }).$promise
-                .then(function (result) {
-                    ctl.recordType = result[0];
+            var typePromise;
+            if (ctl.record) {
+                typePromise = RecordTypes.query({ record: ctl.record.uuid }).$promise
+                    .then(function (result) {
+                        var recordType = result[0];
+                        RecordState.getSecondary().then(function (secondaryType) {
+                            if (!!secondaryType && secondaryType.uuid === recordType.uuid) {
+                                ctl.secondary = true;
+                            }
+                        });
+                        return recordType;
+                    });
+            } else if (ctl.secondary) {
+                typePromise = RecordState.getSecondary();
+            } else {
+                typePromise = RecordState.getSelected();
+            }
+            return typePromise.then(function (recordType) {
+                if (recordType) {
+                    ctl.recordType = recordType;
                     /* jshint camelcase: false */
                     return RecordSchemaState.get(ctl.recordType.current_schema)
                     /* jshint camelcase: true */
                         .then(function(recordSchema) { ctl.recordSchema = recordSchema; });
-                });
+                } else {
+                    ctl.error = 'Unable to load record schema.';
+                    return $q.reject(ctl.error);
+                }
+            });
         }
 
-        function occurredFromChanged() {
+        function onDateChanged() {
             // update whether all constant fields are present
             constantFieldsValidationErrors();
         }
@@ -301,26 +351,33 @@
             var required = {
                 'latitude': ctl.geom.lat,
                 'longitude': ctl.geom.lng,
-                'occurred': (ctl.record ? ctl.record.occurred_from : null)
+                'occurred': ctl.occurred_from
             };
             /* jshint camelcase: true */
 
             ctl.constantFieldErrors = {};
-            var errorMessage = '';
             angular.forEach(required, function(value, fieldName) {
                 if (!value) {
                     // message formatted to match errors from json-editor
-                    errorMessage += '<p>' + fieldName + ': Value required</p>';
-                    ctl.constantFieldErrors[fieldName] = true;
+                    ctl.constantFieldErrors[fieldName] = fieldName + ': Value required';
                 }
             });
+            /* jshint camelcase: false */
+            if (ctl.occurred_from && ctl.occurred_to && ctl.occurred_from > ctl.occurred_to) {
+                ctl.constantFieldErrors.occurred_to = 'End date cannot be before start date.';
+            }
+            /* jshint camelcase: true */
 
             // make field errors falsy if empty, for partial to check easily
             if (Object.keys(ctl.constantFieldErrors).length === 0) {
                 ctl.constantFieldErrors = null;
+                return '';
+            } else {
+                var errors = _.map(ctl.constantFieldErrors, function(message) {
+                    return '<p>' + message + '</p>';
+                });
+                return errors.join('');
             }
-
-            return errorMessage;
         }
 
         function goBack() {
@@ -359,11 +416,17 @@
             var saveMethod = null;
             var dataToSave = null;
 
-            // Reverse the date and time picker timezone fix to get back to the actual correct time
-            fixOccurredDTForPickers(ctl.record, true);
-
+            // If editing a primary record (where we don't ask for 'to' date) or if 'to' date is
+            // blank, set it to be the same as 'from' date.
             /* jshint camelcase: false */
-            if (ctl.record.geom) {
+            if (!ctl.secondary || !ctl.occurred_to) {
+                ctl.occurred_to = ctl.occurred_from;
+            }
+
+            // Reverse the date and time picker timezone fix to get back to the actual correct time
+            fixOccurredDTForPickers(true);
+
+            if (ctl.record && ctl.record.geom) {
                 // set back coordinates and nominatim values
                 ctl.record.geom.coordinates = [ctl.geom.lng, ctl.geom.lat];
                 ctl.record.location_text = ctl.nominatimLocationText;
@@ -375,10 +438,10 @@
                 ctl.record.state = ctl.nominatimState;
                 ctl.record.weather = ctl.weather;
                 ctl.record.light = ctl.light;
+                ctl.record.occurred_from = ctl.occurred_from;
+                ctl.record.occurred_to = ctl.occurred_to;
 
                 saveMethod = 'update';
-                // set `to` date to match `from` date
-                ctl.record.occurred_to = ctl.record.occurred_from;
                 dataToSave = ctl.record;
                 dataToSave.data = editorData;
             } else {
@@ -399,9 +462,8 @@
                     weather: ctl.weather,
                     light: ctl.light,
 
-                    occurred_from: ctl.record.occurred_from,
-                    // set `to` date to match `from` date
-                    occurred_to: ctl.record.occurred_from
+                    occurred_from: ctl.occurred_from,
+                    occurred_to: ctl.occurred_to
                 };
             }
             /* jshint camelcase: true */

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -27,8 +27,9 @@
 
             ctl.userCanWrite = AuthService.hasWriteAccess();
 
-            // This state attribute will be true when adding secondary records
-            ctl.secondary = $state.current.secondary;
+            // This state attribute will be true when adding secondary records. When editing,
+            // this will be set when the record type is loaded.
+            ctl.isSecondary = $state.current.secondary;
 
             // Only location text is currently being displayed in the UI. The other nominatim
             // values are only being stored. The variables have been placed on the controller
@@ -98,7 +99,7 @@
 
             schemaPromise.then(function () {
                 // Suppress light and weather for Interventions
-                if (!ctl.secondary) {
+                if (!ctl.isSecondary) {
                     // Weather
                     ctl.lightValues = WeatherService.lightValues;
                     ctl.weatherValues = WeatherService.weatherValues;
@@ -190,9 +191,9 @@
 
         /* Loads the right schema:
          * -If there's a record, loads the latest schema for the record's type, checking whether
-         *  it matches the secondary type and setting ctl.secondary to true if so.
+         *  it matches the secondary type and setting ctl.isSecondary to true if so.
          * -Othersise, loads either the latest schema for either the primary or the secondary
-         *  record type, depending on whether ctl.secondary is true.
+         *  record type, depending on whether ctl.isSecondary is true.
          * If no record type loads (e.g. if someone is trying to add a secondary record but has
          * no secondary recordType), sets an error and returns a rejected promise.
          */
@@ -204,12 +205,12 @@
                         var recordType = result[0];
                         RecordState.getSecondary().then(function (secondaryType) {
                             if (!!secondaryType && secondaryType.uuid === recordType.uuid) {
-                                ctl.secondary = true;
+                                ctl.isSecondary = true;
                             }
                         });
                         return recordType;
                     });
-            } else if (ctl.secondary) {
+            } else if (ctl.isSecondary) {
                 typePromise = RecordState.getSecondary();
             } else {
                 typePromise = RecordState.getSelected();
@@ -358,7 +359,7 @@
                     ctl.constantFieldErrors[fieldName] = fieldName + ': Value required';
                 }
             });
-            if (ctl.secondary && ctl.occurredFrom && ctl.occurredTo &&
+            if (ctl.isSecondary && ctl.occurredFrom && ctl.occurredTo &&
                     ctl.occurredFrom > ctl.occurredTo) {
                 ctl.constantFieldErrors.occurredTo = 'End date cannot be before start date.';
             }
@@ -413,7 +414,7 @@
 
             // If editing a primary record (where we don't ask for 'to' date) or if 'to' date is
             // blank, set it to be the same as 'from' date.
-            if (!ctl.secondary || !ctl.occurredTo) {
+            if (!ctl.isSecondary || !ctl.occurredTo) {
                 ctl.occurredTo = ctl.occurredFrom;
             }
 

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -137,8 +137,7 @@
          * @param {bool} reverse True if the fix is being reversed out of for saving purposes
          */
         function fixOccurredDTForPickers(reverse) {
-            /* jshint camelcase: false */
-            var occurredFromDT = new Date(ctl.occurred_from);
+            var occurredFromDT = new Date(ctl.occurredFrom);
             var browserTZOffset = occurredFromDT.getTimezoneOffset();
             var configuredTZOffset = moment(occurredFromDT).tz(timeZone)._offset;
             // Note that the native js getTimezoneOffset returns the opposite of what
@@ -149,14 +148,13 @@
             var offset = (browserTZOffset + configuredTZOffset) * (reverse ? -1 : +1);
 
             occurredFromDT.setMinutes(occurredFromDT.getMinutes() + offset);
-            ctl.occurred_from = occurredFromDT;
+            ctl.occurredFrom = occurredFromDT;
 
-            if (ctl.occurred_to) {
-                var occurredToDT = new Date(ctl.occurred_to);
+            if (ctl.occurredTo) {
+                var occurredToDT = new Date(ctl.occurredTo);
                 occurredToDT.setMinutes(occurredToDT.getMinutes() + offset);
-                ctl.occurred_to = occurredToDT;
+                ctl.occurredTo = occurredToDT;
             }
-            /* jshint camelcase: true */
         }
 
         // Helper for loading the record -- only used when in edit mode
@@ -166,8 +164,8 @@
                     ctl.record = record;
 
                     /* jshint camelcase: false */
-                    ctl.occurred_from = ctl.record.occurred_from;
-                    ctl.occurred_to = ctl.record.occurred_to;
+                    ctl.occurredFrom = ctl.record.occurred_from;
+                    ctl.occurredTo = ctl.record.occurred_to;
                     // Prep the occurred_from datetime for use with pickers
                     fixOccurredDTForPickers(false);
 
@@ -347,13 +345,11 @@
          * @returns {String} error message, which is empty if there are no errors
          */
         function constantFieldsValidationErrors() {
-            /* jshint camelcase: false */
             var required = {
                 'latitude': ctl.geom.lat,
                 'longitude': ctl.geom.lng,
-                'occurred': ctl.occurred_from
+                'occurred': ctl.occurredFrom
             };
-            /* jshint camelcase: true */
 
             ctl.constantFieldErrors = {};
             angular.forEach(required, function(value, fieldName) {
@@ -362,11 +358,10 @@
                     ctl.constantFieldErrors[fieldName] = fieldName + ': Value required';
                 }
             });
-            /* jshint camelcase: false */
-            if (ctl.occurred_from && ctl.occurred_to && ctl.occurred_from > ctl.occurred_to) {
-                ctl.constantFieldErrors.occurred_to = 'End date cannot be before start date.';
+            if (ctl.secondary && ctl.occurredFrom && ctl.occurredTo &&
+                    ctl.occurredFrom > ctl.occurredTo) {
+                ctl.constantFieldErrors.occurredTo = 'End date cannot be before start date.';
             }
-            /* jshint camelcase: true */
 
             // make field errors falsy if empty, for partial to check easily
             if (Object.keys(ctl.constantFieldErrors).length === 0) {
@@ -418,14 +413,14 @@
 
             // If editing a primary record (where we don't ask for 'to' date) or if 'to' date is
             // blank, set it to be the same as 'from' date.
-            /* jshint camelcase: false */
-            if (!ctl.secondary || !ctl.occurred_to) {
-                ctl.occurred_to = ctl.occurred_from;
+            if (!ctl.secondary || !ctl.occurredTo) {
+                ctl.occurredTo = ctl.occurredFrom;
             }
 
             // Reverse the date and time picker timezone fix to get back to the actual correct time
             fixOccurredDTForPickers(true);
 
+            /* jshint camelcase: false */
             if (ctl.record && ctl.record.geom) {
                 // set back coordinates and nominatim values
                 ctl.record.geom.coordinates = [ctl.geom.lng, ctl.geom.lat];
@@ -438,8 +433,8 @@
                 ctl.record.state = ctl.nominatimState;
                 ctl.record.weather = ctl.weather;
                 ctl.record.light = ctl.light;
-                ctl.record.occurred_from = ctl.occurred_from;
-                ctl.record.occurred_to = ctl.occurred_to;
+                ctl.record.occurred_from = ctl.occurredFrom;
+                ctl.record.occurred_to = ctl.occurredTo;
 
                 saveMethod = 'update';
                 dataToSave = ctl.record;
@@ -462,8 +457,8 @@
                     weather: ctl.weather,
                     light: ctl.light,
 
-                    occurred_from: ctl.occurred_from,
-                    occurred_to: ctl.occurred_to
+                    occurred_from: ctl.occurredFrom,
+                    occurred_to: ctl.occurredTo
                 };
             }
             /* jshint camelcase: true */

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -1,4 +1,4 @@
-<div class="json-editor-form form-area no-filterbar" ng-if="::ctl.userCanWrite">
+<div class="json-editor-form form-area no-filterbar" ng-if="ctl.userCanWrite && !ctl.error">
     <div class="col-sm-8 col-sm-offset-2">
         <div class="form-area-heading">
             <h2>{{ ::ctl.recordType.label }} Input Form</h2>
@@ -46,22 +46,22 @@
                                         class="help-block errormsg">Value required.</p>
                                 </div>
                             </div>
-        		</div>
+                        </div>
 
                         <div class="row">
                             <div class="col-md-6">
                                 <div class="form-group date-picker"
                                     ng-class="ctl.constantFieldErrors.occurred ? 'has-error' : ''">
-                                    <label class="control-label required">Occurred</label>
+                                    <label class="control-label required">Occurred {{ ctl.secondary ? 'from' : ''}}</label>
                                     <div class="input-group">
                                         <input type="text" class="form-control"
                                             datepicker-popup="longDate"
                                             is-open="ctl.occurredDatePicker.opened"
-                                            ng-change="ctl.occurredFromChanged()"
-                                            ng-model="ctl.record.occurred_from"
+                                            ng-change="ctl.onDateChanged()"
+                                            ng-model="ctl.occurred_from"
                                             placeholder="From">
                                         <span class="input-group-addon picker"
-                                              ng-click="ctl.openOccurredDatePicker()">
+                                              ng-click="ctl.occurredDatePicker.opened = true">
                                             <span class="glyphicon glyphicon-calendar"></span>
                                         </span>
                                     </div>
@@ -73,12 +73,46 @@
                                 <div class="form-group time-picker">
                                     <div class="input-group"
                                          timepicker
-                                         ng-model="ctl.record.occurred_from">
+                                         ng-model="ctl.occurred_from"
+                                         ng-change="ctl.onDateChanged()">
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="row">
+
+                        <div class="row" ng-if="ctl.secondary">
+                            <div class="col-md-6">
+                                <div class="form-group date-picker"
+                                    ng-class="ctl.constantFieldErrors.occurred_to ? 'has-error' : ''">
+                                    <label class="control-label">Occurred to</label>
+                                    <div class="input-group">
+                                        <input type="text" class="form-control"
+                                            datepicker-popup="longDate"
+                                            is-open="ctl.occurredToDatePicker.opened"
+                                            ng-change="ctl.onDateChanged()"
+                                            ng-model="ctl.occurred_to"
+                                            placeholder="To">
+                                        <span class="input-group-addon picker"
+                                              ng-click="ctl.occurredToDatePicker.opened = true">
+                                            <span class="glyphicon glyphicon-calendar"></span>
+                                        </span>
+                                    </div>
+                                    <p ng-if="ctl.constantFieldErrors.occurred_to"
+                                        class="help-block errormsg">{{ctl.constantFieldErrors.occurred_to}}</p>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="form-group time-picker">
+                                    <div class="input-group"
+                                         timepicker
+                                         ng-model="ctl.occurred_to"
+                                         ng-change="ctl.onDateChanged()">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row" ng-if="!ctl.secondary">
                             <div class="col-md-6">
                                 <label class="control-label">Weather</label>
                                 <div class="input-group">
@@ -128,4 +162,8 @@
 <div class="form-area no-filterbar" ng-if="::!ctl.userCanWrite">
     <!-- Shouldn't get here, but have a message to display, just in case -->
     <h2>Current user does not have access to write records</h2>
+</div>
+<div class="form-area no-filterbar" ng-if="::ctl.error">
+    <!-- Shouldn't get here, but have a message to display, just in case -->
+    <h2>{{ctl.error}}</h2>
 </div>

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -52,7 +52,7 @@
                             <div class="col-md-6">
                                 <div class="form-group date-picker"
                                     ng-class="ctl.constantFieldErrors.occurred ? 'has-error' : ''">
-                                    <label class="control-label required">Occurred {{ ctl.secondary ? 'from' : ''}}</label>
+                                    <label class="control-label required">Occurred {{ ctl.isSecondary ? 'from' : ''}}</label>
                                     <div class="input-group">
                                         <input type="text" class="form-control"
                                             datepicker-popup="longDate"
@@ -80,7 +80,7 @@
                             </div>
                         </div>
 
-                        <div class="row" ng-if="ctl.secondary">
+                        <div class="row" ng-if="ctl.isSecondary">
                             <div class="col-md-6">
                                 <div class="form-group date-picker"
                                     ng-class="ctl.constantFieldErrors.occurredTo ? 'has-error' : ''">
@@ -112,7 +112,7 @@
                             </div>
                         </div>
 
-                        <div class="row" ng-if="!ctl.secondary">
+                        <div class="row" ng-if="!ctl.isSecondary">
                             <div class="col-md-6">
                                 <label class="control-label">Weather</label>
                                 <div class="input-group">

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -58,7 +58,7 @@
                                             datepicker-popup="longDate"
                                             is-open="ctl.occurredDatePicker.opened"
                                             ng-change="ctl.onDateChanged()"
-                                            ng-model="ctl.occurred_from"
+                                            ng-model="ctl.occurredFrom"
                                             placeholder="From">
                                         <span class="input-group-addon picker"
                                               ng-click="ctl.occurredDatePicker.opened = true">
@@ -73,7 +73,7 @@
                                 <div class="form-group time-picker">
                                     <div class="input-group"
                                          timepicker
-                                         ng-model="ctl.occurred_from"
+                                         ng-model="ctl.occurredFrom"
                                          ng-change="ctl.onDateChanged()">
                                     </div>
                                 </div>
@@ -83,29 +83,29 @@
                         <div class="row" ng-if="ctl.secondary">
                             <div class="col-md-6">
                                 <div class="form-group date-picker"
-                                    ng-class="ctl.constantFieldErrors.occurred_to ? 'has-error' : ''">
+                                    ng-class="ctl.constantFieldErrors.occurredTo ? 'has-error' : ''">
                                     <label class="control-label">Occurred to</label>
                                     <div class="input-group">
                                         <input type="text" class="form-control"
                                             datepicker-popup="longDate"
                                             is-open="ctl.occurredToDatePicker.opened"
                                             ng-change="ctl.onDateChanged()"
-                                            ng-model="ctl.occurred_to"
+                                            ng-model="ctl.occurredTo"
                                             placeholder="To">
                                         <span class="input-group-addon picker"
                                               ng-click="ctl.occurredToDatePicker.opened = true">
                                             <span class="glyphicon glyphicon-calendar"></span>
                                         </span>
                                     </div>
-                                    <p ng-if="ctl.constantFieldErrors.occurred_to"
-                                        class="help-block errormsg">{{ctl.constantFieldErrors.occurred_to}}</p>
+                                    <p ng-if="ctl.constantFieldErrors.occurredTo"
+                                        class="help-block errormsg">{{ctl.constantFieldErrors.occurredTo}}</p>
                                 </div>
                             </div>
                             <div class="col-md-6">
                                 <div class="form-group time-picker">
                                     <div class="input-group"
                                          timepicker
-                                         ng-model="ctl.occurred_to"
+                                         ng-model="ctl.occurredTo"
                                          ng-change="ctl.onDateChanged()">
                                     </div>
                                 </div>

--- a/web/app/scripts/views/record/details-controller.js
+++ b/web/app/scripts/views/record/details-controller.js
@@ -2,13 +2,13 @@
     'use strict';
 
     /* ngInject */
-    function RecordDetailsController($stateParams, Records, RecordSchemaState, RecordTypes) {
+    function RecordDetailsController($stateParams, Records, RecordTypes,
+                                     RecordState, RecordSchemaState) {
         var ctl = this;
         initialize();
 
         function initialize() {
-            loadRecord()
-                .then(loadRecordSchema);
+            loadRecord().then(loadRecordSchema);
         }
 
         function loadRecord () {
@@ -22,10 +22,20 @@
             return RecordTypes.query({ record: $stateParams.recorduuid }).$promise
                 .then(function (result) {
                     ctl.recordType = result[0];
-                    /* jshint camelcase: false */
-                    return RecordSchemaState.get(ctl.recordType.current_schema)
-                    /* jshint camelcase: true */
-                        .then(function(recordSchema) { ctl.recordSchema = recordSchema; });
+                    RecordState.getSecondary().then(function (secondaryType) {
+                        if (!!secondaryType && secondaryType.uuid === ctl.recordType.uuid) {
+                            ctl.isSecondary = true;
+                        } else {
+                            ctl.isSecondary = false;
+                        }
+                        // TODO: refactor things off the object and onto the schema so that we
+                        // don't have to change behavior based on record type.
+                        ctl.record.isSecondary = ctl.isSecondary;
+                        /* jshint camelcase: false */
+                        return RecordSchemaState.get(ctl.recordType.current_schema)
+                        /* jshint camelcase: true */
+                            .then(function(recordSchema) { ctl.recordSchema = recordSchema; });
+                    });
                 });
         }
     }

--- a/web/app/scripts/views/record/details-modal-controller.js
+++ b/web/app/scripts/views/record/details-modal-controller.js
@@ -3,16 +3,28 @@
 
     /* ngInject */
     function RecordDetailsModalController($modalInstance, record, recordType,
-                                          recordSchema, userCanWrite) {
+                                          recordSchema, userCanWrite, RecordState) {
         var ctl = this;
-        ctl.record = record;
-        ctl.recordType = recordType;
-        ctl.recordSchema = recordSchema;
-        ctl.userCanWrite = userCanWrite;
+        initialize();
 
-        ctl.close = function () {
-            $modalInstance.close();
-        };
+        function initialize() {
+            ctl.record = record;
+            ctl.recordType = recordType;
+            ctl.recordSchema = recordSchema;
+            ctl.userCanWrite = userCanWrite;
+
+            ctl.close = function () {
+                $modalInstance.close();
+            };
+
+            RecordState.getSecondary().then(function (secondaryType) {
+                if (!!secondaryType && secondaryType.uuid === ctl.recordType.uuid) {
+                    ctl.record.isSecondary = true;
+                } else {
+                    ctl.record.isSecondary = false;
+                }
+            });
+        }
     }
 
     angular.module('driver.views.record')

--- a/web/app/scripts/views/record/module.js
+++ b/web/app/scripts/views/record/module.js
@@ -14,6 +14,13 @@
             label: 'Add a Record',
             showInNavbar: false
         });
+        $stateProvider.state('record.addSecondary', {
+            url: '/addsecondary',
+            template: '<driver-record-add-edit></driver-record-add-edit>',
+            label: 'Add a Record',
+            showInNavbar: false,
+            secondary: true
+        });
         $stateProvider.state('record.list', {
             url: '/list',
             template: '<driver-record-list></driver-record-list>',

--- a/web/app/styles/partials/_add-new.scss
+++ b/web/app/styles/partials/_add-new.scss
@@ -41,5 +41,5 @@
 }
 
 .constant-fields .date-picker {
-    margin-top: 12px;
+    margin-top: 20px !important;
 }

--- a/web/test/spec/views/record/add-edit-controller.spec.js
+++ b/web/test/spec/views/record/add-edit-controller.spec.js
@@ -101,14 +101,14 @@ describe('driver.views.record: AddEditController', function () {
         $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it('should fix occurred_from for date pickers', function () {
-        var original = new Date(Controller.occurred_from);
+    it('should fix occurredFrom for date pickers', function () {
+        var original = new Date(Controller.occurredFrom);
         Controller.fixOccurredDTForPickers();
         // Occured from should be changed after applying the fix
-        expect(Controller.occurred_from).not.toEqual(original);
+        expect(Controller.occurredFrom).not.toEqual(original);
         Controller.fixOccurredDTForPickers(true);
         // Occured from should equal original after reverting the fix
-        expect(Controller.occurred_from).toEqual(original);
+        expect(Controller.occurredFrom).toEqual(original);
 
         $httpBackend.verifyNoOutstandingRequest();
     });

--- a/web/test/spec/views/record/add-edit-directive.spec.js
+++ b/web/test/spec/views/record/add-edit-directive.spec.js
@@ -40,7 +40,7 @@ describe('driver.views.record: RecordAddEdit', function () {
                             then: function(callback) {
                                 return callback(true); // read-write
                             }
-                        }
+                        };
                     },
                     isAdmin: function() { return {
                             then: function(callback) {
@@ -92,10 +92,11 @@ describe('driver.views.record: RecordAddEdit', function () {
         var recordSchema = ResourcesMock.RecordSchema;
         var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchema.uuid);
         var recordTypeUrl = new RegExp('api/recordtypes/.*record=' + recordId);
+        var allRecordTypesUrl = new RegExp('api/recordtypes/');
         var recordUrl = new RegExp('api/records/' + recordId);
         var nominatimRevUrl = /\/reverse/;
 
-
+        $httpBackend.expectGET(allRecordTypesUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordUrl).respond(200, DriverResourcesMock.RecordResponse.results[0]);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(nominatimRevUrl).respond(200, NominatimMock.ReverseResponse);

--- a/web/test/spec/views/record/details-controller.spec.js
+++ b/web/test/spec/views/record/details-controller.spec.js
@@ -32,10 +32,12 @@ describe('driver.views.record: DetailsController', function () {
         $stateParams.recorduuid = recordId;
         var recordSchema = ResourcesMock.RecordSchema;
 
+        var allRecordTypesUrl = new RegExp('api/recordtypes/');
         var recordTypeUrl = new RegExp('api/recordtypes/.*record=' + recordId);
         var recordUrl = new RegExp('api/records/' + recordId);
         var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchema.uuid);
 
+        $httpBackend.expectGET(allRecordTypesUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordUrl).respond(200, DriverResourcesMock.RecordResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);

--- a/web/test/spec/views/record/details-directive.spec.js
+++ b/web/test/spec/views/record/details-directive.spec.js
@@ -32,10 +32,12 @@ describe('driver.views.record: RecordDetails', function () {
         $stateParams.recorduuid = recordId;
         var recordSchema = ResourcesMock.RecordSchema;
 
+        var allRecordTypesUrl = new RegExp('api/recordtypes/');
         var recordTypeUrl = new RegExp('api/recordtypes/.*record=' + recordId);
         var recordUrl = new RegExp('api/records/' + recordId);
         var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchema.uuid);
 
+        $httpBackend.expectGET(allRecordTypesUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordUrl).respond(200, DriverResourcesMock.RecordResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);

--- a/web/test/spec/views/record/details-modal-controller.spec.js
+++ b/web/test/spec/views/record/details-modal-controller.spec.js
@@ -7,6 +7,7 @@ describe('driver.views.record: RecordDetailsModalController', function () {
     beforeEach(module('driver.views.record'));
 
     var $controller;
+    var $httpBackend;
     var $rootScope;
     var $scope;
     var Controller;
@@ -14,9 +15,10 @@ describe('driver.views.record: RecordDetailsModalController', function () {
     var ResourcesMock;
     var ModalInstance;
 
-    beforeEach(inject(function (_$controller_, _$rootScope_,
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_,
                                 _DriverResourcesMock_, _ResourcesMock_) {
         $controller = _$controller_;
+        $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
         $scope = $rootScope.$new();
         DriverResourcesMock = _DriverResourcesMock_;
@@ -27,6 +29,10 @@ describe('driver.views.record: RecordDetailsModalController', function () {
     }));
 
     it('should initialize the modal controller and be able to close it', function () {
+        var allRecordTypesUrl = new RegExp('api/recordtypes/');
+        $httpBackend.expectGET(allRecordTypesUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(allRecordTypesUrl).respond(200, ResourcesMock.RecordTypeResponse);
+
         Controller = $controller('RecordDetailsModalController', {
             $scope: $scope,
             $modalInstance: ModalInstance,
@@ -36,6 +42,8 @@ describe('driver.views.record: RecordDetailsModalController', function () {
             userCanWrite: true
         });
         $scope.$apply();
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
 
         expect(Controller.record).toEqual(DriverResourcesMock.RecordResponse);
         expect(Controller.recordType).toEqual(ResourcesMock.RecordTypeResponse);


### PR DESCRIPTION
Makes the add/edit record view work for interventions (i.e. for secondary records).
Some things are generic (it loads the secondary record type from config) but some things are hard-coded: it shows the 'occurred to' date and hides the weather and light fields based on ctl.secondary (a boolean to indicate that we're looking at a secondary record) rather than through any sort of generic config, which would be more proper.

Some notes:
* Makes the driver-details-selectlist field type check for an array and join with comma if that's what's stored.
* Changes the RecordState service to return a promise for getSecondary.
* Changes the date picker(s) to use local controller properties that get initialized on load and copied back to record.occurred_from and _to on save, and changes the timezone correction method accordingly.

You can edit an intervention from the link in the map pop-up.  To add one, go to /addsecondary.  A link to that will be coming in the next feature.
