### PR TITLE
Pass query parameters to graph functions properly

### DIFF
--- a/web/app/scripts/views/dashboard/dashboard-controller.js
+++ b/web/app/scripts/views/dashboard/dashboard-controller.js
@@ -65,7 +65,7 @@
             });
             /* jshint camelcase: true */
 
-            RecordAggregates.toddow(false, params).then(function(toddowData) {
+            RecordAggregates.toddow(params, false, false).then(function(toddowData) {
                 ctl.toddow = toddowData;
             });
         }

--- a/web/app/scripts/views/map/map-controller.js
+++ b/web/app/scripts/views/map/map-controller.js
@@ -94,7 +94,7 @@
 
             ctl.recordQueryParams = params;
 
-            RecordAggregates.stepwise(true, params).then(function(stepwiseData) {
+            RecordAggregates.stepwise(params).then(function(stepwiseData) {
                 // minDate and maxDate are important for determining where the barchart begins/ends
                 ctl.minDate = null;
                 ctl.maxDate = null;
@@ -109,7 +109,7 @@
                 ctl.stepwise = stepwiseData;
             });
 
-            RecordAggregates.toddow(true, params).then(function(toddowData) {
+            RecordAggregates.toddow(params).then(function(toddowData) {
                 ctl.toddow = toddowData;
             });
         }


### PR DESCRIPTION
The `stepwise` and `toddow` functions expect `extraParams` to be an Object, but the order of the parameters was incorrect and it was getting passed as a boolean instead.