### PR TITLE
Limits windshaft provision check to staging instance

### DIFF
--- a/deployment/ansible/roles/driver.windshaft/tasks/main.yml
+++ b/deployment/ansible/roles/driver.windshaft/tasks/main.yml
@@ -4,6 +4,7 @@
         owner={{ansible_ssh_user}}
         group={{ansible_ssh_user}}
         state=directory
+  when: staging
 
 - name: Synchronize Windshaft configuration
   synchronize: archive=no


### PR DESCRIPTION
Fixes this error on app provision
```TASK [driver.windshaft : Ensure windshaft directory exists] ********************
fatal: [app]: FAILED! => {"changed": false, "failed": true, "gid": 1310893680, "group": "1310893680", "mode": "0755", "msg": "chown failed", "owner": "524742318", "path": "/opt/windshaft", "size": 204, "state": "directory", "uid": 524742318}```