### PR TITLE
Add function to download OSM data

### DIFF
--- a/app/black_spots/tasks/__init__.py
+++ b/app/black_spots/tasks/__init__.py
@@ -4,5 +4,4 @@ from celery import shared_task, Task
 from celery.utils.log import get_task_logger
 
 from black_spots.tasks.calculate_black_spots import calculate_black_spots
-
-
+from black_spots.tasks.load_road_network import load_road_network

--- a/app/black_spots/tasks/load_road_network.py
+++ b/app/black_spots/tasks/load_road_network.py
@@ -1,0 +1,54 @@
+import glob
+import os
+import shutil
+import subprocess
+
+from django.conf import settings
+
+from celery import shared_task
+from celery.utils.log import get_task_logger
+
+import requests
+
+
+logger = get_task_logger(__name__)
+
+
+@shared_task
+def load_road_network(output_root=None, output_srid='EPSG:3395'):
+    """Downloads OpenStreetMap data to a Shapefile by using an OSM extract PBF file.
+
+    Args:
+        output_root (string): Absolute path of directory to output to; default current directory
+        output_srid (string): Tranform Shapefile output to this SRID; default 'EPSG:3395'
+    Returns:
+        Path to OSM data as shapefile.
+    """
+    if not output_root:
+        output_root = os.getcwd()
+    osm_path = os.path.join(output_root, 'road_network.osm.pbf')
+
+    # Download OSM data
+    with open(osm_path, 'wb') as osm_fh:
+        logger.info('Downloading OSM extract')
+        response = requests.get(settings.OSM_EXTRACT_URL, stream=True)
+        response.raise_for_status()
+        for chunk in response.iter_content(chunk_size=1024):
+            if chunk:
+                osm_fh.write(chunk)
+        osm_fh.flush()
+
+    # Convert from OSM XML to a Shapefile using ogr2ogr
+    logger.info('Converting to Shapefile')
+    cmd_args = ['ogr2ogr', '-overwrite', '-skipfailures',
+                '-f', 'ESRI Shapefile', '-s_srs', 'EPSG:4326', '-t_srs', output_srid,
+                '-lco', 'ENCODING=UTF-8',
+                os.path.join(output_root, 'road_network'), osm_path]
+
+    subprocess.check_call(cmd_args)
+
+    # Move lines.* to output root and remove shapefile folder, OSM extract
+    for f in glob.glob(os.path.join(output_root, 'road_network', 'lines.*')):
+        shutil.move(f, output_root)
+    shutil.rmtree(os.path.join(output_root, 'road_network'))
+    return os.path.join(output_root, 'lines.shp')

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -123,6 +123,9 @@ USE_L10N = True
 
 USE_TZ = True
 
+OSM_EXTRACT_URL = os.environ.get('DRIVER_OSM_EXTRACT_URL',
+                                 'https://download.geofabrik.de/asia/philippines-latest.osm.pbf')
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -53,6 +53,7 @@ oauth_client_secret: ''
 local_time_zone_id: 'Asia/Manila'
 local_country_code: 'ph'
 local_center_lat_lon: [12.375, 121.5]
+osm_extract_url: 'https://download.geofabrik.de/asia/philippines-latest.osm.pbf'
 
 ## Forecast.io settings
 forecast_io_api_key: ''

--- a/deployment/ansible/roles/driver.app/defaults/main.yml
+++ b/deployment/ansible/roles/driver.app/defaults/main.yml
@@ -24,6 +24,7 @@ driver_conf:
   DJANGO_POSTGIS_VERSION: "{{ driver_postgis_version }}"
   DJANGO_SECRET_KEY: "{{ postgresql_password | md5 }}"
   DJANGO_ENV: "{% if developing %}development{% elif staging %}staging{% else %}production{% endif %}"
+  DRIVER_OSM_EXTRACT_URL: "{{ osm_extract_url }}"
 
 driver_postgis_version: 2.1.3
 


### PR DESCRIPTION
This is currently structured as a Celery task. To test, run `./scripts/manage.sh shell_plus` and then

```python
import black_spots.tasks as tasks
tasks.load_road_network()
```

Uses EPSG:3395 for projection by default because `ogr2ogr` apparently projects EPSG:3857 strictly following the EPSG specification, whereas map tiles are projected slightly differently, so if you project to EPSG:3857 the geometries appear shifted when displayed over map tiles.