### PR TITLE
Use main map state on add-record map

### DIFF
--- a/web/app/scripts/state/mapstate-service.js
+++ b/web/app/scripts/state/mapstate-service.js
@@ -5,15 +5,20 @@
     'use strict';
 
     /* ngInject */
-    function MapState() {
-        var filterGeoJSON, zoom, location;
+    function MapState(BaseLayersService, localStorageService) {
+        var filterGeoJSON, zoom, location, baseLayer;
+        var baseLayers = _.map(BaseLayersService.baseLayers(), 'label');
+        var baseLayerStorageName = 'map.baseLayerName';
+
         var svc = {
             setFilterGeoJSON: setFilterGeoJSON,
             getFilterGeoJSON: getFilterGeoJSON,
             setZoom: setZoom,
             getZoom: getZoom,
             setLocation: setLocation,
-            getLocation: getLocation
+            getLocation: getLocation,
+            setBaseLayerName: setBaseLayerName,
+            getBaseLayerName: getBaseLayerName
         };
 
         return svc;
@@ -61,9 +66,26 @@
          */
         function getLocation() {
             return location;
-
         }
 
+        /**
+         * Set base map selection (by name) and save it in local storage
+         */
+        function setBaseLayerName(layerName) {
+            baseLayer = layerName;
+            localStorageService.set(baseLayerStorageName, layerName);
+        }
+
+        /**
+         * Get base map selection (by name), from local storage if not initialized, falling
+         * back to the first basemap if local storage doesn't have one set.
+         */
+        function getBaseLayerName() {
+            if (!baseLayer) {
+                baseLayer = localStorageService.get(baseLayerStorageName);
+            }
+            return baseLayer || baseLayers[0];
+        }
     }
 
     angular.module('driver.state')

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -106,10 +106,15 @@
             }).then(
                 getTilekeys
             ).then(function() {
-                // add base layer
+                // load base layers
                 var layers = BaseLayersService.baseLayers();
-                ctl.map.addLayer(layers[0].layer);
                 bmapDefer.resolve(layers);
+
+                // set the base layer to the one selected in MapState
+                var baseLayer = _.find(layers, function (l) {
+                    return l.label === MapState.getBaseLayerName();
+                });
+                ctl.map.addLayer(baseLayer.layer);
 
                 // add polygon draw control and layer to edit on
                 ctl.editLayers = new L.FeatureGroup();
@@ -191,6 +196,10 @@
 
                 ctl.map.on('moveend', function() {
                     MapState.setLocation(ctl.map.getCenter());
+                });
+
+                ctl.map.on('baselayerchange', function(e) {
+                    MapState.setBaseLayerName(e.name);
                 });
 
                 // TODO: Find a better way to ensure this doesn't happen until filterbar ready

--- a/web/test/spec/state/mapstate-service.spec.js
+++ b/web/test/spec/state/mapstate-service.spec.js
@@ -4,26 +4,57 @@ describe('driver.state: Map', function () {
 
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.state'));
+    beforeEach(module('driver.map-layers'));
 
     var $rootScope;
     var $httpBackend;
     var MapState;
+    var BaseLayersService;
+    var LocalStorageService;
 
-    beforeEach(inject(function (_$rootScope_, _$httpBackend_, _MapState_) {
+    beforeEach(inject(function (_$rootScope_, _$httpBackend_, _MapState_, _BaseLayersService_,
+                                _localStorageService_) {
         $rootScope = _$rootScope_;
         $httpBackend = _$httpBackend_;
         MapState = _MapState_;
+        BaseLayersService = _BaseLayersService_;
+        LocalStorageService = _localStorageService_;
     }));
 
-    it('should make a request for state options on call to "updateOptions"', function () {
+    it('should set and get FilterGeoJSON', function () {
+        expect(MapState.getFilterGeoJSON()).toBeUndefined();
         MapState.setFilterGeoJSON('asdf');
         expect(MapState.getFilterGeoJSON()).toBe('asdf');
+    });
 
+    it('should return default zoomlevel when none has been set', function () {
+        expect(MapState.getZoom()).toEqual(5);
+    });
+
+    it('should set and get zoomlevel', function () {
         MapState.setZoom(1);
         expect(MapState.getZoom()).toBe(1);
+    });
 
+    it('should set and get location', function () {
+        expect(MapState.getLocation()).toBeUndefined();
         MapState.setLocation({'loc': 1});
         expect(MapState.getLocation()).toEqual({'loc': 1});
+    });
+
+    it('should have a local storage provider', function () {
+        expect(LocalStorageService).toBeDefined();
+    });
+
+    it('should return a default base map selection when none is set', function () {
+        expect(LocalStorageService.get('map.baseLayerName')).toBeNull();
+        expect(MapState.getBaseLayerName()).toEqual(BaseLayersService.baseLayers()[0].label);
+    });
+
+    it('should set, get, and store base map selection', function () {
+        MapState.setBaseLayerName('Satellite');
+        expect(MapState.getBaseLayerName()).toEqual('Satellite');
+        expect(LocalStorageService.get('map.baseLayerName')).toEqual('Satellite');
     });
 
 });


### PR DESCRIPTION
Makes the embedded map used by the add-record view read the zoom, center, and basemap state as set by the main map, so that the map shown when someone hits the "add record" button looks similar to the one they were just seeing rather than resetting to the streets basemap and wide zoom.

Saves the basemap selection to local storage because otherwise views that spawn a new window and use the embedded map (e.g. Edit) don't get the selection.  Since those views have their own defaults for zoom and location, I didn't add those to local storage.

Other inset maps (blackspots, recent events) still don't pull anything from MapState.

(Kenny, sending this to you because you're the only other person who has PRS in their "doing" box at the moment.)

