### PR TITLE
Add workaround to hide datepicker

### DIFF
--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -125,6 +125,15 @@
                   ctl.map.fire('click', e);
                 });
 
+                // The datepicker calendar div gets added to the end of <body> where it doesn't
+                // get to hear all the clicks that Leaflet swallows. This crappy workaround still
+                // leaves some bad behavior when clicks don't make it through to the map (e.g.
+                // they're on the layer switcher or an incident pop-up) but it handles the most
+                // common case of clicking in empty map space.
+                ctl.map.on('click', function() {
+                    angular.element('.datepicker').hide();
+                });
+
                 ctl.drawControl = new L.Control.Draw({
                     draw: {
                         // TODO: figure out a good way to export circles.


### PR DESCRIPTION
Leaflet swallows events all over the place.  The worst offender for our purposes, I think, is here: https://github.com/Leaflet/Leaflet/blob/v0.7.7/src/dom/Draggable.js#L55.  Which I guess is believed necessary per this: https://github.com/Leaflet/Leaflet/issues/2590.  Also see https://github.com/Leaflet/Leaflet/pull/4306, in which it had apparently gone away and was put back in then reverted a few weeks later.

Anyway, as far as I've been able to figure, the datepicker is sticking around because it gets tacked on at the very end of &lt;body&gt;, so the bootstrap event hooks that make it disappear won't fire unless the click is allowed to bubble all the way up, but because Leaflet is prone to bugs whereby unintended stuff happens when something behind a control or layer gets an event and does something with it, there are stopPropagation calls sprinkled throughout.

So what I've come up with is a workaround that solves the problem in the most common cases by just going ahead and hiding the datepicker whenever the map gets a click.