### PR TITLE
Fix race condition with translations

### DIFF
--- a/web/app/scripts/custom-reports/aggregations-config.js
+++ b/web/app/scripts/custom-reports/aggregations-config.js
@@ -80,7 +80,8 @@
                     return RecordSchemaState.get(recordType.current_schema);
                     /* jshint camelcase: false */
                 });
-                return $q.all([filtersPromise, GeographyState.getOptions()]).then(function (data) {
+                var promises = [filtersPromise, GeographyState.getOptions(), $translate.onReady()];
+                return $q.all(promises).then(function (data) {
                     var schema = data[0];
                     var geographies = data[1];
 

--- a/web/app/scripts/state/initialstate-service.js
+++ b/web/app/scripts/state/initialstate-service.js
@@ -7,11 +7,12 @@
     'use strict';
 
     /* ngInject */
-    function InitialState($q) {
+    function InitialState($translate, $q) {
 
         var recordTypeInitialized = false;
         var boundaryInitialized = false;
         var geographyInitialized = false;
+        var languageInitialized = false;
 
         var deferreds = [];
 
@@ -19,8 +20,13 @@
             ready: ready,
             setRecordTypeInitialized: setRecordTypeInitialized,
             setBoundaryInitialized: setBoundaryInitialized,
-            setGeographyInitialized: setGeographyInitialized
+            setGeographyInitialized: setGeographyInitialized,
+            setLanguageInitialized: setLanguageInitialized
         };
+
+        // Ensure the translation file is available, since many components that
+        // use InitialState also rely on instant translations.
+        $translate.onReady(setLanguageInitialized);
 
         return svc;
 
@@ -55,7 +61,8 @@
          * Returns true when all state values are available
          */
         function allInitialized() {
-            return recordTypeInitialized && boundaryInitialized && geographyInitialized;
+            return recordTypeInitialized && boundaryInitialized &&
+                geographyInitialized && languageInitialized;
         }
 
         /**
@@ -79,6 +86,14 @@
          */
         function setGeographyInitialized() {
             geographyInitialized = true;
+            resolveDeferreds();
+        }
+
+        /**
+         * Sets the language initialized state value to true
+         */
+        function setLanguageInitialized() {
+            languageInitialized = true;
             resolveDeferreds();
         }
 

--- a/web/app/scripts/stepwise/stepwise-directive.js
+++ b/web/app/scripts/stepwise/stepwise-directive.js
@@ -29,28 +29,10 @@
                 var x = d3.scale.ordinal().rangeBands([0, width], 0.05);
                 var y = d3.scale.linear().range([height, 0]);
 
-                var tooltip = d3.tip().html(function(d) {
-                    return '<strong>' +
-                        $translate.instant('RECORD.WEEK_OF') +
-                        ': </strong>' +
-                        d.dt.toLocaleDateString() +
-                        '</br><strong>' +
-                        $translate.instant('RECORD.EVENT_COUNT') +
-                        ':</strong> <span>' +
-                        d.count +
-                        '</span>';
-                }).offset([-20,-15]);
-                init();
+                // Need to set after initialization to guarantee translations are available
+                var tooltip = null;
 
-                /**
-                 * Watch for changes to chartData and redraw and redraw and redraw
-                 */
-                scope.$watch('chartData', function(newVal) {
-                    if (newVal) {
-                        var data = formatData(newVal);
-                        updateChart(data);
-                    }
-                });
+                $translate.onReady(init);
 
                 /**
                  * Initialize graph to make clean updates possible in a separate, 'updateChart',
@@ -58,6 +40,28 @@
                  *  elements together under `rect`.
                  */
                 function init() {
+                    /**
+                     * Watch for changes to chartData and redraw
+                     */
+                    scope.$watch('chartData', function(newVal) {
+                        if (newVal) {
+                            var data = formatData(newVal);
+                            updateChart(data);
+                        }
+                    });
+
+                    tooltip = d3.tip().html(function(d) {
+                        return '<strong>' +
+                            $translate.instant('RECORD.WEEK_OF') +
+                            ': </strong>' +
+                            d.dt.toLocaleDateString() +
+                            '</br><strong>' +
+                            $translate.instant('RECORD.EVENT_COUNT') +
+                            ':</strong> <span>' +
+                            d.count +
+                            '</span>';
+                    }).offset([-20,-15]);
+
                     var rawSvg = elem.find('svg')[0];
                     var bufferedWidth = width + margin.left + margin.right;
                     var bufferedHeight = height + margin.top + margin.bottom;

--- a/web/app/scripts/toddow/toddow-directive.js
+++ b/web/app/scripts/toddow/toddow-directive.js
@@ -26,20 +26,8 @@
                 var rect, color, svg;  // GLOBAL
                 var tooltip = d3.tip();
                 tooltip.offset(function() { return [-16, -18]; });
-                init();
 
-                /**
-                 * Watch for changes to chartData and redraw and redraw and redraw
-                 */
-                scope.$watch('chartData', function(val) {
-                    if (val) {
-                        var data = formatData(val);
-                        color = d3.scale.quantile()
-                            .domain([0, _.max(val, function(x) { return x.count; }).count])
-                            .range(rampValues);
-                        updateChart(data);
-                    }
-                });
+                $translate.onReady(init);
 
                 /**
                  * Initialize graph to make clean updates possible in a separate, 'updateChart',
@@ -47,6 +35,19 @@
                  *  elements together under `rect`.
                  */
                 function init() {
+                    /**
+                     * Watch for changes to chartData and redraw
+                     */
+                    scope.$watch('chartData', function(val) {
+                        if (val) {
+                            var data = formatData(val);
+                            color = d3.scale.quantile()
+                                .domain([0, _.max(val, function(x) { return x.count; }).count])
+                                .range(rampValues);
+                            updateChart(data);
+                        }
+                    });
+
                     svg = d3.select(rawSvg)
                         .attr('viewBox', '0 0 ' + width + ' ' + height)
                         .attr('preserveAspectRatio', 'xMinYMin')

--- a/web/test/spec/black-spots/black-spots-controller.spec.js
+++ b/web/test/spec/black-spots/black-spots-controller.spec.js
@@ -41,6 +41,7 @@ describe('driver.blackSpots: BlackSpotsController', function() {
         InitialState.setRecordTypeInitialized();
         InitialState.setBoundaryInitialized();
         InitialState.setGeographyInitialized();
+        InitialState.setLanguageInitialized();
 
         MapState.setLocation({
             lat: 123,

--- a/web/test/spec/export/export-controller.spec.js
+++ b/web/test/spec/export/export-controller.spec.js
@@ -41,7 +41,7 @@ describe('driver.tools.export: ExportController', function () {
         InitialState.setRecordTypeInitialized();
         InitialState.setBoundaryInitialized();
         InitialState.setGeographyInitialized();
-
+        InitialState.setLanguageInitialized();
 
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
         var boundariesUrl = /api\/boundaries/;

--- a/web/test/spec/map-layers/recent-events/recent-events-layer-directive.spec.js
+++ b/web/test/spec/map-layers/recent-events/recent-events-layer-directive.spec.js
@@ -10,15 +10,19 @@ describe('driver.map-layers.recent-events: Recent Events Layer Directive', funct
     var $rootScope;
     var $httpBackend;
     var DriverResourcesMock;
+    var InitialState;
     var ResourcesMock;
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_,
-                                _DriverResourcesMock_, _ResourcesMock_) {
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_, _DriverResourcesMock_,
+                                _InitialState_, _ResourcesMock_) {
         $compile = _$compile_;
         $rootScope = _$rootScope_;
         $httpBackend = _$httpBackend_;
         DriverResourcesMock = _DriverResourcesMock_;
+        InitialState = _InitialState_;
         ResourcesMock = _ResourcesMock_;
+
+        InitialState.setLanguageInitialized();
     }));
 
     it('should create a leaflet map', function () {

--- a/web/test/spec/recent-counts/recent-counts-controller.spec.js
+++ b/web/test/spec/recent-counts/recent-counts-controller.spec.js
@@ -5,6 +5,7 @@ describe('driver.recentCounts: RecentCountsController', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('driver.recentCounts'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $controller;
     var $httpBackend;
@@ -27,6 +28,7 @@ describe('driver.recentCounts: RecentCountsController', function () {
         InitialState = _InitialState_;
         InitialState.setBoundaryInitialized();
         InitialState.setGeographyInitialized();
+        InitialState.setLanguageInitialized();
     }));
 
     it('should make requests to recent_counts', function () {

--- a/web/test/spec/recent-counts/recent-counts-directive.spec.js
+++ b/web/test/spec/recent-counts/recent-counts-directive.spec.js
@@ -44,6 +44,7 @@ describe('driver.recentCounts: RecentCounts', function () {
         InitialState = _InitialState_;
         InitialState.setBoundaryInitialized();
         InitialState.setGeographyInitialized();
+        InitialState.setLanguageInitialized();
     }));
 
     it('It should construct the dom when given the appropriate object', function () {

--- a/web/test/spec/resources/aggregate-query-service.spec.js
+++ b/web/test/spec/resources/aggregate-query-service.spec.js
@@ -5,6 +5,7 @@ describe('driver.resources: Aggregate Queries', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.resources'));
     beforeEach(module('driver.mock.resources'));
+    beforeEach(module('pascalprecht.translate'));
 
     var RecordAggregates;
     var $rootScope;

--- a/web/test/spec/resources/query-builder-service-spec.js
+++ b/web/test/spec/resources/query-builder-service-spec.js
@@ -17,6 +17,7 @@ describe('driver.resources: QueryBuilder', function () {
         $provide.value('FilterState', mockFilterState);
     }));
     beforeEach(module('driver.mock.resources'));
+    beforeEach(module('pascalprecht.translate'));
 
     var QueryBuilder;
     var $rootScope;

--- a/web/test/spec/saved-filters/saved-filters-controller.spec.js
+++ b/web/test/spec/saved-filters/saved-filters-controller.spec.js
@@ -4,6 +4,7 @@ describe('driver.savedFilters: SavedFiltersController', function () {
 
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('driver.savedFilters'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $controller;
     var $httpBackend;

--- a/web/test/spec/state/boundarystate-service.spec.js
+++ b/web/test/spec/state/boundarystate-service.spec.js
@@ -4,6 +4,7 @@ describe('driver.state: BoundaryState', function () {
 
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('driver.state'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $rootScope;
     var $httpBackend;

--- a/web/test/spec/state/filterstate-service.spec.js
+++ b/web/test/spec/state/filterstate-service.spec.js
@@ -3,6 +3,7 @@
 describe('driver.state: Records', function () {
 
     beforeEach(module('driver.state'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $rootScope;
     var $timeout;

--- a/web/test/spec/state/geographystate-service.spec.js
+++ b/web/test/spec/state/geographystate-service.spec.js
@@ -4,6 +4,7 @@ describe('driver.state: Geographies', function () {
 
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.state'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $rootScope;
     var $httpBackend;

--- a/web/test/spec/state/initialstate-service.spec.js
+++ b/web/test/spec/state/initialstate-service.spec.js
@@ -3,6 +3,7 @@
 describe('driver.state: InitialState', function () {
 
     beforeEach(module('driver.state'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $timeout;
     var InitialState;
@@ -41,6 +42,7 @@ describe('driver.state: InitialState', function () {
         expect(testVar3).toEqual(false);
 
         InitialState.setGeographyInitialized();
+        InitialState.setLanguageInitialized();
 
         $timeout(function() {
             expect(testVar1).toEqual(true);

--- a/web/test/spec/state/recordstate-service.spec.js
+++ b/web/test/spec/state/recordstate-service.spec.js
@@ -4,6 +4,7 @@ describe('driver.state: Records', function () {
 
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.state'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $rootScope;
     var $httpBackend;

--- a/web/test/spec/state/zoom-to-boundary-directive-spec.js
+++ b/web/test/spec/state/zoom-to-boundary-directive-spec.js
@@ -4,6 +4,7 @@ describe('driver.state: Zoom to Boundary Directive', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.state'));
     beforeEach(module('Leaflet'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $compile;
     var $httpBackend;

--- a/web/test/spec/views/dashboard/dashboard-controller.spec.js
+++ b/web/test/spec/views/dashboard/dashboard-controller.spec.js
@@ -5,6 +5,7 @@ describe('driver.views.dashboard: DashboardController', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('driver.views.dashboard'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $controller;
     var $httpBackend;

--- a/web/test/spec/views/duplicates/duplicates-list-controller.spec.js
+++ b/web/test/spec/views/duplicates/duplicates-list-controller.spec.js
@@ -5,6 +5,7 @@ describe('driver.views.duplicates: DuplicatesListController', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('driver.views.duplicates'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $controller;
     var $httpBackend;
@@ -29,6 +30,7 @@ describe('driver.views.duplicates: DuplicatesListController', function () {
         InitialState.setRecordTypeInitialized();
         InitialState.setBoundaryInitialized();
         InitialState.setGeographyInitialized();
+        InitialState.setLanguageInitialized();
 
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
 

--- a/web/test/spec/views/duplicates/duplicates-list-directive.spec.js
+++ b/web/test/spec/views/duplicates/duplicates-list-directive.spec.js
@@ -31,6 +31,7 @@ describe('driver.views.duplicates: Duplicates List Directive', function () {
         InitialState.setRecordTypeInitialized();
         InitialState.setBoundaryInitialized();
         InitialState.setGeographyInitialized();
+        InitialState.setLanguageInitialized();
 
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
 

--- a/web/test/spec/views/map/layers-directive.spec.js
+++ b/web/test/spec/views/map/layers-directive.spec.js
@@ -42,6 +42,7 @@ describe('driver.views.map: Layers Directive', function () {
         InitialState.setRecordTypeInitialized();
         InitialState.setBoundaryInitialized();
         InitialState.setGeographyInitialized();
+        InitialState.setLanguageInitialized();
 
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
         $httpBackend.whenGET(recordTypeUrl).respond(200, ResourcesMock.RecordTypeResponse);

--- a/web/test/spec/views/record/details-controller.spec.js
+++ b/web/test/spec/views/record/details-controller.spec.js
@@ -5,6 +5,7 @@ describe('driver.views.record: DetailsController', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('driver.views.record'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $controller;
     var $httpBackend;

--- a/web/test/spec/views/record/details-modal-controller.spec.js
+++ b/web/test/spec/views/record/details-modal-controller.spec.js
@@ -5,6 +5,7 @@ describe('driver.views.record: RecordDetailsModalController', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('driver.views.record'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $controller;
     var $httpBackend;

--- a/web/test/spec/views/record/list-controller.spec.js
+++ b/web/test/spec/views/record/list-controller.spec.js
@@ -5,6 +5,7 @@ describe('driver.views.record: ListController', function () {
     beforeEach(module('ase.mock.resources'));
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('driver.views.record'));
+    beforeEach(module('pascalprecht.translate'));
 
     var $controller;
     var $httpBackend;
@@ -12,20 +13,24 @@ describe('driver.views.record: ListController', function () {
     var $scope;
     var Controller;
     var DriverResourcesMock;
+    var InitialState;
     var ResourcesMock;
     var FilterState;
 
     // Initialize the controller and a mock scope
-    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_,
-                                _DriverResourcesMock_, _ResourcesMock_, _FilterState_) {
+    beforeEach(inject(function (_$controller_, _$httpBackend_, _$rootScope_, _DriverResourcesMock_,
+                                _FilterState_, _InitialState_, _ResourcesMock_) {
         $controller = _$controller_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
         $scope = $rootScope.$new();
         DriverResourcesMock = _DriverResourcesMock_;
-        ResourcesMock = _ResourcesMock_;
         FilterState = _FilterState_;
+        InitialState = _InitialState_;
+        ResourcesMock = _ResourcesMock_;
+
         FilterState.reset();
+        InitialState.setLanguageInitialized();
 
         var recordTypeUrl = /\/api\/recordtypes\/\?active=True/;
 

--- a/web/test/spec/views/record/list-directive.spec.js
+++ b/web/test/spec/views/record/list-directive.spec.js
@@ -15,17 +15,22 @@ describe('driver.views.record: RecordList', function () {
     var localStorageService;
     var recordState;
     var DriverResourcesMock;
+    var InitialState;
     var ResourcesMock;
 
     beforeEach(inject(function (_$compile_, _$httpBackend_, _$rootScope_, _localStorageService_,
-                                _RecordState_, _DriverResourcesMock_, _ResourcesMock_) {
+                                _RecordState_, _DriverResourcesMock_, _InitialState_,
+                                _ResourcesMock_) {
         $compile = _$compile_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
         localStorageService = _localStorageService_;
         recordState = _RecordState_;
         DriverResourcesMock = _DriverResourcesMock_;
+        InitialState = _InitialState_;
         ResourcesMock = _ResourcesMock_;
+
+        InitialState.setLanguageInitialized();
 
         spyOn(localStorageService, 'get');
     }));


### PR DESCRIPTION
The translations performed in javascript with `$translate.instant`
need to ensure the translation file is ready at the time of translation.
`InitialState` is an object that many controllers rely on in order
to wait for all basic resources to be available before initialization.
`InitialState` has been modified to also check for translations being
ready. This covers the majority of potential translation race conditions.

There are a couple modules that aren't using `InitialState` and also
rely on `$translate.instant`. In these cases, `$translate.onReady` is
being used directly. It's hard to test these locally, since translation
files are loaded so quickly, the race condition is not apparent. I'll
test this once it makes its way to staging and will fix any additional
sections that show themselves, if there are any.