### PR TITLE
Feature/region saving2

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,7 +3,7 @@ djangorestframework-gis==0.9.1
 django-filter==0.11.0
 django-extensions==1.6.1
 django-cors-headers==1.0.0
-git+https://github.com/rohe/pyoidc.git@c9880cac2e5435f4197bda4364ace82206795f92#egg=pyoidc
+git+https://github.com/rohe/pyoidc.git@c9880cac2e5435f4197bda4364ace82206795f92#egg=oic
 # TODO: revert to marcanpilami django-oidc when https://github.com/rohe/pyoidc/issues/161 fixed
 git+https://github.com/flibbertigibbet/django-oidc.git
 #git+https://github.com/marcanpilami/django-oidc.git

--- a/schema_editor/app/scripts/app.js
+++ b/schema_editor/app/scripts/app.js
@@ -22,8 +22,7 @@
 
     /* ngInject */
     function LocalStorageConfig(localStorageServiceProvider) {
-        localStorageServiceProvider.setPrefix('DRIVER.ASE')
-                                   .setStorageType('sessionStorage');
+        localStorageServiceProvider.setPrefix('DRIVER.ASE');
     }
 
     /* ngInject */

--- a/web/app/scripts/black-spots/black-spots-controller.js
+++ b/web/app/scripts/black-spots/black-spots-controller.js
@@ -3,7 +3,7 @@
 
     /* ngInject */
     function BlackSpotsController(
-        InitialState, TileUrlService, FilterState, RecordState, BlackspotSets
+        InitialState, TileUrlService, FilterState, RecordState, BoundaryState, BlackspotSets
     ) {
         var cartoDBAttribution = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
         var ctl = this;
@@ -13,6 +13,7 @@
         function initMap(leafletController) {
             leafletController.getMap()
                 .then(addBaseLayers)
+                .then(updateBoundary)
                 .then(addBlackSpotLayer);
         }
 
@@ -64,6 +65,16 @@
             } else {
                 return '';
             }
+        }
+
+        function updateBoundary(map) {
+            BoundaryState.getSelected().then(function(boundary) {
+                if (boundary.bbox) {
+                    map.fitBounds(boundary.bbox);
+                }
+            });
+
+            return map;
         }
     }
 

--- a/web/test/spec/black-spots/black-spots-controller.spec.js
+++ b/web/test/spec/black-spots/black-spots-controller.spec.js
@@ -48,12 +48,21 @@ describe('driver.blackSpots: BlackSpotsController', function() {
         MapState.setZoom(7);
 
         var recordTypeUrl = /\/api\/recordtypes\//;
+        var boundaryUrl = /\/api\/boundaries\//;
         var blackspotUrl = /\/api\/blackspotsets\//;
+        var boundaryPolygonsUrl = /\/api\/boundarypolygons/;
 
         $httpBackend.expectGET(recordTypeUrl)
             .respond(200, ResourcesMock.RecordTypeResponse);
+
+        $httpBackend.expectGET(boundaryUrl)
+            .respond(200, DriverResourcesMock.BoundaryResponse);        
+
         $httpBackend.expectGET(recordTypeUrl)
             .respond(200, ResourcesMock.RecordTypeResponse);
+
+        $httpBackend.expectGET(boundaryPolygonsUrl)
+            .respond(200, ResourcesMock.BoundaryNoGeomResponse);
 
         $httpBackend.expectGET(blackspotUrl)
             .respond(200, DriverResourcesMock.BlackspotSetResponse);


### PR DESCRIPTION
Persist region across app

We want to save boundary data between sessions. So I changed localStorageService to local instead of session storage. Previously sessionStorage was chosen -- was this for a particular reason that this change shouldn't quash?
PR #142 

Oddity/bug under investigation: Local storage only works if browser history is cleared.