### PR TITLE
Display full text in filterbar buttons

### DIFF
--- a/web/app/styles/partials/_filterbar.scss
+++ b/web/app/styles/partials/_filterbar.scss
@@ -58,6 +58,10 @@
             border: 2px solid #232313;
         }
     }
+
+    .filter-option.pull-left {
+        max-width: 100%;
+    }
 }
 
 .no-filterbar {


### PR DESCRIPTION
Quick and dirty CSS fix for it because moving the select carat would take more effort than necessary.

Before:
<img width="466" alt="screen shot 2016-03-11 at 3 38 38 pm" src="https://cloud.githubusercontent.com/assets/10568752/13714882/5f2dac08-e79f-11e5-97af-47822eef0584.png">

After:
<img width="484" alt="screen shot 2016-03-11 at 3 38 21 pm" src="https://cloud.githubusercontent.com/assets/10568752/13714885/63907f8c-e79f-11e5-9b78-8bc0f776c98c.png">


@KlaasH  feel free to merge this for me
