### PR TITLE
Add endpoint to get API token from mobile SSO

### DIFF
--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     url(r'^api/', include(router.urls)),
     # get token for given username/password
     url(r'^api-token-auth/', auth_views.obtain_auth_token),
+    url(r'^api/sso-token-auth/', auth_views.sso_auth_token),
     url(r'^openid/clientlist/', auth_views.get_oidc_client_list, name='openid_client_list'),
     # override openid login callback endpoint by adding url here before djangooidc include
     url(r'^openid/callback/login/?$', auth_views.authz_cb, name='openid_login_cb'),

--- a/app/driver_auth/views.py
+++ b/app/driver_auth/views.py
@@ -68,9 +68,9 @@ def authz_cb(request):
             # authentication failed
             # return 403 here instead of raising error
             return JsonResponse({'error': 'This login is not valid in this application'},
-                            status=403)
+                            status=status.HTTP_403_FORBIDDEN)
     except OIDCError as err:
-        return JsonResponse({'error': err, 'callback': query}, status=400)
+        return JsonResponse({'error': err, 'callback': query}, status=status.HTTP_400_BAD_REQUEST)
 
 
 # helper to return list of available SSO clients
@@ -87,7 +87,7 @@ class DriverSsoAuthToken(APIView):
         if token:
             return validate_oauth_token(token)
         else:
-            return JsonResponse({'error': 'Token parameter is required'}, status=400)
+            return JsonResponse({'error': 'Token parameter is required'}, status=status.HTTP_400_BAD_REQUEST)
 
 
 def validate_oauth_token(token):
@@ -99,9 +99,9 @@ def validate_oauth_token(token):
     try:
         idinfo = client.verify_id_token(token, settings.GOOGLE_OAUTH_CLIENT_ID)
         if idinfo['aud'] not in [settings.GOOGLE_OAUTH_CLIENT_ID]:
-            return JsonResponse({'error': 'Unrecognized client.'}, status=403)
+            return JsonResponse({'error': 'Unrecognized client.'}, status=status.HTTP_403_FORBIDDEN)
         if idinfo['iss'] not in ['accounts.google.com', 'https://accounts.google.com']:
-            return JsonResponse({'error': 'Wrong issuer.'}, status=403)
+            return JsonResponse({'error': 'Wrong issuer.'}, status=status.HTTP_403_FORBIDDEN)
         # have a good token; get API token now
         user = authenticate(**idinfo)
         if user:
@@ -109,9 +109,9 @@ def validate_oauth_token(token):
             token, created = Token.objects.get_or_create(user=user)
             return Response({'token': token.key, 'user': token.user_id})
         else:
-            return JsonResponse({'error': 'This login is not valid in this application'}, status=403)
+            return JsonResponse({'error': 'This login is not valid in this application'}, status=status.HTTP_403_FORBIDDEN)
     except crypt.AppIdentityError:
-        return JsonResponse({'error': 'Invalid token'}, status=403)
+        return JsonResponse({'error': 'Invalid token'}, status=status.HTTP_403_FORBIDDEN)
 
 
 class UserViewSet(viewsets.ModelViewSet):

--- a/app/driver_auth/views.py
+++ b/app/driver_auth/views.py
@@ -1,3 +1,4 @@
+import logging
 from urllib import quote
 from urlparse import parse_qs
 
@@ -6,9 +7,14 @@ from django.contrib.auth.models import User, Group
 from django.http import JsonResponse
 from django.shortcuts import redirect
 
+from oauth2client import client, crypt
+
 from rest_framework import status, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
 from rest_framework.response import Response
 
 from djangooidc.oidc import OIDCError
@@ -16,6 +22,7 @@ from djangooidc.views import CLIENTS
 
 from ashlar.pagination import OptionalLimitOffsetPagination
 
+from django.conf import settings
 from driver_auth.serializers import UserSerializer, GroupSerializer
 from driver_auth.permissions import (IsAdminOrReadSelfOnly, IsAdminOrReadOnly, is_admin_or_writer,
                                      is_admin)
@@ -26,6 +33,8 @@ TOKEN_COOKIE = 'AuthService.token'
 CAN_WRITE_COOKIE = 'AuthService.canWrite'
 ADMIN_COOKIE = 'AuthService.isAdmin'
 
+logger = logging.getLogger(__name__)
+
 
 def authz_cb(request):
     """
@@ -35,12 +44,12 @@ def authz_cb(request):
     Overriden to set auth token cookie for client; still logs in session as well.
     """
 
-    client = CLIENTS[request.session["op"]]
+    oauth_client = CLIENTS[request.session["op"]]
     query = None
 
     try:
         query = parse_qs(request.META['QUERY_STRING'])
-        userinfo = client.callback(query, request.session)
+        userinfo = oauth_client.callback(query, request.session)
         request.session["userinfo"] = userinfo
         user = authenticate(**userinfo)
         if user:
@@ -58,7 +67,7 @@ def authz_cb(request):
         else:
             # authentication failed
             # return 403 here instead of raising error
-            return JsonResponse({'error': 'this login is not valid in this application'},
+            return JsonResponse({'error': 'This login is not valid in this application'},
                             status=403)
     except OIDCError as err:
         return JsonResponse({'error': err, 'callback': query}, status=400)
@@ -67,6 +76,42 @@ def authz_cb(request):
 # helper to return list of available SSO clients
 def get_oidc_client_list(request):
     return JsonResponse({'clients': CLIENTS.keys()})
+
+
+class DriverSsoAuthToken(APIView):
+    parser_classes = (JSONParser,)
+    permission_classes = (AllowAny,)
+
+    def post(self, request, format=None):
+        token = request.data.get('token')
+        if token:
+            return validate_oauth_token(token)
+        else:
+            return JsonResponse({'error': 'Token parameter is required'}, status=400)
+
+
+def validate_oauth_token(token):
+    """Validate the token code from a mobile client SSO login, then return the user's DRF token
+    for use in authenticating future requests to this API.
+
+    https://developers.google.com/identity/sign-in/android/backend-auth#using-a-google-api-client-library
+    """
+    try:
+        idinfo = client.verify_id_token(token, settings.GOOGLE_OAUTH_CLIENT_ID)
+        if idinfo['aud'] not in [settings.GOOGLE_OAUTH_CLIENT_ID]:
+            return JsonResponse({'error': 'Unrecognized client.'}, status=403)
+        if idinfo['iss'] not in ['accounts.google.com', 'https://accounts.google.com']:
+            return JsonResponse({'error': 'Wrong issuer.'}, status=403)
+        # have a good token; get API token now
+        user = authenticate(**idinfo)
+        if user:
+            logger.debug('validated SSO token code for user: {email}'.format(email=user.email))
+            token, created = Token.objects.get_or_create(user=user)
+            return Response({'token': token.key, 'user': token.user_id})
+        else:
+            return JsonResponse({'error': 'This login is not valid in this application'}, status=403)
+    except crypt.AppIdentityError:
+        return JsonResponse({'error': 'Invalid token'}, status=403)
 
 
 class UserViewSet(viewsets.ModelViewSet):
@@ -109,3 +154,4 @@ class DriverObtainAuthToken(ObtainAuthToken):
 
 
 obtain_auth_token = DriverObtainAuthToken.as_view()
+sso_auth_token = DriverSsoAuthToken.as_view()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,6 +3,7 @@ djangorestframework-gis==0.9.1
 django-filter==0.11.0
 django-extensions==1.6.1
 django-cors-headers==1.0.0
+google-api-python-client==1.5.0
 git+https://github.com/rohe/pyoidc.git@c9880cac2e5435f4197bda4364ace82206795f92#egg=oic
 # TODO: revert to marcanpilami django-oidc when https://github.com/rohe/pyoidc/issues/161 fixed
 git+https://github.com/flibbertigibbet/django-oidc.git


### PR DESCRIPTION
Backend portion of mobile client SSO authentication.

https://developers.google.com/identity/sign-in/android/backend-auth#send-the-id-token-to-your-server

Adds an endpoint that accepts a single posted `token` parameter, which is the token ID obtained by the mobile client from authorizing an account with Google for use with DRIVER. This token is then validated for the app server-side, using the Google python authentication client; if it is, the endpoint returns the same response as the existing `api-token-auth` endpoint: the user ID and token for DRF authentication of API requests.
