### PR TITLE
Custom report view

### DIFF
--- a/app/data/views.py
+++ b/app/data/views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+import calendar
 
 from dateutil.parser import parse as parse_date
 from datetime import timedelta
@@ -224,6 +225,10 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             records before any aggregation is applied. This may result in some rows / columns /
             tables having zero records.
 
+        Note that the tables are sparse: rows will only appear in 'data' and 'row_totals',
+        and columns will only appear in rows, if there are values returned by the query.
+        'row_labels' and 'col_labels', however, are complete and in order.
+
         Response format:
         {
             "row_labels": [
@@ -244,18 +249,21 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
                     "data": {
                         {
                             "row_key1": {
-                                "col_key1": X,
-                                "col_key3": Y,
+                                "col_key1": N,
+                                "col_key3": N,
                             },
                         },
                         ...
-                    ]
+                    },
+                    "row_totals": {
+                        {
+                            "row_key1": N,
+                            "row_key3": N,
+                    }
                 },
                 ...
             ]
         }
-        Note that all combinations of rows / columns are NOT guaranteed to exist within the
-        table `data` dictionaries; in other words, the tables are sparse.
         """
         valid_row_params = set(['row_period_type', 'row_boundary_id', 'row_choices_path'])
         valid_col_params = set(['col_period_type', 'col_boundary_id', 'col_choices_path'])
@@ -266,16 +274,16 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             raise ParseError(detail='Exactly one col_* and row_* parameter required; options are {}'
                                     .format(list(valid_row_params | valid_col_params)))
 
-        # Pass parameters to case-statement generators
-        row_param = row_params.pop()  # Guaranteed to be just one at this point
-        col_param = col_params.pop()
-        row_case, row_labels = self._query_param_to_case_stmnt(row_param, request)
-        col_case, col_labels = self._query_param_to_case_stmnt(col_param, request)
-
         # Generate filtered queryset based on other params
         queryset = self.get_queryset()
         for backend in list(self.filter_backends):
             queryset = backend().filter_queryset(request, queryset, self)
+
+        # Pass parameters to case-statement generators
+        row_param = row_params.pop()  # Guaranteed to be just one at this point
+        col_param = col_params.pop()
+        row_case, row_labels = self._query_param_to_case_stmnt(row_param, request, queryset)
+        col_case, col_labels = self._query_param_to_case_stmnt(col_param, request, queryset)
 
         # Apply case statements to filtered queryset
         annotated_qs = queryset.annotate(row=row_case).annotate(col=col_case)
@@ -297,69 +305,73 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
                                         for poly in boundaries}
             # Filter by polygon for counting
             for poly in boundaries:
-                counted = self._fill_table(annotated_qs.filter(geom__within=poly.geom))
-                response['tables'].append({'tablekey': poly.pk, 'data': counted})
+                table = self._fill_table(annotated_qs.filter(geom__within=poly.geom))
+                table['tablekey'] = poly.pk
+                response['tables'].append(table)
         else:
-            counted = self._fill_table(annotated_qs)
-            response['tables'].append({'tablekey': None, 'data': counted})
+            response['tables'].append(self._fill_table(annotated_qs))
         return Response(response)
 
     def _fill_table(self, annotated_qs):
-        """ Fill a nested dictionary with the counts """
+        """ Fill a nested dictionary with the counts and compute row totals. """
         data = {}
         for value in (annotated_qs.values('row', 'col')
-                                  .order_by('row', 'col')
-                                  .annotate(count=Count('row'))):
-            print 'value is {}'.format(value)
+                      .order_by('row', 'col')
+                      .annotate(count=Count('row'))):
             data.setdefault(str(value['row']), {})[str(value['col'])] = value['count']
-        return data
 
-    def _query_param_to_case_stmnt(self, param, request):
+        row_totals = {row: sum(cols.values()) for (row, cols) in data.items()}
+
+        return {'data': data, 'row_totals': row_totals}
+
+    def _query_param_to_case_stmnt(self, param, request, queryset):
         """Wrapper to handle getting the params for each case generator because we do it twice"""
         try:
             record_type_id = request.query_params['record_type']
         except KeyError:
             raise ParseError(detail="The 'record_type' parameter is required")
         if param.endswith('period_type'):
-            return self._make_period_case(request.query_params[param], record_type_id)
+            return self._make_period_case(request.query_params[param], queryset)
         elif param.endswith('boundary_id'):
             return self._make_boundary_case(request.query_params[param])
         else:  # 'choices_path'; ensured by parent function
             schema = RecordType.objects.get(pk=record_type_id).get_current_schema()
             return self._make_choices_case(schema, request.query_params[param].split(','))
 
-    def _make_period_case(self, period_type, record_type_id):
+    def _make_period_case(self, period_type, queryset):
         """Constructs a Django Case statement for a certain type of period.
 
         Args:
             period_type (string): One of 'hour', 'day', 'week_day', 'week', 'month', 'year'
-            record_type_id (string): Record type to use (uuid)
+            queryset (string): Filtered queryset to use for getting range for some period types
         Returns:
             (Case, labels), where Case is a Django Case object giving the period in which each
             record's occurred_from falls, and labels is a dict mapping Case values to period labels
 
         """
         easy_ranges = {  # Most date-related things are 1-indexed.
-            'month': xrange(1, 13),
-            'week': xrange(1, 54),  # Up to 53 weeks in a year
-            'week_day': xrange(1, 8),
-            'day': xrange(1, 32),
-            'hour': xrange(0, 24)
+            'month': {'keys': xrange(1, 13), 'labels': lambda x: calendar.month_name[x]},
+            # Up to 53 weeks in a year
+            'week': {'keys': xrange(1, 54), 'labels': lambda x: 'Week {}'.format(str(x))},
+            'week_day': {'keys': xrange(1, 8), 'labels': lambda x: calendar.day_name[x-1]},
+            'day': {'keys': xrange(1, 32), 'labels': lambda x: str(x)},
+            'hour': {'keys': xrange(0, 24), 'labels': lambda x: '{}:00'.format(x)},
         }
-        valid_periods = easy_ranges.keys() + ['year']
-        if period_type not in valid_periods:
-            raise ParseError(detail=('row_/col_period_type must be one of {}; received {}'
-                                     .format(valid_periods, period_type)))
 
-        # Set the range min / maxes based on the period type
-        period_range = None
+        # TODO: This sets year range based on the oldest and youngest records in the filtered
+        # queryset, but it (and possibly other date ranges) should be defined by the request's
+        # occurred_max and occurred_min parameters if available.
         if period_type == 'year':
-            recs = Record.objects.filter(schema__record_type_id=record_type_id)
-            range_min = recs.order_by('occurred_from').first().occurred_from.year
-            range_max = recs.order_by('-occurred_from').first().occurred_from.year + 1
+            range_min = queryset.order_by('occurred_from').first().occurred_from.year
+            range_max = queryset.order_by('-occurred_from').first().occurred_from.year + 1
             period_range = xrange(range_min, range_max)
+            period_labels = lambda x: str(x)
+        elif period_type in easy_ranges.keys():
+            period_range = easy_ranges[period_type]['keys']
+            period_labels = easy_ranges[period_type]['labels']
         else:
-            period_range = easy_ranges[period_type]
+            raise ParseError(detail=('row_/col_period_type must be one of {}; received {}'
+                                     .format(easy_ranges.keys() + 'year', period_type)))
 
         whens = []  # Eventual list of When-clause objects
         when_lookup = 'occurred_from__{}'.format(period_type)
@@ -367,11 +379,8 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             when_args = {'then': Value(x)}
             when_args[when_lookup] = x
             whens.append(When(**when_args))
-        # TODO: It would be nice to have friendlier names for weekdays and months, but that
-        # would introduce potential translation complexity down the road so I'm going to hold off
-        # until we get a better understanding of what the upcoming multilingual / date issues look
-        # like.
-        labels = [{'key': str(x), 'label': str(x)} for x in period_range]
+
+        labels = [{'key': str(x), 'label': period_labels(x)} for x in period_range]
         return (Case(*whens, output_field=IntegerField()), labels)
 
     def _make_boundary_case(self, boundary_id):

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -311,7 +311,7 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
                                   .order_by('row', 'col')
                                   .annotate(count=Count('row'))):
             print 'value is {}'.format(value)
-            data.setdefault(value['row'], {})[value['col']] = value['count']
+            data.setdefault(str(value['row']), {})[str(value['col'])] = value['count']
         return data
 
     def _query_param_to_case_stmnt(self, param, request):

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -118,6 +118,16 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             response = super(DriverRecordViewSet, self).list(self, request, *args, **kwargs)
         return response
 
+    def _cache_tile_sql(self, token, sql):
+        """Stores a sql string in the common cache so it can be retrieved by Windshaft later"""
+        # We need to use a raw Redis connection because the Django cache backend
+        # transforms the keys and values before storing them. If the cached data
+        # were being read by Django, this transformation would be reversed, but
+        # since the stored sql will be parsed by Windshaft / Postgres, we need
+        # to store the data exactly as it is.
+        redis_conn = get_redis_connection('default')
+        redis_conn.set(token, sql.encode('utf-8'))
+
     @list_route(methods=['get'])
     def stepwise(self, request):
         """Return an aggregation counts the occurrence of events per week (per year) between
@@ -216,14 +226,14 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
 
         Response format:
         {
-            "row_labels": {
-                "row_key1": "row_label1",
+            "row_labels": [
+                { "key": "row_key1", "label": "row_label1"},
                 ...
-            },
-            "col_labels": {
-                "col_key1": "col_label1",
+            ],
+            "col_labels": [
+                { "key": "col_key1", "label": "col_label1"},
                 ...
-            },
+            ],
             "table_labels": {
                 "table_key1": "table_label1",
                 // This will be empty if aggregation_boundary is not provided
@@ -231,11 +241,12 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             "tables": [
                 {
                     "tablekey": "table_key1",
-                    "data": [
+                    "data": {
                         {
-                            "row": "row_key1",
-                            "col": "col_key1",
-                            "count": X
+                            "row_key1": {
+                                "col_key1": X,
+                                "col_key3": Y,
+                            },
                         },
                         ...
                     ]
@@ -244,7 +255,7 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             ]
         }
         Note that all combinations of rows / columns are NOT guaranteed to exist within the
-        table `data` arrays; in other words, the tables are sparse.
+        table `data` dictionaries; in other words, the tables are sparse.
         """
         valid_row_params = set(['row_period_type', 'row_boundary_id', 'row_choices_path'])
         valid_col_params = set(['col_period_type', 'col_boundary_id', 'col_choices_path'])
@@ -286,30 +297,35 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
                                         for poly in boundaries}
             # Filter by polygon for counting
             for poly in boundaries:
-                counted = (annotated_qs.filter(geom__within=poly.geom)
-                                       .values('row', 'col')
-                                       .order_by('row', 'col')
-                                       .annotate(count=Count('row')))
+                counted = self._fill_table(annotated_qs.filter(geom__within=poly.geom))
                 response['tables'].append({'tablekey': poly.pk, 'data': counted})
         else:
-            counted = (annotated_qs.values('row', 'col')
-                                   .order_by('row', 'col')
-                                   .annotate(count=Count('row')))
+            counted = self._fill_table(annotated_qs)
             response['tables'].append({'tablekey': None, 'data': counted})
         return Response(response)
+
+    def _fill_table(self, annotated_qs):
+        """ Fill a nested dictionary with the counts """
+        data = {}
+        for value in (annotated_qs.values('row', 'col')
+                                  .order_by('row', 'col')
+                                  .annotate(count=Count('row'))):
+            print 'value is {}'.format(value)
+            data.setdefault(value['row'], {})[value['col']] = value['count']
+        return data
 
     def _query_param_to_case_stmnt(self, param, request):
         """Wrapper to handle getting the params for each case generator because we do it twice"""
         try:
-            record_type = request.query_params['record_type']
+            record_type_id = request.query_params['record_type']
         except KeyError:
             raise ParseError(detail="The 'record_type' parameter is required")
         if param.endswith('period_type'):
-            return self._make_period_case(request.query_params[param], record_type)
+            return self._make_period_case(request.query_params[param], record_type_id)
         elif param.endswith('boundary_id'):
             return self._make_boundary_case(request.query_params[param])
         else:  # 'choices_path'; ensured by parent function
-            schema = RecordType.objects.get(pk=record_type).get_current_schema()
+            schema = RecordType.objects.get(pk=record_type_id).get_current_schema()
             return self._make_choices_case(schema, request.query_params[param].split(','))
 
     def _make_period_case(self, period_type, record_type_id):
@@ -355,7 +371,8 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
         # would introduce potential translation complexity down the road so I'm going to hold off
         # until we get a better understanding of what the upcoming multilingual / date issues look
         # like.
-        return (Case(*whens, output_field=IntegerField()), {str(x): str(x) for x in period_range})
+        labels = [{'key': str(x), 'label': str(x)} for x in period_range]
+        return (Case(*whens, output_field=IntegerField()), labels)
 
     def _make_boundary_case(self, boundary_id):
         """Constructs a Django Case statement for points falling within a particular polygon
@@ -368,9 +385,10 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
         """
         boundary = Boundary.objects.get(pk=boundary_id)
         polygons = BoundaryPolygon.objects.filter(boundary=boundary)
+        labels = [{'key': str(poly.pk), 'label': poly.data[boundary.display_field]}
+                  for poly in polygons]
         return (Case(*[When(geom__within=poly.geom, then=Value(poly.pk)) for poly in polygons],
-                     output_field=UUIDField()),
-                {str(poly.pk): poly.data[boundary.display_field] for poly in polygons})
+                     output_field=UUIDField()), labels)
 
     def _make_choices_case(self, schema, path):
         """Constructs a Django Case statement for the choices of a schema property
@@ -407,17 +425,8 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
                 tmp[component] = filter_rule
                 filter_rule = tmp
             whens.append(When(data__jsonb=filter_rule, then=Value(choice)))
-        return (Case(*whens, output_field=CharField()), {choice: choice for choice in choices})
-
-    def _cache_tile_sql(self, token, sql):
-        """Stores a sql string in the common cache so it can be retrieved by Windshaft later"""
-        # We need to use a raw Redis connection because the Django cache backend
-        # transforms the keys and values before storing them. If the cached data
-        # were being read by Django, this transformation would be reversed, but
-        # since the stored sql will be parsed by Windshaft / Postgres, we need
-        # to store the data exactly as it is.
-        redis_conn = get_redis_connection('default')
-        redis_conn.set(token, sql.encode('utf-8'))
+        labels = [{'key': choice, 'label': choice} for choice in choices]
+        return (Case(*whens, output_field=CharField()), labels)
 
 
 class DriverRecordAuditLogViewSet(viewsets.ModelViewSet):

--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -160,6 +160,7 @@
 
     <script src="scripts/custom-reports/module.js"></script>
     <script src="scripts/custom-reports/custom-reports-modal-controller.js"></script>
+    <script src="scripts/custom-reports/custom-report-controller.js"></script>
 
     <script src="scripts/leaflet/module.js"></script>
     <script src="scripts/leaflet/leaflet-map-directive.js"></script>

--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -162,6 +162,7 @@
     <script src="scripts/custom-reports/aggregations-config.js"></script>
     <script src="scripts/custom-reports/custom-reports-modal-controller.js"></script>
     <script src="scripts/custom-reports/custom-report-controller.js"></script>
+    <script src="scripts/custom-reports/table-data-string-directive.js"></script>
 
     <script src="scripts/leaflet/module.js"></script>
     <script src="scripts/leaflet/leaflet-map-directive.js"></script>

--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -159,6 +159,7 @@
     <script src="scripts/saved-filters/saved-filter-as-html.js"></script>
 
     <script src="scripts/custom-reports/module.js"></script>
+    <script src="scripts/custom-reports/aggregations-config.js"></script>
     <script src="scripts/custom-reports/custom-reports-modal-controller.js"></script>
     <script src="scripts/custom-reports/custom-report-controller.js"></script>
 

--- a/web/app/scripts/custom-reports/aggregations-config.js
+++ b/web/app/scripts/custom-reports/aggregations-config.js
@@ -1,0 +1,108 @@
+(function () {
+    'use strict';
+
+    /* Builds a list of available aggregations for the rows and columns of custom reports.
+     *
+     * The time-related options (type: `Time`) are constant.
+     * The list is further populated with all available filterable types (type: `Filter`)
+     * and all available geographies (type: `Geography`).
+     */
+
+    /* ngInject */
+    function AggregationsConfig($q, RecordState, RecordSchemaState, GeographyState) {
+        var aggregations = [
+            {
+                label: 'Day of Month',
+                value: 'day',
+                type: 'Time'
+            },
+            {
+                label: 'Day of Week',
+                value: 'week_day',
+                type: 'Time'
+            },
+            {
+                label: 'Hour of Day',
+                value: 'hour',
+                type: 'Time'
+            },
+            {
+                label: 'Month of Year',
+                value: 'month',
+                type: 'Time'
+            },
+            {
+                label: 'Week of Year',
+                value: 'week',
+                type: 'Time'
+            },
+            {
+                label: 'Year',
+                value: 'year',
+                type: 'Time'
+            }
+        ];
+        var initialized = false;
+
+        var svc = {
+            getOptions: getOptions,
+        };
+        return svc;
+
+        function getOptions() {
+            if (initialized) {
+                return $q.resolve(aggregations);
+            } else {
+                return RecordState.getSelected()
+                    .then(loadFilters)
+                    .then(loadGeographies)
+                    .then(function() {
+                        initialized = true;
+                        return aggregations;
+                    });
+            }
+        }
+
+        /**
+         * We can only aggregate on enumerated properties. Loops through the schema (at the
+         * definition#property level, not recursively) and adds filters for each
+         * enumerated property it finds.
+         *
+         * TODO:  add " || property.format === 'number'" to the condition to enable aggregating
+         * numerical properties if/when that's implemented on the back end.
+         */
+        function loadFilters(recordType) {
+            /* jshint camelcase: false */
+            return RecordSchemaState.get(recordType.current_schema).then(function(schema) {
+            /* jshint camelcase: true */
+                _.forEach(schema.schema.definitions, function(definition, defName) {
+                    _.forEach(definition.properties, function(property, propName) {
+                        if (property.fieldType === 'selectlist') {
+                            aggregations.push({
+                                label: propName,
+                                value: [defName, 'properties', propName].join(','),
+                                type: 'Filter'
+                            });
+                        }
+                    });
+                });
+            });
+        }
+
+        // Add the list of geographies availalable to the dropdown aggregation lists
+        function loadGeographies() {
+            return GeographyState.getOptions().then(function(geographies) {
+                _.each(geographies, function(geography) {
+                    aggregations.push({
+                        label: geography.label,
+                        value: geography.uuid,
+                        type: 'Geography'
+                    });
+                });
+            });
+        }
+    }
+
+    angular.module('driver.customReports')
+    .service('AggregationsConfig', AggregationsConfig);
+})();

--- a/web/app/scripts/custom-reports/custom-report-controller.js
+++ b/web/app/scripts/custom-reports/custom-report-controller.js
@@ -2,14 +2,38 @@
     'use strict';
 
     /* ngInject */
-    function CustomReportController($state, $stateParams, Records) {
+    function CustomReportController($state, $stateParams, Records, AggregationsConfig) {
         var ctl = this;
+        ctl.dateFormat = 'MMM D, YYYY';
         init();
 
         function init() {
-            var params = $stateParams;
-            Records.report(params).$promise.then(function (report) {
-                ctl.report = report;
+            ctl.params = $stateParams;
+
+            getCategoryLabels().then(function () {
+                Records.report(ctl.params).$promise.then(function (report) {
+                    ctl.report = report;
+                });
+            });
+        }
+
+        function getCategoryLabels() {
+            return AggregationsConfig.getOptions().then(function (options) {
+                /* jshint camelcase: false */
+                var rowCategory = _.find(options, function (filter) {
+                    return [ctl.params.row_period_type,
+                            ctl.params.row_boundary_id,
+                            ctl.params.row_choices_path].indexOf(filter.value) >= 0;
+                    });
+                ctl.rowCategoryLabel = rowCategory.label;
+
+                var colCategory = _.find(options, function (filter) {
+                    return [ctl.params.col_period_type,
+                            ctl.params.col_boundary_id,
+                            ctl.params.col_choices_path].indexOf(filter.value) >= 0;
+                    });
+                ctl.colCategoryLabel = colCategory.label;
+                /* jshint camelcase: true */
             });
         }
     }

--- a/web/app/scripts/custom-reports/custom-report-controller.js
+++ b/web/app/scripts/custom-reports/custom-report-controller.js
@@ -1,0 +1,20 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function CustomReportController($state, $stateParams, Records) {
+        var ctl = this;
+        init();
+
+        function init() {
+            var params = $stateParams;
+            Records.report(params).$promise.then(function (report) {
+                ctl.report = report;
+            });
+        }
+    }
+
+    angular.module('driver.customReports')
+    .controller('CustomReportController', CustomReportController);
+
+})();

--- a/web/app/scripts/custom-reports/custom-report-controller.js
+++ b/web/app/scripts/custom-reports/custom-report-controller.js
@@ -1,6 +1,13 @@
 (function () {
     'use strict';
 
+    /* Custom report view.  Receives filter and aggregation parameters via $stateParams,
+     * gets a report from the API and displays it.
+     *
+     * The HTML for the table body and column header is built as a string here in the controller,
+     * because ng-repeat is too slow.
+     */
+
     /* ngInject */
     function CustomReportController($state, $stateParams, Records, AggregationsConfig) {
         var ctl = this;
@@ -8,15 +15,21 @@
         init();
 
         function init() {
+            ctl.loading = true;
             ctl.params = $stateParams;
 
             getCategoryLabels().then(function () {
-                Records.report(ctl.params).$promise.then(function (report) {
-                    ctl.report = report;
-                });
+                return Records.report(ctl.params).$promise;
+            }).then(function (report) {
+                console.log('report ready');
+                ctl.report = report;
+                composeTables();
+                ctl.loading = false;
             });
         }
 
+        // Gets text labels for the row and column categories by looking up the given parameters
+        // in the options list that was presented on the report generation modal.
         function getCategoryLabels() {
             return AggregationsConfig.getOptions().then(function (options) {
                 /* jshint camelcase: false */
@@ -34,6 +47,37 @@
                     });
                 ctl.colCategoryLabel = colCategory.label;
                 /* jshint camelcase: true */
+            });
+        }
+
+        // Since ng-repeat is so slow, this builds the table HTML by hand, which then gets
+        // crammed right into the view with a <table-data-string> directive.
+        function composeTables() {
+            /* jshint camelcase: false */
+            var header = '<tr><th>' + ctl.rowCategoryLabel + '</th>';
+            _.forEach(ctl.report.col_labels, function(col) {
+                header += '<th>' + col.label + '</th>'; });
+            header += '<th>Total</th>' + '</tr>';
+            ctl.headerHTML = header;
+
+            _.forEach(ctl.report.tables, function (table) {
+                var body = '';
+                _.forEach(ctl.report.row_labels, function (rowLabel) {
+                    body += '<tr><td>' + rowLabel.label + '</td>';
+                    if (table.data[rowLabel.key]) {
+                        _.forEach(ctl.report.col_labels, function (colLabel) {
+                            body += '<td>' + (table.data[rowLabel.key][colLabel.key] || 0) + '</td>';
+                        });
+                        body += '<td>' + table.row_totals[rowLabel.key] + '</td>';
+                    } else {
+                        _.forEach(ctl.report.col_labels, function () {
+                            body += '<td>0</td>';
+                        });
+                        body += '<td>0</td>';
+                    }
+                    body += '</tr>';
+                });
+                table.bodyHTML = body;
             });
         }
     }

--- a/web/app/scripts/custom-reports/custom-report-partial.html
+++ b/web/app/scripts/custom-reports/custom-report-partial.html
@@ -1,20 +1,18 @@
 <cube-grid-spinner ng-if="ctl.loading"></cube-grid-spinner>
 <div class="table-view custom-report" ng-if="!ctl.loading">
-    <div class="table-view-container">
-        <table class="table" ng-repeat="table in ctl.report.tables">
-            <caption>
-                <h2>
-                    <span>{{ ::ctl.params.occurred_min | localDateTime : ctl.dateFormat }}</span> -
-                    <span>{{ ::ctl.params.occurred_max | localDateTime : ctl.dateFormat }}</span>
-                </h2>
-                <h3>
-                    Incidents
-                    <span ng-if="ctl.params.aggregation_boundary"> for {{ ::ctl.report.table_labels[table.tablekey] }}</span>
-                    by {{ ::ctl.rowCategoryLabel }} and {{ ::ctl.colCategoryLabel }}
-                </h3>
-            </caption>
-            <thead table-data-string="ctl.headerHTML"></thead>
-            <tbody table-data-string="table.bodyHTML"></tbody>
-        </table>
-    </div>
+    <table class="table" ng-repeat="table in ctl.report.tables">
+        <caption>
+            <h2>
+                <span>{{ ::ctl.params.occurred_min | localDateTime : ctl.dateFormat }}</span> -
+                <span>{{ ::ctl.params.occurred_max | localDateTime : ctl.dateFormat }}</span>
+            </h2>
+            <h3>
+                Incidents
+                <span ng-if="ctl.params.aggregation_boundary"> for {{ ::ctl.report.table_labels[table.tablekey] }}</span>
+                by {{ ::ctl.rowCategoryLabel }} and {{ ::ctl.colCategoryLabel }}
+            </h3>
+        </caption>
+        <thead table-data-string="ctl.headerHTML"></thead>
+        <tbody table-data-string="table.bodyHTML"></tbody>
+    </table>
 </div>

--- a/web/app/scripts/custom-reports/custom-report-partial.html
+++ b/web/app/scripts/custom-reports/custom-report-partial.html
@@ -1,0 +1,23 @@
+<div class="table-view custom-report">
+    <div class="table-view-container">
+        <div class="overflow">
+            <table class="table" ng-repeat="table in ctl.report.tables">
+                <caption><!-- Table title --></caption>
+                <thead>
+                    <tr>
+                        <th><!--Label for row category--></th>
+                        <th ng-repeat="col in ctl.report.col_labels">{{ ::col.label }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="row in ctl.report.row_labels">
+                        <td>{{ ::row.label }}</td>
+                        <td ng-repeat="col in ctl.report.col_labels">
+                            {{ table.data && table.data[row.key] && table.data[row.key][col.key] || 0 }}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/web/app/scripts/custom-reports/custom-report-partial.html
+++ b/web/app/scripts/custom-reports/custom-report-partial.html
@@ -15,4 +15,6 @@
         <thead table-data-string="ctl.headerHTML"></thead>
         <tbody table-data-string="table.bodyHTML"></tbody>
     </table>
+
+    <div ng-if="ctl.error" class="error">Error: {{ ctl.error }}</div>
 </div>

--- a/web/app/scripts/custom-reports/custom-report-partial.html
+++ b/web/app/scripts/custom-reports/custom-report-partial.html
@@ -2,19 +2,31 @@
     <div class="table-view-container">
         <div class="overflow">
             <table class="table" ng-repeat="table in ctl.report.tables">
-                <caption><!-- Table title --></caption>
+                <caption>
+                    <h2>
+                        <span>{{ ::ctl.params.occurred_min | localDateTime : ctl.dateFormat }}</span> -
+                        <span>{{ ::ctl.params.occurred_max | localDateTime : ctl.dateFormat }}</span>
+                    </h2>
+                    <h3>
+                        Incidents
+                        <span ng-if="ctl.params.aggregation_boundary"> for {{ ::ctl.report.table_labels[table.tablekey] }}</span>
+                        by {{ ::ctl.rowCategoryLabel }} and {{ ::ctl.colCategoryLabel }}
+                    </h3>
+                </caption>
                 <thead>
                     <tr>
-                        <th><!--Label for row category--></th>
+                        <th>{{ ::ctl.rowCategoryLabel }}</th>
                         <th ng-repeat="col in ctl.report.col_labels">{{ ::col.label }}</th>
+                        <th>Total</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr ng-repeat="row in ctl.report.row_labels">
                         <td>{{ ::row.label }}</td>
                         <td ng-repeat="col in ctl.report.col_labels">
-                            {{ table.data && table.data[row.key] && table.data[row.key][col.key] || 0 }}
+                            {{ table.data[row.key] && table.data[row.key][col.key] || 0 }}
                         </td>
+                        <td>{{ table.row_totals && table.row_totals[row.key] || 0}}
                     </tr>
                 </tbody>
             </table>

--- a/web/app/scripts/custom-reports/custom-report-partial.html
+++ b/web/app/scripts/custom-reports/custom-report-partial.html
@@ -1,35 +1,20 @@
-<div class="table-view custom-report">
+<cube-grid-spinner ng-if="ctl.loading"></cube-grid-spinner>
+<div class="table-view custom-report" ng-if="!ctl.loading">
     <div class="table-view-container">
-        <div class="overflow">
-            <table class="table" ng-repeat="table in ctl.report.tables">
-                <caption>
-                    <h2>
-                        <span>{{ ::ctl.params.occurred_min | localDateTime : ctl.dateFormat }}</span> -
-                        <span>{{ ::ctl.params.occurred_max | localDateTime : ctl.dateFormat }}</span>
-                    </h2>
-                    <h3>
-                        Incidents
-                        <span ng-if="ctl.params.aggregation_boundary"> for {{ ::ctl.report.table_labels[table.tablekey] }}</span>
-                        by {{ ::ctl.rowCategoryLabel }} and {{ ::ctl.colCategoryLabel }}
-                    </h3>
-                </caption>
-                <thead>
-                    <tr>
-                        <th>{{ ::ctl.rowCategoryLabel }}</th>
-                        <th ng-repeat="col in ctl.report.col_labels">{{ ::col.label }}</th>
-                        <th>Total</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr ng-repeat="row in ctl.report.row_labels">
-                        <td>{{ ::row.label }}</td>
-                        <td ng-repeat="col in ctl.report.col_labels">
-                            {{ table.data[row.key] && table.data[row.key][col.key] || 0 }}
-                        </td>
-                        <td>{{ table.row_totals && table.row_totals[row.key] || 0}}
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+        <table class="table" ng-repeat="table in ctl.report.tables">
+            <caption>
+                <h2>
+                    <span>{{ ::ctl.params.occurred_min | localDateTime : ctl.dateFormat }}</span> -
+                    <span>{{ ::ctl.params.occurred_max | localDateTime : ctl.dateFormat }}</span>
+                </h2>
+                <h3>
+                    Incidents
+                    <span ng-if="ctl.params.aggregation_boundary"> for {{ ::ctl.report.table_labels[table.tablekey] }}</span>
+                    by {{ ::ctl.rowCategoryLabel }} and {{ ::ctl.colCategoryLabel }}
+                </h3>
+            </caption>
+            <thead table-data-string="ctl.headerHTML"></thead>
+            <tbody table-data-string="table.bodyHTML"></tbody>
+        </table>
     </div>
 </div>

--- a/web/app/scripts/custom-reports/custom-reports-modal-controller.js
+++ b/web/app/scripts/custom-reports/custom-reports-modal-controller.js
@@ -96,7 +96,17 @@
         }
 
         function createReport() {
-            $window.open($state.href('report', ctl.params, {absolute: true}), '_blank');
+            // If we were using $resource, Angular would automagically encode params that are
+            // objects. But since we're using $state.href, we have to do it ourselves.
+            var urlParams = _.mapValues(ctl.params, function (value) {
+                if (typeof(value) === 'object') {
+                    return angular.toJson(value);
+                } else {
+                    return value;
+                }
+            });
+
+            $window.open($state.href('report', urlParams, {absolute: true}), '_blank');
         }
 
         return ctl;

--- a/web/app/scripts/custom-reports/custom-reports-modal-controller.js
+++ b/web/app/scripts/custom-reports/custom-reports-modal-controller.js
@@ -126,7 +126,7 @@
                 key += 'period_type';
             } else if (aggObj.type === 'Filter') {
                 key += 'choices_path';
-            } else if (aggObj.type === 'Geometry') {
+            } else if (aggObj.type === 'Geography') {
                 key += 'boundary_id';
             } else {
                 $log.error('Cannot set row/col param with type: ', aggObj.type);

--- a/web/app/scripts/custom-reports/custom-reports-modal-controller.js
+++ b/web/app/scripts/custom-reports/custom-reports-modal-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function CustomReportsModalController($log, $modalInstance, $state, $window,
                                           FilterState, GeographyState, QueryBuilder,
-                                          RecordState, RecordSchemaState) {
+                                          AggregationsConfig) {
         var ctl = this;
         ctl.closeModal = closeModal;
         ctl.createReport = createReport;
@@ -18,42 +18,6 @@
         ctl.rowAggSelected = null;
         ctl.geoAggSelected = null;
 
-        // List of aggregations available for rows and columns.
-        // The time-related options defined here (type: `Time`) are constant.
-        // This list is later populated with all available filterable types (type: `Filter`),
-        // and all available geographies (type: `Geography`).
-        ctl.rowColAggs = [
-            {
-                label: 'Day of Month',
-                value: 'day',
-                type: 'Time'
-            },
-            {
-                label: 'Day of Week',
-                value: 'week_day',
-                type: 'Time'
-            },
-            {
-                label: 'Hour of Day',
-                value: 'hour',
-                type: 'Time'
-            },
-            {
-                label: 'Month of Year',
-                value: 'month',
-                type: 'Time'
-            },
-            {
-                label: 'Week of Year',
-                value: 'week',
-                type: 'Time'
-            },
-            {
-                label: 'Year',
-                value: 'year',
-                type: 'Time'
-            }
-        ];
 
         init();
 
@@ -64,49 +28,8 @@
             ctl.nonDateFilters = _.omit(FilterState.filters, '__dateRange');
             ctl.dateFilter = FilterState.getDateFilter();
 
-            // Add the list of geographies availalable to the dropdown aggregation lists
-            loadGeographies();
-
-            // Add the list of filters availalable to the dropdown aggregation lists
-            RecordState.getSelected()
-                .then(loadFilters);
-        }
-
-        function loadGeographies() {
-            return GeographyState.getOptions().then(function(geographies) {
-                _.each(geographies, function(geography) {
-                    ctl.rowColAggs.push({
-                        label: geography.label,
-                        value: geography.uuid,
-                        type: 'Geography'
-                    });
-                });
-            });
-        }
-
-        /**
-         * We can only aggregate on enumerated properties. Loops through the schema (at the
-         * definition#property level, not recursively) and adds filters for each
-         * enumerated property it finds.
-         *
-         * TODO:  add " || property.format === 'number'" to the condition to enable aggregating
-         * numerical properties if/when that's implemented on the back end.
-         */
-        function loadFilters(recordType) {
-            /* jshint camelcase: false */
-            return RecordSchemaState.get(recordType.current_schema).then(function(schema) {
-            /* jshint camelcase: true */
-                _.forEach(schema.schema.definitions, function(definition, defName) {
-                    _.forEach(definition.properties, function(property, propName) {
-                        if (property.fieldType === 'selectlist') {
-                            ctl.rowColAggs.push({
-                                label: propName,
-                                value: [defName, 'properties', propName].join(','),
-                                type: 'Filter'
-                            });
-                        }
-                    });
-                });
+            AggregationsConfig.getOptions().then(function (options) {
+                ctl.rowColAggs = options;
             });
         }
 

--- a/web/app/scripts/custom-reports/custom-reports-modal-partial.html
+++ b/web/app/scripts/custom-reports/custom-reports-modal-partial.html
@@ -28,6 +28,7 @@
                                 for agg in modal.rowColAggs
                                 | orderBy: 'label'"
                     ng-model="modal.rowAggSelected"
+                    ng-change="modal.onParamChanged()"
                     class="form-control">
             </select>
         </div>
@@ -39,6 +40,7 @@
                                 for agg in modal.rowColAggs
                                 | orderBy: 'label'"
                     ng-model="modal.colAggSelected"
+                    ng-change="modal.onParamChanged()"
                     class="form-control">
             </select>
         </div>
@@ -54,6 +56,7 @@
                                 | filter: { type: 'Geography' }
                                 | orderBy: 'label'"
                     ng-model="modal.geoAggSelected"
+                    ng-change="modal.onParamChanged()"
                     class="form-control">
                 <option value=""></option>
             </select>
@@ -66,8 +69,8 @@
         </button>
         <button class="btn btn-default"
                 ng-click="modal.createReport()"
-                ng-disabled="!modal.colAggSelected || !modal.rowAggSelected">
-            Custom Report
+                ng-disabled="!modal.ready">
+                Custom Report
         </button>
     </div>
 </div>

--- a/web/app/scripts/custom-reports/module.js
+++ b/web/app/scripts/custom-reports/module.js
@@ -1,10 +1,28 @@
 (function () {
     'use strict';
 
+    /* ngInject */
+    function StateConfig($stateProvider) {
+        $stateProvider.state('report', {
+            url: '/report/?' + ['row_period_type', 'row_boundary_id', 'row_choices_path',
+                                'col_period_type', 'col_boundary_id', 'col_choices_path',
+                                'aggregation_boundary', 'occurred_max', 'occurred_min',
+                                'jsonb', 'record_type'].join('&'),
+            templateUrl: 'scripts/custom-reports/custom-report-partial.html',
+            label: 'Custom Report',
+            controller: 'CustomReportController',
+            controllerAs: 'ctl',
+            showInNavbar: false,
+        });
+    }
+
     angular.module('driver.customReports', [
-        'ui.bootstrap',
         'ui.router',
-        'driver.resources'
-    ]);
+        'ase.auth',
+        'driver.config',
+        'driver.resources',
+        'driver.state',
+        'ui.bootstrap',
+    ]).config(StateConfig);
 
 })();

--- a/web/app/scripts/custom-reports/table-data-string-directive.js
+++ b/web/app/scripts/custom-reports/table-data-string-directive.js
@@ -1,0 +1,29 @@
+(function () {
+    'use strict';
+
+    /* Special directive for cramming hand-composed HTML tables into the custom reports view.
+     * Watches its argument then sets its HTML to the given value and stops watching.
+     */
+
+    /* ngInject */
+    function tableDataString() {
+        var module = {
+            restrict: 'A',
+            scope: {
+                tableDataString: '='
+            },
+            link: function (scope, element) {
+                // Watch for the composed HTML and dump it into the element.
+                // Calling the watcher unbinds it.
+                var watcher = scope.$watch('tableDataString', function (newData) {
+                    element.html(newData);
+                    watcher();
+                });
+            }
+        };
+        return module;
+    }
+
+    angular.module('driver.customReports')
+    .directive('tableDataString', tableDataString);
+})();

--- a/web/app/scripts/resources/records-service.js
+++ b/web/app/scripts/resources/records-service.js
@@ -13,6 +13,14 @@
             get: {
                 method: 'GET'
             },
+            query: {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data).results; },
+                isArray: true
+            },
+            update: {
+                method: 'PATCH'
+            },
             toddow: {
                 url: WebConfig.api.hostname + '/api/records/toddow/',
                 method: 'GET',
@@ -23,14 +31,10 @@
                 method: 'GET',
                 isArray: true
             },
-            query: {
+            report: {
+                url: WebConfig.api.hostname + '/api/records/crosstabs/',
                 method: 'GET',
-                transformResponse: function(data) { return angular.fromJson(data).results; },
-                isArray: true
             },
-            update: {
-                method: 'PATCH'
-            }
         });
     }
 

--- a/web/app/scripts/views/map/module.js
+++ b/web/app/scripts/views/map/module.js
@@ -19,6 +19,7 @@
         'driver.tools.charts',
         'driver.tools.export',
         'driver.tools.interventions',
+        'driver.customReports',
         'driver.config',
         'driver.localization',
         'driver.map-layers',

--- a/web/app/styles/_variables.scss
+++ b/web/app/styles/_variables.scss
@@ -1,0 +1,2 @@
+
+$light-gray: #f1f2f2;

--- a/web/app/styles/partials/_dashboard.scss
+++ b/web/app/styles/partials/_dashboard.scss
@@ -1,5 +1,5 @@
 .dashboard {
-    background: #f1f2f2;
+    background: $light-gray;
     padding: 2.5%;
     position: fixed;
     bottom: 0;

--- a/web/app/styles/partials/_duplicates.scss
+++ b/web/app/styles/partials/_duplicates.scss
@@ -5,7 +5,7 @@
     top: 52px;
     height: 50px !important;
     padding: 0px 14px !important;
-    background: #f1f2f2;
+    background: $light-gray;
 }
 
 driver-duplicates-list {

--- a/web/app/styles/partials/_incident-report.scss
+++ b/web/app/styles/partials/_incident-report.scss
@@ -41,7 +41,7 @@
             padding-top: 0;
 
             h2 {
-                background: #f1f2f2;
+                background: $light-gray;
                 padding: 12px 16px;
 
                 @media print {
@@ -103,7 +103,7 @@
     }
     .report-sections {
         margin: 0 -15px;
-        background-color: #f1f2f2;
+        background-color: $light-gray;
         padding: 5px 8px 0;
 
         a { font-weight: 700; }
@@ -161,7 +161,7 @@
                     }
 
                     &.open {
-                        background-color: #f1f2f2;
+                        background-color: $light-gray;
 
                         & + .table-body-row-content {
                             max-height: 1000px;

--- a/web/app/styles/partials/_login.scss
+++ b/web/app/styles/partials/_login.scss
@@ -1,5 +1,5 @@
 .login-view {
-    background: #f1f2f2;
+    background: $light-gray;
     padding: 2.5%;
     position: absolute;
     bottom: 0;
@@ -50,7 +50,7 @@
         &.divider {
             margin: 30px auto;
             width: 25%;
-            border-bottom: 10px solid #f1f2f2;
+            border-bottom: 10px solid $light-gray;
         }
     }
 }

--- a/web/app/styles/partials/_map-view.scss
+++ b/web/app/styles/partials/_map-view.scss
@@ -5,7 +5,7 @@
     width: 100%;
 
     #map {
-        background: #f1f2f2;
+        background: $light-gray;
         position: absolute;
         top: 52px;
         bottom: 0;

--- a/web/app/styles/partials/_nav.scss
+++ b/web/app/styles/partials/_nav.scss
@@ -67,7 +67,7 @@ nav {
         border-radius: 0;
 
         > li {
-            border-bottom: 1px solid #f1f2f2;
+            border-bottom: 1px solid $light-gray;
             z-index: 10;
 
             &:last-of-type {

--- a/web/app/styles/partials/_print-view.scss
+++ b/web/app/styles/partials/_print-view.scss
@@ -40,7 +40,7 @@
                 text-align: left;
             }
             &:nth-child(2n) {
-                background: #f1f2f2;
+                background: $light-gray;
             }
         }
         td {
@@ -51,7 +51,7 @@
                 text-align: left;
             }
             &:nth-child(2n) {
-                background: #f1f2f2;
+                background: $light-gray;
             }
         }
     }
@@ -62,7 +62,7 @@
         &:last-of-type { margin: 0; }
 
         .map {
-            background: #f1f2f2;
+            background: $light-gray;
             margin-right: 5%;
             width: 45%;
             height: 260px;

--- a/web/app/styles/partials/_table-view.scss
+++ b/web/app/styles/partials/_table-view.scss
@@ -1,9 +1,21 @@
 .table-view {
-    background: #f1f2f2;
+    background: $light-gray;
     position: absolute;
     bottom: 0;
     width: 100%;
     top: 0;
+
+    &.custom-report {
+        // Custom report uses table-view without table-view-container, because it scrolls
+        // the whole page so the absolute-positioned gray background breaks things.
+        background: white;
+        margin-top: 50px;
+        padding: 0px 20px;
+
+        td:nth-child(even) {
+            background: $light-gray;
+        }
+    }
 
     .table-view-container {
         margin: 25px;
@@ -14,13 +26,14 @@
         left: 0;
         right: 0;
 
+
         .links {
             text-align: right;
 
             a {
                 font-weight: 700;
                 font-size: 12px;
-                border: 1px solid #ccc;;
+                border: 1px solid #ccc;
                 padding: 4px 10px;
                 border-radius: 99px;
                 margin-left: 8px;
@@ -55,6 +68,12 @@
             font-size: 12px;
             font-weight: 700;
             text-transform: uppercase;
+        }
+
+        caption {
+            text-align: left;
+            margin: 10px;
+            font-size: 18px;
         }
     }
 }


### PR DESCRIPTION
Creates a custom report view, which you get to via the custom report modal from the map's Export tab.

I modified the crosstabs view a bit in the course of making this, the main changes being:
* Some format changes for easier usability in controller
* Added row totals
* Added labels for months and days of the week
* Changed the year range to be based on the query rather than pulling the range of all records ever.

A further note on date ranges: the year range should actually be based on the range selected in the filters.  That should also be the case for day, month, and week aggregates, which are not currently supported and need to be added.

Building the tables using ng-repeat was unacceptably slow, so this uses ng-repeat for the headers but builds the bulk of the table HTML by hand in the controller.