### PR TITLE
Fix deleting related content types

### DIFF
--- a/schema_editor/app/scripts/views/recordtype/related-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/related-controller.js
@@ -19,6 +19,7 @@
         function deleteSchema(key) {
             if (ctl.currentSchema.schema.definitions[key]) {
                 delete ctl.currentSchema.schema.definitions[key];
+                delete ctl.currentSchema.schema.properties[key];
                 // TODO: Error handle and revert delete if failure
                 RecordSchemas.create({
                     /* jshint camelcase:false */

--- a/schema_editor/test/spec/views/recordtype/related-controller.spec.js
+++ b/schema_editor/test/spec/views/recordtype/related-controller.spec.js
@@ -43,4 +43,37 @@ describe('ase.views.recordtype: RelatedController', function () {
         $httpBackend.flush();
         $httpBackend.verifyNoOutstandingRequest();
     });
+
+    it('should correctly delete related content types', function() {
+        $httpBackend.whenGET(new RegExp('api\/recordtypes\/*')).respond(
+            200, {'current_schema': 'irrelevant'}
+        );
+        $httpBackend.whenGET(new RegExp('api\/recordschemas\/*')).respond(
+            200,
+            {
+                'schema': {
+                    'definitions': {
+                        'keyToDelete': 'should be gone',
+                        'keyToRemain': 'should remain'
+                    },
+                    'properties': {
+                        'keyToDelete': 'should be gone',
+                        'keyToRemain': 'should remain'
+                    }
+                }
+            }
+        );
+        Controller = $controller('RTRelatedController', {
+            $scope: $scope, $stateParams: { uuid: 'irrelevant' }
+        });
+
+        $scope.$apply();
+        $httpBackend.flush();
+
+        Controller.deleteSchema('keyToDelete');
+        expect(Controller.currentSchema.schema.definitions.keyToDelete).not.toBeDefined();
+        expect(Controller.currentSchema.schema.properties.keyToDelete).not.toBeDefined();
+        expect(Controller.currentSchema.schema.definitions.keyToRemain).toBeDefined();
+        expect(Controller.currentSchema.schema.properties.keyToRemain).toBeDefined();
+    });
 });


### PR DESCRIPTION
The content type needs to get deleted from both the schema's
`definitions` section and its `properties` section.

Closes #411 