### PR TITLE
Ensure batch cron jobs are not run multiple times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - secure: rxJHlPjag0Ie6mFk5p40Rc+v0yegXXn+JLDwVJB5koZNOH4KNvDis+KG/VyZpLAXohd7Mrdqd87Z8xfzExur4Q10ubHyMMdLrgMDOTEx5j2S+8tt0kek+iFyTM4tsMi9H5MnS+zQ0MRNoF+Ay1tVi7XeHODMz/TKWGWsWzf+cvg=
   - secure: wc2LNYrPX8OfaytX9iQi4Wp9CBdMzBEt2PGiJIzcxALl8CS/PnP4/efnSuuAW49zaKvtSZ2kwqXObH0E0PamcCufkR3QCbnG+pxuq+Zxu11152inz3FO8UiaYksmzBcO3tidGuehWFPr+ULinlbT3RYaItXmPoPTAfO5l/0r1F4=
   - secure: hZNrcEi/XfMpdjegA9AAFm/XDM6+aP+NV7NfQAo4/P5IN2rBz20TEHcLmtDs0YODPnT0mneoqWaEM1V55VFZIp4FhDJetOA3nk+MhKpo6jAy+E5au+jJ8R5yWkwGAosedBBEYhU5T6iF073SpYcjfyun4fgC58o7yuYNoBISWVg=
+  - secure: fcgtvICGfCMqxgbF2A0i+FCImh/vNC5lTyBvwztPLShhIg0z/SxE1aDcHRGEFu5hkqw04B4kQN17XPpcRS2CKgne/Fv7n+k/7mPiVImTVk oWL/TZHPplmYFm9szQKR5RWnAVKcejjC4PK6E1w9jgwK+7U6usnPHF9BcvPpKOYN8=
 language: bash
 services:
 - docker

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -9,6 +9,9 @@ postgresql_username: driver
 postgresql_password: driver
 windshaft_db_username: windshaft
 windshaft_db_password: windshaft
+heimdall_db_username: heimdall
+heimdall_db_password: heimdall
+heimdall_lock_db: lockspace
 postgresql_database: driver
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "192.168.12.1/24", method: "md5" }

--- a/deployment/ansible/group_vars/staging
+++ b/deployment/ansible/group_vars/staging
@@ -6,6 +6,9 @@ postgresql_username: driver
 postgresql_password: "{{ lookup('env', 'DRIVER_DB_PASSWORD') | default('driver', true) }}"
 windshaft_db_username: windshaft
 windshaft_db_password: "{{ lookup('env', 'WINDSHAFT_DB_PASSWORD') | default('windshaft', true) }}"
+heimdall_db_username: heimdall
+heimdall_db_password: "{{ lookup('env', 'HEIMDALL_DB_PASSWORD') | default('heimdall', true) }}"
+heimdall_lock_db: lockspace
 postgresql_database: driver
 postgresql_hba_mapping:
   - { type: "host", database: "all", user: "all", address: "172.30.2.1/24", method: "md5" }

--- a/deployment/ansible/roles/driver.celery/defaults/main.yml
+++ b/deployment/ansible/roles/driver.celery/defaults/main.yml
@@ -32,3 +32,5 @@ root_www_dir: "/var/www"
 root_windshaft_dir: "/opt/windshaft"
 root_static_dir: "{{ root_www_dir }}/static"
 root_media_dir: "{{ root_www_dir }}/media"
+
+heimdall_db_connection: "postgres://{{ heimdall_db_user }}:{{ heimdall_db_password }}@{{ postgresql_host }}:{{ postgresql_port }}/{{ heimdall_lock_db }}"

--- a/deployment/ansible/roles/driver.celery/meta/main.yml
+++ b/deployment/ansible/roles/driver.celery/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - { role: "driver.docker" }
+  - { role: "driver.heimdall" }

--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -29,14 +29,25 @@
 - name: Ensure Driver celery service is running
   service: name=driver-celery state=started
 
+# TODO: uncomment and modify this when the final script is ready
 # - name: Add black spot calculation cronjob
 #   cron: name="black spot calculation"
-#         job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py calculate_black_spots"
+#         job="/usr/local/bin/heimdall
+#         --database '{{ heimdall_db_connection }}'
+#         --namespace records
+#         --name find_duplicates
+#         --timeout 300
+#         docker exec $(docker ps -q -f name=driver-celery) ./manage.py calculate_black_spots"
 #         hour=19 minute=10  # 3:10am in UTC+8
 
 - name: Add find duplicate records cronjob
   cron: name="find duplicate records"
-        job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py find_duplicate_records"
+        job="/usr/local/bin/heimdall
+        --database '{{ heimdall_db_connection }}'
+        --namespace records
+        --name find_duplicates
+        --timeout 300
+        docker exec $(docker ps -q -f name=driver-celery) ./manage.py find_duplicate_records"
         hour=17 minute=10  # 1:10am in UTC+8
 
 - name: Clean up CSV export files cronjob

--- a/deployment/ansible/roles/driver.database/tasks/main.yml
+++ b/deployment/ansible/roles/driver.database/tasks/main.yml
@@ -27,3 +27,16 @@
                    role_attr_flags=LOGIN
                    db="{{ postgresql_database }}"
                    state=present
+
+- name: Create PostgreSQL user for Heimdall
+  become_user: postgres
+  postgresql_user: name="{{ heimdall_db_username }}"
+                   password="{{ heimdall_db_password }}"
+                   role_attr_flags=LOGIN
+                   db="{{ postgresql_database }}"
+                   state=present
+
+- name: Create PostgreSQL database for Heimdall
+  become_user: postgres
+  postgresql_db: name="{{ heimdall_lock_db }}"
+                 owner="{{ heimdall_db_username }}"

--- a/deployment/ansible/roles/driver.heimdall/defaults/main.yml
+++ b/deployment/ansible/roles/driver.heimdall/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+heimdall_version: "0.2.3"
+heimdall_install_path: "/usr/local/bin/heimdall"
+heimdall_db_user: "heimdall"
+heimdall_lock_db: "lockspace"

--- a/deployment/ansible/roles/driver.heimdall/tasks/install.yml
+++ b/deployment/ansible/roles/driver.heimdall/tasks/install.yml
@@ -1,0 +1,11 @@
+---
+- name: Download Heimdall
+  get_url: dest=/tmp/heimdall.tar.gz
+           url="https://github.com/hectcastro/heimdall/releases/download/{{ heimdall_version }}/linux_amd64_heimdall.tar.gz"
+
+- name: Expand Heimdall
+  unarchive: src="/tmp/heimdall.tar.gz" dest=/tmp/ copy=no creates=/tmp/heimdall
+
+- name: Install Heimdall
+  command: cp /tmp/heimdall {{ heimdall_install_path }} creates={{ heimdall_install_path }}
+  register: heimdall_install

--- a/deployment/ansible/roles/driver.heimdall/tasks/main.yml
+++ b/deployment/ansible/roles/driver.heimdall/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+# Just in case we want to create azavea.heimdall later, we can copy install.yml
+- include: install.yml


### PR DESCRIPTION
This commit adds an initial heimdall configuration. Heimdall is a program
that wraps an executable program inside of an exclusive lock provided by
PostgreSQL's `pg_try_advisory_lock`. This results in the ability to wrap
cron jobs in heimdall across multiple worker machines and have only one
instance of the job run.

Note: this is only the initial configuration to set up heimdall. When the final 
commands for calculating black spots are finalized, this will need to be 
modified to account for them.
