### PR TITLE
Make recent counts filter by selected boundary

### DIFF
--- a/schema_editor/app/scripts/resources/recordtypes-service.js
+++ b/schema_editor/app/scripts/resources/recordtypes-service.js
@@ -16,11 +16,6 @@
                 transformResponse: function(data) { return angular.fromJson(data).results; },
                 isArray: true
             },
-            // Recent counts for a record type: monthly, quarterly, yearly totals included
-            recentCounts: {
-                method: 'GET',
-                url: url + 'recent_counts/'
-            },
             update: {
                 method: 'PATCH'
             }

--- a/web/app/scripts/custom-reports/custom-reports-modal-controller.js
+++ b/web/app/scripts/custom-reports/custom-reports-modal-controller.js
@@ -66,7 +66,9 @@
         }
 
         function assembleParams() {
-            return QueryBuilder.assembleParams(0, true, true).then(
+            // TODO: if there's a boundary selected, should that filter be applied when
+            // they haven't selected a geographical aggregation? Currently it's never applied.
+            return QueryBuilder.assembleParams(0, {doBoundaryFilter: false}).then(
                 function(params) {
                     var crosstabsParams = {};
                     setRowColParam('col', ctl.colAggSelected, crosstabsParams);

--- a/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
+++ b/web/app/scripts/map-layers/recent-events/recent-events-layer-directive.js
@@ -79,21 +79,19 @@
                 return TileUrlService.recTilesUrl(selected.uuid);
             // Construct Windshaft URL
             }).then(function(baseUrl) {
-                return BoundaryState.getSelected().then(function(boundary) {
-                    /* jshint camelcase: false */
-                    var params = {
-                        tilekey: true,
-                        occurred_min: occurredMin.toISOString()
-                    };
-                    if (boundary.uuid) {
-                        params.polygon_id = boundary.uuid;
-                    }
-                    /* jshint camelcase: true */
+                /* jshint camelcase: false */
+                var params = {
+                    tilekey: true,
+                    occurred_min: occurredMin.toISOString()
+                };
+                /* jshint camelcase: true */
+                var filterConfig = { doAttrFilters: false,
+                                     doBoundaryFilter: true,
+                                     doJsonFilters: false, };
 
-                    return QueryBuilder.unfilteredDjangoQuery(0, params).then(function(result) {
-                        var tilekeyParam = (baseUrl.match(/\?/) ? '&' : '?') + 'tilekey=';
-                        return baseUrl + tilekeyParam + result.tilekey;
-                    });
+                return QueryBuilder.djangoQuery(0, params, filterConfig).then(function(result) {
+                    var tilekeyParam = (baseUrl.match(/\?/) ? '&' : '?') + 'tilekey=';
+                    return baseUrl + tilekeyParam + result.tilekey;
                 });
             // Swap layers
             }).then(function(fullUrl) {

--- a/web/app/scripts/recent-counts/recent-counts-controller.js
+++ b/web/app/scripts/recent-counts/recent-counts-controller.js
@@ -2,17 +2,13 @@
     'use strict';
 
     /* ngInject */
-    function RecentCountsController($scope, BoundaryState, InitialState,
-                                    RecordAggregates, RecordState) {
+    function RecentCountsController($scope, InitialState, RecordAggregates, RecordState) {
         var ctl = this;
         InitialState.ready().then(init);
         return ctl;
 
         function init() {
             RecordState.getSelected()
-                .then(BoundaryState.getSelected().then(function(selected) {
-                    ctl.boundaryId = selected.uuid;
-                }))
                 .then(function(recordType) {
                     /* jshint camelcase: false */
                     ctl.recordTypePlural = recordType.plural_label;
@@ -20,14 +16,13 @@
                     loadRecords();
                 });
 
-            $scope.$on('driver.state.boundarystate:selected', function(event, selected) {
-                ctl.boundaryId = selected.uuid;
+            $scope.$on('driver.state.boundarystate:selected', function() {
                 loadRecords();
             });
         }
 
         function loadRecords() {
-            RecordAggregates.recentCounts(ctl.boundaryId).then(function(aggregate) {
+            RecordAggregates.recentCounts().then(function(aggregate) {
                 ctl.year = aggregate.year;
                 ctl.quarter = aggregate.quarter;
                 ctl.month = aggregate.month;

--- a/web/app/scripts/recent-counts/recent-counts-controller.js
+++ b/web/app/scripts/recent-counts/recent-counts-controller.js
@@ -27,7 +27,6 @@
         }
 
         function loadRecords() {
-            // TODO: implement filtering by polygon_id on the server side
             RecordAggregates.recentCounts(ctl.boundaryId).then(function(aggregate) {
                 ctl.year = aggregate.year;
                 ctl.quarter = aggregate.quarter;

--- a/web/app/scripts/resources/aggregate-query-service.js
+++ b/web/app/scripts/resources/aggregate-query-service.js
@@ -65,20 +65,21 @@
          */
         function recentCounts(boundaryId) {
             var deferred = $q.defer();
-            // Record Type
-            RecordState.getSelected().then(function(selected) {
-                var uuid = selected.uuid;
-                var params = { id: uuid };
-                if (boundaryId) {
-                    /* jshint camelcase: false */
-                    params.polygon_id = boundaryId;
-                    /* jshint camelcase: true */
+            QueryBuilder.assembleParams(0, false, false, true).then(
+                function (params) {
+                    if (params.limit) {
+                       delete params.limit;
+                    }
+                    if (boundaryId) {
+                        /* jshint camelcase: false */
+                        params = _.extend(params, { polygon_id: boundaryId });
+                        /* jshint camelcase: true */
+                    }
+                    Records.recentCounts(params).$promise.then(function(counts) {
+                        deferred.resolve(counts);
+                    });
                 }
-
-                RecordTypes.recentCounts(params).$promise.then(function(counts) {
-                    deferred.resolve(counts);
-                });
-            });
+            );
             return deferred.promise;
         }
     }

--- a/web/app/scripts/resources/aggregate-query-service.js
+++ b/web/app/scripts/resources/aggregate-query-service.js
@@ -16,12 +16,11 @@
         /**
          * Retrieve TODDOW data - API mirroring the query builder service
          */
-        function toddow(extraParams, doAttrFilters, doJsonFilters) {
+        function toddow(extraParams, filterConfig) {
             var deferred = $q.defer();
             extraParams = extraParams || {};
-            doAttrFilters = doAttrFilters !== false;
-            doJsonFilters = doJsonFilters !== false;
-            QueryBuilder.assembleParams(0, doAttrFilters, doJsonFilters, true).then( // 0 for offset
+            filterConfig = filterConfig || {};
+            QueryBuilder.assembleParams(0, filterConfig, true).then( // 0 for offset
                 function(params) {
                     // toddow should never use a limit
                     params = _.extend(params, extraParams);
@@ -40,41 +39,40 @@
         /**
          * Retrieve stepwise data - API mirroring the query builder service
          */
-        function stepwise(extraParams, doAttrFilters, doJsonFilters) {
+        function stepwise(extraParams, filterConfig) {
             var deferred = $q.defer();
             extraParams = extraParams || {};
-            doAttrFilters = doAttrFilters !== false;
-            doJsonFilters = doJsonFilters !== false;
-            QueryBuilder.assembleParams(0, doAttrFilters, doJsonFilters, true).then( // 0 for offset
+            filterConfig = filterConfig || {};
+            QueryBuilder.assembleParams(0, filterConfig, true).then( // 0 for offset
                 function(params) {
-                // stepwise should never use a limit
-                params = _.extend(params, extraParams);
-                if (params.limit) {
-                    delete params.limit;
-                }
+                    // stepwise should never use a limit
+                    params = _.extend(params, extraParams);
+                    if (params.limit) {
+                        delete params.limit;
+                    }
 
-                Records.stepwise(params).$promise.then(function(stepwiseData) {
-                    deferred.resolve(stepwiseData);
-                });
-            });
+                    Records.stepwise(params).$promise.then(function(stepwiseData) {
+                        deferred.resolve(stepwiseData);
+                    });
+                }
+            );
             return deferred.promise;
         }
 
         /**
          * Request the most recent 30, 90, 365 day counts for the currently selected record type
          */
-        function recentCounts(boundaryId) {
+        function recentCounts() {
             var deferred = $q.defer();
-            QueryBuilder.assembleParams(0, false, false, true).then(
+            var filterConfig = { doAttrFilters: false,
+                                 doBoundaryFilter: true,
+                                 doJsonFilters: false, };
+            QueryBuilder.assembleParams(0, filterConfig, true).then(
                 function (params) {
                     if (params.limit) {
                        delete params.limit;
                     }
-                    if (boundaryId) {
-                        /* jshint camelcase: false */
-                        params = _.extend(params, { polygon_id: boundaryId });
-                        /* jshint camelcase: true */
-                    }
+
                     Records.recentCounts(params).$promise.then(function(counts) {
                         deferred.resolve(counts);
                     });

--- a/web/app/scripts/resources/records-service.js
+++ b/web/app/scripts/resources/records-service.js
@@ -3,7 +3,8 @@
 
     /* ngInject */
     function Records($resource, WebConfig) {
-        return $resource(WebConfig.api.hostname + '/api/records/:id/', {
+        var baseUrl = WebConfig.api.hostname + '/api/records/';
+        return $resource(baseUrl + ':id/', {
             id: '@uuid',
             archived: 'False' // Note: a regular 'false' boolean doesn't filter properly in DRF
         }, {
@@ -22,17 +23,21 @@
                 method: 'PATCH'
             },
             toddow: {
-                url: WebConfig.api.hostname + '/api/records/toddow/',
+                url: baseUrl + 'toddow/',
                 method: 'GET',
                 isArray: true
             },
             stepwise: {
-                url: WebConfig.api.hostname + '/api/records/stepwise/',
+                url: baseUrl + 'stepwise/',
                 method: 'GET',
                 isArray: true
             },
+            recentCounts: {
+                method: 'GET',
+                url: baseUrl + 'recent_counts/'
+            },
             report: {
-                url: WebConfig.api.hostname + '/api/records/crosstabs/',
+                url: baseUrl + 'crosstabs/',
                 method: 'GET',
             },
         });

--- a/web/app/scripts/tools/interventions/interventions-controller.js
+++ b/web/app/scripts/tools/interventions/interventions-controller.js
@@ -48,12 +48,14 @@
                                   ctl.recordQueryParams);
             /* jshint camelcase: true */
             // Get a tilekey then trigger an export
-            QueryBuilder.djangoQuery(0, params, true, false, true).then(function(records) {
-                RecordExports.exportCSV(records.tilekey).promise.then(
-                    function (result) { ctl.downloadURL = result; },
-                    function (error) { ctl.error = error; }
-                ).finally(function() { ctl.pending = false; });
-            });
+            QueryBuilder.djangoQuery(0, params, {doJsonFilters: false}, true).then(
+                function(records) {
+                    RecordExports.exportCSV(records.tilekey).promise.then(
+                        function (result) { ctl.downloadURL = result; },
+                        function (error) { ctl.error = error; }
+                    ).finally(function() { ctl.pending = false; });
+                }
+            );
         }
 
         $scope.$on('$destroy', RecordExports.cancelPolling);

--- a/web/app/scripts/views/dashboard/dashboard-controller.js
+++ b/web/app/scripts/views/dashboard/dashboard-controller.js
@@ -3,7 +3,7 @@
 
     /* ngInject */
     function DashboardController($scope, $state, $timeout,
-                                 BoundaryState, FilterState, InitialState, Records,
+                                 FilterState, InitialState, Records,
                                  RecordSchemaState, RecordState, RecordAggregates) {
         var ctl = this;
 
@@ -11,9 +11,6 @@
 
         function init() {
             RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
-                .then(BoundaryState.getSelected().then(function(selected) {
-                    ctl.boundaryId = selected.uuid;
-                }))
                 .then(loadRecordSchema)
                 .then(loadRecords)
                 .then(onRecordsLoaded);
@@ -23,8 +20,7 @@
                 loadRecords();
             });
 
-            $scope.$on('driver.state.boundarystate:selected', function(event, selected) {
-                ctl.boundaryId = selected.uuid;
+            $scope.$on('driver.state.boundarystate:selected', function() {
                 loadRecords();
             });
             $scope.$on('driver.savedFilters:filterSelected', function(event, selectedFilter) {
@@ -58,14 +54,17 @@
             var threeMonthsBack = new Date(now - duration).toISOString();
 
             /* jshint camelcase: false */
-            var params = ctl.boundaryId ? {polygon_id: ctl.boundaryId} : {};
-            params = angular.extend(params, {
+            var params = {
               occurred_min: threeMonthsBack,
               occurred_max: today
-            });
+            };
             /* jshint camelcase: true */
 
-            RecordAggregates.toddow(params, false, false).then(function(toddowData) {
+            var filterConfig = { doAttrFilters: false,
+                                 doBoundaryFilter: true,
+                                 doJsonFilters: false, };
+
+            RecordAggregates.toddow(params, filterConfig).then(function(toddowData) {
                 ctl.toddow = toddowData;
             });
         }

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -773,17 +773,12 @@
             if (geojson) {
                 params.polygon = geojson;
             }
-            if (ctl.boundaryId) {
-                /* jshint camelcase: false */
-                params.polygon_id = ctl.boundaryId;
-                /* jshint camelcase: true */
-            }
 
             return params;
         }
 
         function getTilekeys() {
-            var primary = QueryBuilder.djangoQuery(0, getAdditionalParams(), true, true, false).then(
+            var primary = QueryBuilder.djangoQuery(0, getAdditionalParams(), {}, false).then(
                 function(records) { ctl.tilekey = records.tilekey; }
             );
             var secondary = $q.resolve('');
@@ -792,7 +787,7 @@
                 /* jshint camelcase: false */
                 params.record_type = ctl.secondaryType.uuid;
                 /* jshint camelcase: true */
-                secondary = QueryBuilder.djangoQuery(0, params, true, false, false).then(
+                secondary = QueryBuilder.djangoQuery(0, params, {doJsonFilters: false}, false).then(
                     function(records) { ctl.secondaryTilekey = records.tilekey; }
                 );
             }

--- a/web/app/scripts/views/map/map-controller.js
+++ b/web/app/scripts/views/map/map-controller.js
@@ -57,9 +57,6 @@
             ctl.userCanWrite = AuthService.hasWriteAccess();
 
             RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
-                .then(BoundaryState.getSelected().then(function(selected) {
-                    ctl.boundaryId = selected.uuid;
-                }))
                 .then(loadRecords);
 
             // TODO: This also needs to listen for changing filters, both from the filterbar
@@ -73,8 +70,7 @@
                 loadRecords();
             });
 
-            $scope.$on('driver.state.boundarystate:selected', function(event, selected) {
-                ctl.boundaryId = selected.uuid;
+            $scope.$on('driver.state.boundarystate:selected', function() {
                 loadRecords();
             });
         }
@@ -83,9 +79,6 @@
             /* jshint camelcase: false */
             var params = {};
 
-            if (ctl.boundaryId) {
-                params.polygon_id = ctl.boundaryId;
-            }
             /* jshint camelcase: true */
             var userDrawnPoly = MapState.getFilterGeoJSON();
             if (userDrawnPoly) {

--- a/web/app/scripts/views/record/list-controller.js
+++ b/web/app/scripts/views/record/list-controller.js
@@ -4,9 +4,8 @@
     /* ngInject */
     function RecordListController($scope, $rootScope, $log, $modal, $state, uuid4, AuthService,
                                   FilterState, InitialState, Notifications, RecordSchemaState,
-                                  RecordState, BoundaryState, QueryBuilder, WebConfig) {
+                                  RecordState, QueryBuilder, WebConfig) {
         var ctl = this;
-        ctl.boundaryId = null;
         ctl.currentOffset = 0;
         ctl.numRecordsPerPage = WebConfig.record.limit;
         ctl.maxDataColumns = 4; // Max number of dynamic data columns to show
@@ -23,9 +22,6 @@
             ctl.isInitialized = false;
             ctl.userCanWrite = AuthService.hasWriteAccess();
             RecordState.getSelected().then(function(selected) { ctl.recordType = selected; })
-                .then(BoundaryState.getSelected().then(function(selected) {
-                    ctl.boundaryId = selected.uuid;
-                }))
                 .then(loadRecordSchema)
                 .then(restoreFilters);
         }
@@ -66,11 +62,7 @@
                 newOffset = 0;
             }
 
-            /* jshint camelcase: false */
-            var params = ctl.boundaryId ? { polygon_id: ctl.boundaryId } : {};
-            /* jshint camelcase: true */
-
-            return QueryBuilder.djangoQuery(newOffset, params, true, true, true)
+            return QueryBuilder.djangoQuery(newOffset)
             .then(function(records) {
                 ctl.records = records;
                 ctl.currentOffset = newOffset;
@@ -165,11 +157,10 @@
             }
         });
 
-        $scope.$on('driver.state.boundarystate:selected', function(event, selected) {
+        $scope.$on('driver.state.boundarystate:selected', function() {
             if (!ctl.isInitialized) {
                 return;
             }
-            ctl.boundaryId = selected.uuid;
 
             loadRecords();
         });

--- a/web/test/spec/custom-reports/custom-reports-modal-controller.spec.js
+++ b/web/test/spec/custom-reports/custom-reports-modal-controller.spec.js
@@ -29,13 +29,16 @@ describe('driver.customReports: CustomReportsModalController', function () {
     }));
 
     it('should initialize the modal controller and be able to close it', function () {
-        var recordId = DriverResourcesMock.RecordResponse.results[0].uuid;
         var recordSchema = ResourcesMock.RecordSchema;
         var recordSchemaIdUrl = new RegExp('api/recordschemas/' + recordSchema.uuid);
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
+        var boundariesUrl = /api\/boundaries/;
+        var boundaryPolygonsUrl = /api\/boundarypolygons/;
 
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
         $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 
         Controller = $controller('CustomReportsModalController', {

--- a/web/test/spec/export/export-controller.spec.js
+++ b/web/test/spec/export/export-controller.spec.js
@@ -41,10 +41,16 @@ describe('driver.tools.export: ExportController', function () {
         InitialState.setBoundaryInitialized();
         InitialState.setGeographyInitialized();
 
+
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        var boundariesUrl = /api\/boundaries/;
+        var boundaryPolygonsUrl = /api\/boundarypolygons/;
         var recordSchemaUrl = /\/api\/recordschemas\/\?limit=all/;
+
+        $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchemaResponse);
+        $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
 
         $scope.recordQueryParams = {};
         Controller = $controller('ExportController', { $scope: $scope });

--- a/web/test/spec/recent-counts/recent-counts-controller.spec.js
+++ b/web/test/spec/recent-counts/recent-counts-controller.spec.js
@@ -31,14 +31,14 @@ describe('driver.recentCounts: RecentCountsController', function () {
 
     it('should make requests to recent_counts', function () {
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True&limit=all/;
-        $httpBackend.expectGET(/\/api\/boundaries/).respond(DriverResourcesMock.BoundaryResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
-        $httpBackend.expectGET(/\/api\/boundarypolygons/)
-            .respond(200, ResourcesMock.BoundaryNoGeomResponse);
+        $httpBackend.expectGET(/\/api\/boundaries/).respond(DriverResourcesMock.BoundaryResponse);
 
         var countsUrl = new RegExp('api/records/recent_counts/\\?archived=False' +
                                    '.*record_type=' + ResourcesMock.RecordType.uuid);
         $httpBackend.expectGET(countsUrl).respond(200);
+        $httpBackend.expectGET(/\/api\/boundarypolygons/)
+            .respond(200, ResourcesMock.BoundaryNoGeomResponse);
         $httpBackend.expectGET(countsUrl).respond(200);
 
         Controller = $controller('RecentCountsController', { $scope: $scope });

--- a/web/test/spec/recent-counts/recent-counts-controller.spec.js
+++ b/web/test/spec/recent-counts/recent-counts-controller.spec.js
@@ -36,10 +36,8 @@ describe('driver.recentCounts: RecentCountsController', function () {
         $httpBackend.expectGET(/\/api\/boundarypolygons/)
             .respond(200, ResourcesMock.BoundaryNoGeomResponse);
 
-        var recordType = ResourcesMock.RecordType;
-        var recordTypeId = recordType.uuid;
-        var countsUrl = new RegExp('api/recordtypes/' + recordTypeId +
-                                   '/recent_counts/\\?limit=all');
+        var countsUrl = new RegExp('api/records/recent_counts/\\?archived=False' +
+                                   '.*record_type=' + ResourcesMock.RecordType.uuid);
         $httpBackend.expectGET(countsUrl).respond(200);
         $httpBackend.expectGET(countsUrl).respond(200);
 

--- a/web/test/spec/resources/aggregate-query-service.spec.js
+++ b/web/test/spec/resources/aggregate-query-service.spec.js
@@ -30,7 +30,8 @@ describe('driver.resources: Aggregate Queries', function () {
 
     it('It should use the currently selected recordtype to query for recent counts', function () {
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
-        var recordTypeCountUrl = /\/api\/recordtypes\/a-very-weird-uuid\/recent_counts/;
+        var recordTypeCountUrl = new RegExp('api/records/recent_counts/' +
+                                            '\\?archived=False.*record_type=a-very-weird-uuid');
 
         RecordAggregates.recentCounts();
 

--- a/web/test/spec/resources/aggregate-query-service.spec.js
+++ b/web/test/spec/resources/aggregate-query-service.spec.js
@@ -30,14 +30,18 @@ describe('driver.resources: Aggregate Queries', function () {
 
     it('It should use the currently selected recordtype to query for recent counts', function () {
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
+        var boundariesUrl = /api\/boundaries/;
+        var boundaryPolygonsUrl = /api\/boundarypolygons/;
         var recordTypeCountUrl = new RegExp('api/records/recent_counts/' +
                                             '\\?archived=False.*record_type=a-very-weird-uuid');
 
         RecordAggregates.recentCounts();
 
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeCountUrl)
           .respond(200, {'plural': 'Birds', 'month': '10', 'quarter': 100, 'year': 1000});
+        $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
 
         $rootScope.$apply();
         $httpBackend.flush();

--- a/web/test/spec/resources/query-builder-service-spec.js
+++ b/web/test/spec/resources/query-builder-service-spec.js
@@ -40,11 +40,15 @@ describe('driver.resources: QueryBuilder', function () {
         var recordsUrl = /\/api\/records\/\?archived=False&details_only=True&limit=50&occurred_min=2015-10-04T16:00:00.000Z&record_type=15460346-65d7-4f4d-944d-27324e224691/;
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
         var recordSchemaUrl = /\/api\/recordschemas/;
+        var boundariesUrl = /api\/boundaries/;
+        var boundaryPolygonsUrl = /api\/boundarypolygons/;
 
         QueryBuilder.djangoQuery();
 
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordSchemaUrl).respond(200, ResourcesMock.RecordSchema);
+        $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
         $httpBackend.expectGET(recordsUrl).respond(200, DriverResourcesMock.RecordResponse);
 
         $rootScope.$apply();

--- a/web/test/spec/views/dashboard/dashboard-controller.spec.js
+++ b/web/test/spec/views/dashboard/dashboard-controller.spec.js
@@ -27,10 +27,10 @@ describe('driver.views.dashboard: DashboardController', function () {
     it('should pass this placeholder test', function () {
         Controller = $controller('DashboardController', { $scope: $scope });
 
-        $httpBackend.expectGET(/\/api\/boundaries/)
-            .respond(ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(/\/api\/recordtypes\//)
             .respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(/\/api\/boundaries/)
+            .respond(ResourcesMock.GeographyResponse);
 
         $scope.$apply();
     });


### PR DESCRIPTION
Moves the recent counts API view to Record (rather than RecordType) and
makes it filter by the selected boundary ID.