### PR TITLE
Add boundary filter to custom report

### DIFF
--- a/web/app/scripts/custom-reports/custom-reports-modal-partial.html
+++ b/web/app/scripts/custom-reports/custom-reports-modal-partial.html
@@ -13,6 +13,10 @@
                 <span>{{ ::modal.dateFilter.minDate | localDateTime : modal.dateFormat }}</span> -
                 <span>{{ ::modal.dateFilter.maxDate | localDateTime : modal.dateFormat }}</span>
             </div>
+            <div ng-if="modal.boundaryFilter">
+                <strong>Boundary:</strong>
+                <span>{{ ::modal.boundaryFilter }}</span>
+            </div>
             <div ng-if="modal.nonDateFilters | savedFilterAsHTML">
                 <span ng-bind-html="modal.nonDateFilters | savedFilterAsHTML: '<br />'"></span>
             </div>

--- a/web/test/spec/custom-reports/custom-reports-modal-controller.spec.js
+++ b/web/test/spec/custom-reports/custom-reports-modal-controller.spec.js
@@ -35,6 +35,7 @@ describe('driver.customReports: CustomReportsModalController', function () {
         var boundariesUrl = /api\/boundaries/;
         var boundaryPolygonsUrl = /api\/boundarypolygons/;
 
+        $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);
         $httpBackend.expectGET(boundariesUrl).respond(200, ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);


### PR DESCRIPTION
Follow-up to PR #455, discussed in issue #456.

Adds the selected boundary (if there is one) to the list of existing filters in the custom report modal, and makes the custom report query filter by boundary.

Notes:
* The text in the "Active Filters" box on the modal is just "Boundary: <state or region name>".  I would have done "State" or "Region" or whatever instead of "Boundary", but we don't have a singular label for geographies. And it seemed a little much to add one for this.
* If they have an active boundary filter and then add a geographic aggregation, they'll get a table in the report for each state/region/whatever, even if it's not within their selected boundary. We would need to add some kind of "exclude" logic to the back-end to change that.