### PR TITLE
Fix cron jobs for './' on manage.py, timezone

### DIFF
--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -29,10 +29,10 @@
 - name: Ensure Driver celery service is running
   service: name=driver-celery state=started
 
-- name: Add black spot calculation cronjob
-  cron: name="black spot calculation"
-        job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py calculate_black_spots"
-        hour=19 minute=10  # 3:10am in UTC+8
+# - name: Add black spot calculation cronjob
+#   cron: name="black spot calculation"
+#         job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py calculate_black_spots"
+#         hour=19 minute=10  # 3:10am in UTC+8
 
 - name: Add find duplicate records cronjob
   cron: name="find duplicate records"

--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -31,15 +31,15 @@
 
 - name: Add black spot calculation cronjob
   cron: name="black spot calculation"
-        job="docker exec $(docker ps -q -f name=driver-celery) manage.py calculate_black_spots"
-        hour=3 minute=10
+        job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py calculate_black_spots"
+        hour=19 minute=10  # 3:10am in UTC+8
 
 - name: Add find duplicate records cronjob
   cron: name="find duplicate records"
-        job="docker exec $(docker ps -q -f name=driver-celery) manage.py find_duplicate_records"
-        hour=1 minute=10
+        job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py find_duplicate_records"
+        hour=17 minute=10  # 1:10am in UTC+8
 
 - name: Clean up CSV export files cronjob
   cron: name="export file cleanup"
-        job="docker exec $(docker ps -q -f name=driver-celery) manage.py remove_old_exports"
+        job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py remove_old_exports"
         minute=10


### PR DESCRIPTION
The cron tasks weren't running because they were trying manage.py rather than ./manage.py.  And I adjusted the schedule since they were written as though the server would be in local time but in fact it's in UTC so they'd be running mid-morning.