### PR TITLE
Don't display heatmap, blackspots, interventions if disabled

### DIFF
--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function DriverLayersController(
         $q, $filter, $log, $scope, $rootScope, $timeout, $translate, $compile,
-        AuthService, FilterState, RecordState, GeographyState,
+        AuthService, WebConfig, FilterState, RecordState, GeographyState,
         RecordSchemaState, BoundaryState, QueryBuilder,
         MapState, TileUrlService, BaseLayersService, InitialState, BlackspotSets) {
         var ctl = this;
@@ -383,11 +383,15 @@
             // event precedence; layers are added on top of each other, so the last layer added
             // will intercept click events first; this is apparently the case regardless of
             // whether a z-index has been set on some or all of the UTF Grid layers.
-            updateBlackspotLayer(urls.blackspotsUrl, urls.blackspotsUtfGridUrl,
-                                 urls.blackspotTileKey);
+            if (WebConfig.blackSpots.visible) {
+                updateBlackspotLayer(urls.blackspotsUrl, urls.blackspotsUtfGridUrl,
+                                     urls.blackspotTileKey);
+            }
             updateSecondaryLayer(urls.secondaryRecordsUrl, urls.secondaryUtfGridUrl);
             updatePrimaryLayer(urls.primaryRecordsUrl, urls.primaryUtfGridUrl);
-            updateHeatmapLayer(urls.primaryHeatmapUrl);
+            if (WebConfig.heatmap.visible) {
+                updateHeatmapLayer(urls.primaryHeatmapUrl);
+            }
         }
 
         /**
@@ -436,8 +440,12 @@
             }
             /* jshint camelcase: true */
 
-            recordLayers.push([$translate.instant('MAP.HEATMAP'), ctl.heatmapLayerGroup]);
-            recordLayers.push([$translate.instant('MAP.BLACKSPOTS'), ctl.blackspotLayerGroup]);
+            if (WebConfig.heatmap.visible) {
+                recordLayers.push([$translate.instant('MAP.HEATMAP'), ctl.heatmapLayerGroup]);
+            }
+            if (WebConfig.blackSpots.visible) {
+                recordLayers.push([$translate.instant('MAP.BLACKSPOTS'), ctl.blackspotLayerGroup]);
+            }
             var overlays = angular.extend(_.zipObject(recordLayers), ctl.boundariesLayerGroup);
 
             ctl.bMaps.then(

--- a/web/app/scripts/views/map/map-controller.js
+++ b/web/app/scripts/views/map/map-controller.js
@@ -3,10 +3,11 @@
 
     /* ngInject */
     function MapController($rootScope, $scope, $modal, AuthService, BoundaryState,
-                           InitialState, FilterState, Records, RecordTypes,
+                           WebConfig, InitialState, FilterState, Records, RecordTypes,
                            RecordState, RecordSchemaState, MapState, RecordAggregates) {
         var ctl = this;
         ctl.userCanWrite = false;
+        ctl.showInterventions = WebConfig.interventions.visible;
 
         /** This is one half of some fairly ugly code which serves to wire up a click
          *  handling event on top of some dynamically generated HTML. The other half is in

--- a/web/app/scripts/views/map/map-partial.html
+++ b/web/app/scripts/views/map/map-partial.html
@@ -8,7 +8,7 @@
         </driver-charts>
 
         <driver-interventions
-            ng-if="ctl.userCanWrite" params="ctl.recordQueryParams">
+            ng-if="ctl.userCanWrite && ctl.showInterventions" params="ctl.recordQueryParams">
         </driver-interventions>
 
         <driver-export params="ctl.recordQueryParams"></driver-export>

--- a/web/test/mock/config.js
+++ b/web/test/mock/config.js
@@ -16,6 +16,15 @@
         nominatim: {
             key: 'abc123'
         },
+        blackSpots: {
+            visible: true
+        },
+        heatmap: {
+            visible: true
+        },
+        interventions: {
+            visible: true
+        },
         record: {
             limit: 50
         },


### PR DESCRIPTION
If you haven't reprovisioned since #513 was merged, it will be necessary to update your `group_vars/all` with the feature flags added in that PR, and then provision before testing this branch. 

To test, run `./scripts/grunt.sh web serve` and then edit `web/app/scripts/config.js` and change the `visible` flags for blackspots, interventions, and heatmaps to `false`. Note that in order to disable Interventions from showing up in the Map layer picker, it will also be necessary to make the following change:
```js
        recordType: {                                                           
            visible: false,                                                     
            primaryLabel: 'Accident',                                           
            secondaryLabel: '' //'Intervention'                                 
        },                                                                      
```