### PR TITLE
Allow public users to see interventions layer

### DIFF
--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -395,7 +395,7 @@
         function addLayerSwitcher() {
             /* jshint camelcase: false */
             var recordLayers = [[ctl.recordType.plural_label, ctl.primaryLayerGroup]];
-            if (ctl.userCanWrite && ctl.secondaryType) {
+            if (ctl.secondaryType) {
                 recordLayers.push([ctl.secondaryType.plural_label, ctl.secondaryLayerGroup]);
             }
             /* jshint camelcase: true */


### PR DESCRIPTION
After a discussion, we actually want to allow public users
to see interventions on the map, they just shouldn't see
the add/export interface.

Trivial, merging.