### PR TITLE
Redirect after login

### DIFF
--- a/web/app/scripts/app.js
+++ b/web/app/scripts/app.js
@@ -42,7 +42,7 @@
                 event.preventDefault();
                 // broadcast success to avoid infinite redirect
                 // see issue: https://github.com/angular-ui/ui-router/issues/178
-                $state.go('login', null, {notify: false}).then(function() {
+                $state.go('login', {next: to, nextParams: toParams}, {notify: false}).then(function() {
                     $rootScope.$broadcast('$stateChangeSuccess', to, toParams, from, fromParams);
                 });
                 return;

--- a/web/app/scripts/state/boundarystate-service.js
+++ b/web/app/scripts/state/boundarystate-service.js
@@ -22,14 +22,14 @@
          * initialization
          */
         function init() {
-          selected = nullBounds;
-          options = [];
-          defaultParams = { active: 'True' };
+            selected = nullBounds;
+            options = [];
+            defaultParams = { active: 'True' };
 
-          GeographyState.getSelected().then(function(geography) {
-              var params = geography ? { boundary: geography.uuid } : {};
-              svc.updateOptions(params);
-          });
+            GeographyState.getSelected().then(function(geography) {
+                var params = geography ? { boundary: geography.uuid } : {};
+                svc.updateOptions(params);
+            });
         }
 
         /**
@@ -56,10 +56,11 @@
 
         function getOptions() {
             var deferred = $q.defer();
-            if (!options) {
+            if (_.isEmpty(options)) {
                 updateOptions().then(function() { deferred.resolve(options); });
+            } else {
+                deferred.resolve(options);
             }
-            deferred.resolve(options);
             return deferred.promise;
         }
 

--- a/web/app/scripts/state/geographystate-service.js
+++ b/web/app/scripts/state/geographystate-service.js
@@ -50,12 +50,12 @@
         }
 
         function getOptions() {
-            if(options){
-                return $q.when(options);
-            } else {
+            if(_.isEmpty(options)) {
                 return updateOptions().then(function(){
                     return options;
                 });
+            } else {
+                return $q.when(options);
             }
         }
 

--- a/web/app/scripts/views/login/module.js
+++ b/web/app/scripts/views/login/module.js
@@ -30,6 +30,10 @@
                         });
                     return dfd.promise;
                 }
+            },
+            params: {
+                next: undefined,
+                nextParams: undefined,
             }
         });
     }

--- a/web/test/spec/custom-reports/custom-reports-modal-controller.spec.js
+++ b/web/test/spec/custom-reports/custom-reports-modal-controller.spec.js
@@ -38,6 +38,7 @@ describe('driver.customReports: CustomReportsModalController', function () {
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(boundaryPolygonsUrl).respond(200, ResourcesMock.BoundaryNoGeomResponse);
         $httpBackend.expectGET(recordSchemaIdUrl).respond(200, recordSchema);
 


### PR DESCRIPTION
Adds a param to the login state, which gets set by the authentication interceptor, to store the page you were trying to reach and send you there once you're logged in.

I went through a process with this, trying to get it to work without a full reload, since that makes the page flash.  I got the navbar working, but then realized that's the easy one, because there are other pieces that initialize from the API and so implicitly rely on authentication but don't actually even check it.  I also tried but failed to find a way to load anything besides '/' in a way that would cause it to load fresh rather than update the state in place.

But it does get you to the page you were trying to get to, and a little flash seems better than always going to the dashboard.