### PR TITLE
Limit CSV exports to the Details field if the user is read-only

### DIFF
--- a/app/data/tests/test_csv_export.py
+++ b/app/data/tests/test_csv_export.py
@@ -12,7 +12,9 @@ from django_redis import get_redis_connection
 from ashlar.models import Record, RecordSchema, RecordType
 
 from data.tasks.export_csv import (get_sql_string_by_key, get_queryset_by_key,
-                                   AshlarRecordExporter, RecordModelExporter, RelatedInfoExporter)
+                                   AshlarRecordExporter, ReadOnlyRecordExporter,
+                                   RecordModelWriter, RelatedInfoWriter,
+                                   ModelAndDetailsWriter)
 
 
 class AshlarRecordExporterTestCase(TestCase):
@@ -23,17 +25,20 @@ class AshlarRecordExporterTestCase(TestCase):
             'definitions': {
                 'testRelatedOne': {
                     'multiple': True,
-                    'properties': {}
+                    'properties': {},
+                    'details': False
                 },
                 'testRelatedTwo': {
                     'multiple': False,
-                    'properties': {}
+                    'properties': {},
+                    'details': True
                 }
             }
         }
         self.schema = RecordSchema.objects.create(schema=self.schema_def, version=1,
                                                   record_type=record_type)
         self.exporter = AshlarRecordExporter(self.schema)
+        self.read_only_exporter = ReadOnlyRecordExporter(self.schema)
 
     def tearDown(self):
         self.exporter.finish()
@@ -41,24 +46,34 @@ class AshlarRecordExporterTestCase(TestCase):
 
     def test_constant_info_setup(self):
         """Test that a writer and output file are created for constant fields"""
-        self.assertIsInstance(self.exporter.rec_writer, RecordModelExporter)
+        self.assertIsInstance(self.exporter.rec_writer, ModelAndDetailsWriter)
         self.assertIsNotNone(self.exporter.rec_outfile, file)
 
     def test_related_info_detection(self):
         """Test that related fields are detected and writers/outfiles created"""
-        self.assertEqual(len(self.exporter.writers), len(self.schema.schema['definitions']))
-        self.assertEqual(len(self.exporter.outfiles), len(self.schema.schema['definitions']))
-        for key in self.schema_def['definitions']:
+        # The Details field is excluded from the related info writers, so we expect to have
+        # one fewer writer and output files than there are related info types.
+        self.assertEqual(len(self.exporter.writers), len(self.schema.schema['definitions']) - 1)
+        self.assertEqual(len(self.exporter.outfiles), len(self.schema.schema['definitions']) - 1)
+        expectedKeys = [key for key, subschema in self.schema_def['definitions'].viewitems()
+                        if subschema['details'] is False]
+        for key in expectedKeys:
             self.assertIn(key, self.exporter.writers, '{} missing from output writers'.format(key))
             self.assertIn(key, self.exporter.outfiles, '{} missing from output files'.format(key))
         for writer in self.exporter.writers.values():
-            self.assertIsInstance(writer, RelatedInfoExporter)
+            self.assertIsInstance(writer, RelatedInfoWriter)
         # Checking for file-like objects in Python is not easy.
         for outfile in self.exporter.outfiles.values():
             self.assertIsNotNone(outfile, file)
 
+    def test_read_only_exporter(self):
+        """Test that a ReadOnlyRecordExporter has the expected writers and outfiles"""
+        self.assertEqual(len(self.read_only_exporter.writers), 0)
+        self.assertEqual(len(self.read_only_exporter.outfiles), 0)
+        self.assertIsNotNone(self.read_only_exporter.rec_outfile)
 
-class RecordModelExporterTestCase(TestCase):
+
+class RecordModelWriterTestCase(TestCase):
     def setUp(self):
         self.csv_columns = ['test1', 'test2']
         self.outfile = StringIO.StringIO()
@@ -68,13 +83,13 @@ class RecordModelExporterTestCase(TestCase):
 
     def test_write_header(self):
         """Test that the header written to a file"""
-        writer = RecordModelExporter(self.csv_columns, {}, {})
+        writer = RecordModelWriter(self.csv_columns, {}, {})
         writer.write_header(self.outfile)
         self.assertEqual(self.outfile.getvalue(), 'test1,test2\r\n')
 
     def test_get_model_value_for_column(self):
         """Test that values are pulled from the correct model fields"""
-        writer = RecordModelExporter(self.csv_columns, {'test1': 'other1'}, {})
+        writer = RecordModelWriter(self.csv_columns, {'test1': 'other1'}, {})
         record = mock.MagicMock(test1=1, other1=2)
         self.assertEqual(writer.get_model_value_for_column(record, 'other1'), 2)
 
@@ -84,19 +99,19 @@ class RecordModelExporterTestCase(TestCase):
             'test1': lambda x: x * 2,
             'test2': lambda x: x * 4
         }
-        writer = RecordModelExporter(self.csv_columns, {}, transforms)
+        writer = RecordModelWriter(self.csv_columns, {}, transforms)
         self.assertEqual(writer.transform_model_value(2, 'test1'), 2 * 2)
         self.assertEqual(writer.transform_model_value(2, 'test2'), 2 * 4)
 
     def test_write_record(self):
         """Test that writer outputs to a file"""
-        writer = RecordModelExporter(self.csv_columns, {}, {})
+        writer = RecordModelWriter(self.csv_columns, {}, {})
         record = mock.MagicMock(test1=1, test2=2, no_out=3)
         writer.write_record(record, self.outfile)
         self.assertEqual(self.outfile.getvalue(), '1,2\r\n')
 
 
-class RelatedInfoExporterTestCase(TestCase):
+class RelatedInfoWriterTestCase(TestCase):
     def setUp(self):
         self.definition = {
             'multiple': True,
@@ -117,8 +132,8 @@ class RelatedInfoExporterTestCase(TestCase):
         """Test that the Exporter auto-detects sub-schema fields properly"""
         bad_def = {}
         with self.assertRaises(ValueError):
-            writer = RelatedInfoExporter(self.definition_name, bad_def)
-        writer = RelatedInfoExporter(self.definition_name, self.definition, field_transform=dict())
+            writer = RelatedInfoWriter(self.definition_name, bad_def)
+        writer = RelatedInfoWriter(self.definition_name, self.definition, field_transform=dict())
         self.assertEqual(writer.is_multiple, self.definition['multiple'])
         self.assertEqual(4, len(writer.csv_columns))
         for prop in ['record_id', 'testRelatedInfo_id', 'prop1', 'prop2']:
@@ -128,9 +143,9 @@ class RelatedInfoExporterTestCase(TestCase):
         """Test that key names are changed and values dropped if specified"""
         rename_transform = {'prop1': 'newName'}
         drop_transform = {'prop1': None}
-        rename_writer = RelatedInfoExporter(self.definition_name, self.definition,
+        rename_writer = RelatedInfoWriter(self.definition_name, self.definition,
                                             field_transform=rename_transform)
-        drop_writer = RelatedInfoExporter(self.definition_name, self.definition,
+        drop_writer = RelatedInfoWriter(self.definition_name, self.definition,
                                           field_transform=drop_transform)
         input_data = {'prop1': 'value'}
         self.assertEqual(rename_writer.transform_value_keys(input_data), {'newName': 'value'})
@@ -138,7 +153,7 @@ class RelatedInfoExporterTestCase(TestCase):
 
     def test_write_header(self):
         """Test that the header written to a file"""
-        writer = RelatedInfoExporter(self.definition_name, self.definition, field_transform=dict())
+        writer = RelatedInfoWriter(self.definition_name, self.definition, field_transform=dict())
         writer.write_header(self.outfile)
         header = self.outfile.getvalue()
         # Unlike the Record exporter, the related info exporter doesn't have a defined field order
@@ -147,7 +162,7 @@ class RelatedInfoExporterTestCase(TestCase):
 
     def test_write_related(self):
         """Test that related info is written to a file"""
-        writer = RelatedInfoExporter(self.definition_name, self.definition, field_transform=dict())
+        writer = RelatedInfoWriter(self.definition_name, self.definition, field_transform=dict())
         related_info = {'prop1': 'value1', 'prop2': 'value2', '_localId': 'relInfoId'}
         writer.write_related('record-id', related_info, self.outfile)
         csv_line = self.outfile.getvalue()

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -699,7 +699,7 @@ class RecordCsvExportViewSet(viewsets.ViewSet):
             return Response({'errors': {'tilekey': 'This parameter is required'}},
                             status=status.HTTP_400_BAD_REQUEST)
 
-        task = export_csv.delay(filter_key)
+        task = export_csv.delay(filter_key, request.user.pk)
         return Response({'success': True, 'taskid': task.id}, status=status.HTTP_201_CREATED)
 
     # TODO: If we switch to a Django/ORM database backend, we can subclass AbortableTask


### PR DESCRIPTION
Mashes the *Details info together with the record model information. I just realized that combining the two files has caused the `record_id` column to be repeated, but I think that this is ready otherwise. The way the Details info is combined with the model information is not the most elegant; I'm happy to hear alternative approaches.

Also fixes an import error in views.py that was preventing me from logging in.