### PR TITLE
Add/edit datetime fixes

### DIFF
--- a/app/data/views.py
+++ b/app/data/views.py
@@ -40,7 +40,7 @@ from ashlar.views import (BoundaryPolygonViewSet,
                           RecordSchemaViewSet,
                           BoundaryViewSet)
 
-from ashlar.serializers import RecordSerializer, RecordSchemaSerializer
+from ashlar.serializers import RecordSchemaSerializer
 
 from driver_auth.permissions import (IsAdminOrReadOnly,
                                      ReadersReadWritersWrite,
@@ -50,8 +50,9 @@ from data.tasks import export_csv
 
 import filters
 from models import RecordAuditLogEntry, RecordDuplicate
-from serializers import (DetailsReadOnlyRecordSerializer, DetailsReadOnlyRecordSchemaSerializer,
-                         RecordAuditLogEntrySerializer, RecordDuplicateSerializer)
+from serializers import (DriverRecordSerializer, DetailsReadOnlyRecordSerializer,
+                         DetailsReadOnlyRecordSchemaSerializer, RecordAuditLogEntrySerializer,
+                         RecordDuplicateSerializer)
 import transformers
 from driver import mixins
 
@@ -75,7 +76,7 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             requested_details_only = True
 
         if is_admin_or_writer(self.request.user) and not requested_details_only:
-            return RecordSerializer
+            return DriverRecordSerializer
         return DetailsReadOnlyRecordSerializer
 
     def get_filtered_queryset(self, request):

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -96,6 +96,12 @@
                 schemaPromise = loadRecord().then(loadRecordSchema);
             } else {
                 schemaPromise = loadRecordSchema();
+                // Besides being friendly, setting a default works around this bug:
+                // https://github.com/angular-ui/bootstrap/issues/1114
+                ctl.occurredFrom = new Date();
+                if (ctl.isSecondary) {
+                    ctl.occurredTo = ctl.occurredFrom;
+                }
             }
 
             schemaPromise.then(function () {
@@ -360,9 +366,14 @@
                     ctl.constantFieldErrors[fieldName] = fieldName + ': Value required';
                 }
             });
+
             if (ctl.isSecondary && ctl.occurredFrom && ctl.occurredTo &&
                     ctl.occurredFrom > ctl.occurredTo) {
                 ctl.constantFieldErrors.occurredTo = 'End date cannot be before start date.';
+            }
+
+            if (ctl.occurredFrom && ctl.occurredFrom > new Date()) {
+                ctl.constantFieldErrors.occurred = 'Date and time must be in the past.';
             }
 
             // make field errors falsy if empty, for partial to check easily

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -507,12 +507,14 @@
                 }
             }, function (error) {
                 $log.debug('Error while creating record:', error);
-                showErrorNotification(['<p>Error creating record</p><p>',
-                   error.status,
-                   ': ',
-                   error.statusText,
-                   '</p>'
-                ].join(''));
+                var errorMessage = '<p>Error creating record</p><p>';
+                if (error.data) {
+                    errorMessage += _.flatten(_.values(error.data)).join('<br>');
+                } else {
+                    errorMessage += (error.status + ': ' + error.statusText);
+                }
+                errorMessage += '</p>';
+                showErrorNotification(errorMessage);
             });
         }
 

--- a/web/app/scripts/views/record/add-edit-partial.html
+++ b/web/app/scripts/views/record/add-edit-partial.html
@@ -66,7 +66,7 @@
                                         </span>
                                     </div>
                                     <p ng-if="ctl.constantFieldErrors.occurred"
-                                        class="help-block errormsg">Value required.</p>
+                                        class="help-block errormsg">{{ctl.constantFieldErrors.occurred}}</p>
                                 </div>
                             </div>
                             <div class="col-md-6">


### PR DESCRIPTION
Makes both the front-end and the back-end produce an error when trying to save a record if the 'occurred_from' date is in the future.

I put the back-end check in DRIVER, rather than in Ashlar, since it seems more like a project-specific requirement (also changing Ashlar is a pain...), which meant creating a DriverRecordSerializer.