### PR TITLE
Fix graph labels when in right-to-left mode

### DIFF
--- a/web/app/scripts/stepwise/module.js
+++ b/web/app/scripts/stepwise/module.js
@@ -6,6 +6,7 @@
     }
 
     angular.module('driver.stepwise', [
+        'driver.state',
         'ui.router',
         'ui.bootstrap'
     ]).config(DirectiveConfig);

--- a/web/app/scripts/stepwise/stepwise-directive.js
+++ b/web/app/scripts/stepwise/stepwise-directive.js
@@ -8,7 +8,7 @@
     'use strict';
 
     /* ngInject */
-    function Stepwise($translate) {
+    function Stepwise($translate, LanguageState) {
         var module = {
             restrict: 'E',
             scope: {
@@ -40,13 +40,15 @@
                  *  elements together under `rect`.
                  */
                 function init() {
+                    var isRightToLeft = LanguageState.getSelected().rtl;
+
                     /**
                      * Watch for changes to chartData and redraw
                      */
                     scope.$watch('chartData', function(newVal) {
                         if (newVal) {
                             var data = formatData(newVal);
-                            updateChart(data);
+                            updateChart(data, isRightToLeft);
                         }
                     });
 
@@ -99,7 +101,7 @@
                  *
                  * @param data {array} the data to change our chart with
                  */
-                function updateChart(data) {
+                function updateChart(data, isRightToLeft) {
                     svg.call(tooltip);
 
                     // Get the max count and use it for the number of ticks.
@@ -133,15 +135,16 @@
                         .selectAll('text')
                             .attr('class', 'label')
                             .style('text-anchor', 'end')
-                            .attr('dx', '-0.8em')
-                            .attr('dy', '0.15em')
+                            .attr('dx', isRightToLeft ? '-3.9em' : '-0.8em')
+                            .attr('dy', isRightToLeft ? '0.3em' : '0.15em')
                             .attr('transform', 'rotate(-50)');
 
                     svg.select('.yAxis')
                         .transition()
                         .call(yAxis)
                         .selectAll('text')
-                            .attr('class', 'label');
+                            .attr('class', 'label')
+                            .attr('x', isRightToLeft ? -20 : -2);
                 }
 
                 function getWeek(datetimeISO) {

--- a/web/app/scripts/toddow/module.js
+++ b/web/app/scripts/toddow/module.js
@@ -6,6 +6,7 @@
     }
 
     angular.module('driver.toddow', [
+        'driver.state',
         'ui.router',
         'ui.bootstrap'
     ]).config(DirectiveConfig);

--- a/web/app/scripts/toddow/toddow-directive.js
+++ b/web/app/scripts/toddow/toddow-directive.js
@@ -8,7 +8,7 @@
     'use strict';
 
     /* ngInject */
-    function ToDDoW($translate) {
+    function ToDDoW($translate, LanguageState) {
         // The color ramp to use
         var rampValues = ['#FDFBED', '#f6edb1', '#f7da22', '#ecbe1d', '#e77124',
                           '#d54927', '#cf3a27', '#a33936', '#7f182a', '#68101a'];
@@ -35,6 +35,8 @@
                  *  elements together under `rect`.
                  */
                 function init() {
+                    var isRightToLeft = LanguageState.getSelected().rtl;
+
                     /**
                      * Watch for changes to chartData and redraw
                      */
@@ -71,6 +73,7 @@
                     });
 
                     var theHours = _.range(24);
+
                     rect = svg.selectAll('.day')
                         .data(theDays)
                             .enter().append('g')
@@ -104,14 +107,16 @@
                         .append('text')
                           .text(function(d, i) { return theDays[i]; })
                           .attr('class', 'label')
-                          .attr('x', 0)
+                          .attr('x', isRightToLeft ? 27 : 0)
                           .attr('y', function(d, i) { return i * cellSize + 40; });
 
                     svg.select('.day').selectAll('g')
                         .append('text')
                             .text(function(d, i) { return theHours[i]; })
                             .attr('class', 'label hours')
-                            .attr('x', function(d, i) { return i * cellSize + 37; })
+                            .attr('x', function(d, i) {
+                                return i * cellSize + (isRightToLeft ? 47 : 37);
+                            })
                             .attr('y', 10);
 
                     // Use try/catch pattern here to prevent unecessary logging before data loads


### PR DESCRIPTION
The labels were being drawn off-screen in RTL-mode.
This adjusts their placement slightly so they show up.
It doesn't change anything else about placement or
alignment, as there are open implementation questions.

![graphs-ltr-stepwise](https://cloud.githubusercontent.com/assets/6386/15077733/da7733ac-137d-11e6-9593-2b83fbbebe52.png)

![graphs-rtl-stepwise](https://cloud.githubusercontent.com/assets/6386/15077731/da6faa9c-137d-11e6-933e-3022de043897.png)

![graphs-ltr-toddow](https://cloud.githubusercontent.com/assets/6386/15077734/da786100-137d-11e6-91af-10e766d17504.png)

![graphs-rtl-toddow](https://cloud.githubusercontent.com/assets/6386/15077732/da769dac-137d-11e6-8b73-518342e18b8a.png)