### PR TITLE
Order Records list by occurred_from

### DIFF
--- a/app/data/views.py
+++ b/app/data/views.py
@@ -79,6 +79,11 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             return DriverRecordSerializer
         return DetailsReadOnlyRecordSerializer
 
+    def get_queryset(self):
+        """Override default model ordering"""
+        qs = super(DriverRecordViewSet, self).get_queryset()
+        return qs.order_by('-occurred_from')
+
     def get_filtered_queryset(self, request):
         """Return the queryset with the filter backends applied. Handy for aggregations."""
         queryset = self.get_queryset()


### PR DESCRIPTION
Overrides the default Ashlar ordering (which is to order by `'-created'`). I initially was planning to put this in Ashlar directly, but I realized that sorting by creation date is probably sane for many uses, so I decided to put the change into DRIVER instead absent a compelling reason to change the default.