### PR TITLE
Refactor list controller

### DIFF
--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -38,7 +38,7 @@
             return RecordSchemaState.get(currentSchemaId)
                 .then(function(recordSchema) {
                     ctl.recordSchema = recordSchema;
-                });
+                }).then(onSchemaLoaded);
         }
 
         /*
@@ -75,7 +75,7 @@
             });
         }
 
-        function onRecordsLoaded() {
+        function onSchemaLoaded() {
             var detailsDefinitions = _.filter(ctl.recordSchema.schema.definitions,
                 function(val, key) {
                     if (key.indexOf('Details') > -1) {
@@ -142,7 +142,6 @@
             }
 
             loadRecords()
-              .then(onRecordsLoaded)
               .then(function() {
                   ctl.isInitialized = true;
               });
@@ -158,8 +157,7 @@
             if (ctl.recordType !== selected) {
                 ctl.recordType = selected;
                 loadRecordSchema()
-                    .then(loadRecords)
-                    .then(onRecordsLoaded);
+                    .then(loadRecords);
             }
         });
 
@@ -169,7 +167,7 @@
             }
             ctl.boundaryId = selected.uuid;
 
-            loadRecords().then(onRecordsLoaded);
+            loadRecords();
         });
 
         // $rootScope listeners must be manually unbound when the $scope is destroyed

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -38,6 +38,7 @@
             return RecordSchemaState.get(currentSchemaId)
                 .then(function(recordSchema) {
                     ctl.recordSchema = recordSchema;
+                    return;
                 }).then(onSchemaLoaded);
         }
 


### PR DESCRIPTION
Load schema labels once.
Remove unnecessary calls and rename function (onRecordsLoaded) so it reflect its use case better.

Follow up to comment on PR #453 