### PR TITLE
Add translation strings for json-editor components

### DIFF
--- a/schema_editor/app/scripts/json-editor/json-editor-defaults-service.js
+++ b/schema_editor/app/scripts/json-editor/json-editor-defaults-service.js
@@ -8,7 +8,8 @@
                 push: pushCustomValidator,
                 pop: popCustomValidator,
                 clear: clearCustomValidators
-            }
+            },
+            addTranslation: addTranslation
         };
 
         /* jshint camelcase: false */
@@ -22,6 +23,12 @@
 
         function clearCustomValidators() {
             JSONEditor.defaults.custom_validators = [];
+        }
+
+        // Adds a translation mapping for the json-editor to use.
+        // To see the available keys, see `src/defaults.json` in the json-editor repo.
+        function addTranslation(key, val) {
+            JSONEditor.defaults.languages.en[key] = val;
         }
         /* jshint camelcase: true */
 

--- a/schema_editor/bower.json
+++ b/schema_editor/bower.json
@@ -12,7 +12,7 @@
     "angular-resource": "^1.3.0",
     "angular-sanitize": "^1.3.0",
     "angular-ui-router": "~0.2.14",
-    "json-editor": "azavea/json-editor#v0.7.24",
+    "json-editor": "azavea/json-editor#v10.7.25",
     "angular-local-storage": "~0.2.2",
     "angular-bootstrap": "~0.13.0",
     "lodash": "^3.8.0"

--- a/web/app/i18n/ar-sa.json
+++ b/web/app/i18n/ar-sa.json
@@ -155,6 +155,10 @@
         "RECORD_LIST": "كل السجلات"
     },
     "RECORD": {
+        "BUTTON_ADD_ROW_TITLE": "!Add \\{\\{0\\}\\}",
+        "BUTTON_COLLAPSE": "!Collapse",
+        "BUTTON_DELETE_ROW_TITLE": "!Delete \\{\\{0\\}\\}",
+        "BUTTON_EXPAND": "!Expand",
         "CREATED": "!Created",
         "DATE_AND_TIME": "اليوم والوقت",
         "DATE_FILTER": "!Filter events by date of occurence",

--- a/web/app/i18n/en-us.json
+++ b/web/app/i18n/en-us.json
@@ -155,6 +155,10 @@
         "RECORD_LIST": "Record List"
     },
     "RECORD": {
+        "BUTTON_ADD_ROW_TITLE": "Add \\{\\{0\\}\\}",
+        "BUTTON_COLLAPSE": "Collapse",
+        "BUTTON_DELETE_ROW_TITLE": "Delete \\{\\{0\\}\\}",
+        "BUTTON_EXPAND": "Expand",
         "CREATED": "Created",
         "DATE_AND_TIME": "Date & Time",
         "DATE_FILTER": "Filter events by date of occurence",

--- a/web/app/i18n/exclaim.json
+++ b/web/app/i18n/exclaim.json
@@ -136,7 +136,7 @@
         "SEPTEMBER": "!September",
         "OCTOBER": "!October",
         "NOVEMBER": "!November",
-        "DECEMBER":"!December"
+        "DECEMBER": "!December"
     },
     "NAV": {
         "ACCOUNT": "!Account",
@@ -155,6 +155,10 @@
         "RECORD_LIST": "!Record List"
     },
     "RECORD": {
+        "BUTTON_ADD_ROW_TITLE": "!Add \\{\\{0\\}\\}",
+        "BUTTON_COLLAPSE": "!Collapse",
+        "BUTTON_DELETE_ROW_TITLE": "!Delete \\{\\{0\\}\\}",
+        "BUTTON_EXPAND": "!Expand",
         "CREATED": "!Created",
         "DATE_AND_TIME": "!Date & Time",
         "DATE_FILTER": "!Filter events by date of occurence",

--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -3,9 +3,9 @@
 
     /* ngInject */
     function RecordAddEditController($log, $scope, $state, $stateParams, $window, $q, $translate,
-                                     uuid4, AuthService, Nominatim, Notifications, Records,
-                                     RecordState, RecordSchemaState, RecordTypes, WeatherService,
-                                     WebConfig) {
+                                     uuid4, AuthService, JsonEditorDefaults, Nominatim,
+                                     Notifications, Records, RecordState, RecordSchemaState,
+                                     RecordTypes, WeatherService, WebConfig) {
         var ctl = this;
         var editorData = null;
         var bbox = null;
@@ -112,7 +112,7 @@
                     ctl.lightValues = WeatherService.lightValues;
                     ctl.weatherValues = WeatherService.weatherValues;
                 }
-                onSchemaReady();
+                $translate.onReady(onSchemaReady);
             });
         }
 
@@ -292,6 +292,16 @@
         function onSchemaReady() {
             fixEmptyFields();
 
+            // Add json-editor translations for button titles (shown on hover)
+            JsonEditorDefaults.addTranslation('button_add_row_title',
+                                              $translate.instant('RECORD.BUTTON_ADD_ROW_TITLE'));
+            JsonEditorDefaults.addTranslation('button_collapse',
+                                              $translate.instant('RECORD.BUTTON_COLLAPSE'));
+            JsonEditorDefaults.addTranslation('button_delete_row_title',
+                                              $translate.instant('RECORD.BUTTON_DELETE_ROW_TITLE'));
+            JsonEditorDefaults.addTranslation('button_expand',
+                                              $translate.instant('RECORD.BUTTON_EXPAND'));
+
             /* jshint camelcase: false */
             ctl.editor = {
                 id: 'new-record-editor',
@@ -299,10 +309,12 @@
                     schema: ctl.recordSchema.schema,
                     disable_edit_json: true,
                     disable_properties: true,
-                    disable_array_add: false,
-                    disable_array_reorder: false,
+                    disable_array_delete_all_rows: true,
+                    disable_array_delete_last_row: true,
+                    disable_array_reorder: true,
                     collapsed: true,
                     theme: 'bootstrap3',
+                    iconlib: 'bootstrap3',
                     show_errors: 'change',
                     no_additional_properties: true,
                     startval: ctl.record ? ctl.record.data : null

--- a/web/bower.json
+++ b/web/bower.json
@@ -22,7 +22,7 @@
     "angular-translate-loader-static-files": "2.11.0",
     "bootstrap-sass-official": "^3.2.0",
     "ng-file-upload": "^4.0.0",
-    "json-editor": "azavea/json-editor#v0.7.24",
+    "json-editor": "azavea/json-editor#v10.7.25",
     "ng-debounce": "^0.1.7",
     "bootstrap-select": "1.7.3",
     "lodash": "^3.8.0",


### PR DESCRIPTION
Translations have been added for the four buttons that are displayed
in the json-editor. The json-editor version was updated as part of
this in order to be able to use some of the new features such as
translation string overrides. Also, some new configuration objects
were added for button display, so some of them have been removed,
and the text has been switched to glyphicons, in order to declutter
the interface a little.

Screenshot:
![json-editor-translations](https://cloud.githubusercontent.com/assets/6386/15056668/c24cc01e-12e0-11e6-9bbf-0aa962b7fc40.png)
