### PR TITLE
Optionally display black spots dashboard widget

### DIFF
--- a/web/app/i18n/ar-sa.json
+++ b/web/app/i18n/ar-sa.json
@@ -50,9 +50,10 @@
         "BLACK_SPOTS_BY_SEVERITY": "!Black Spots by Severity",
         "DAYS": "يوم",
         "LAST_WEEK": "الأسبوع الماضي",
-        "RECENT_EVENTS_PERIOD": "!during the past two weeks",
+        "RECENT_EVENTS_PERIOD": "!Last Two Weeks",
         "RECENT_PROPORTIONS_TEXT": "!of all traffic incidents involved",
-        "TODDOW_TITLE": "!Time of Day, Day of Week: The Last 90 Days",
+        "STEPWISE_TITLE": "!Weekly Counts: Last 90 Days",
+        "TODDOW_TITLE": "!Time of Day, Day of Week: Last 90 Days",
         "VIEW_ALL": "عرض جميع"
     },
     "DAY": {

--- a/web/app/i18n/en-us.json
+++ b/web/app/i18n/en-us.json
@@ -50,9 +50,10 @@
         "BLACK_SPOTS_BY_SEVERITY": "Black Spots by Severity",
         "DAYS": "Days",
         "LAST_WEEK": "last week",
-        "RECENT_EVENTS_PERIOD": "during the past two weeks",
+        "RECENT_EVENTS_PERIOD": "Last Two Weeks",
         "RECENT_PROPORTIONS_TEXT": "of all traffic incidents involved",
-        "TODDOW_TITLE": "Time of Day, Day of Week: The Last 90 Days",
+        "STEPWISE_TITLE": "Weekly Counts: Last 90 Days",
+        "TODDOW_TITLE": "Time of Day, Day of Week: Last 90 Days",
         "VIEW_ALL": "View all"
     },
     "DAY": {

--- a/web/app/i18n/exclaim.json
+++ b/web/app/i18n/exclaim.json
@@ -50,9 +50,10 @@
         "BLACK_SPOTS_BY_SEVERITY": "!Black Spots by Severity",
         "DAYS": "!Days",
         "LAST_WEEK": "!last week",
-        "RECENT_EVENTS_PERIOD": "!during the past two weeks",
+        "RECENT_EVENTS_PERIOD": "!Last Two Weeks",
         "RECENT_PROPORTIONS_TEXT": "!of all traffic incidents involved",
-        "TODDOW_TITLE": "!Time of Day, Day of Week: The Last 90 Days",
+        "STEPWISE_TITLE": "!Weekly Counts: Last 90 Days",
+        "TODDOW_TITLE": "!Time of Day, Day of Week: Last 90 Days",
         "VIEW_ALL": "!View all"
     },
     "DAY": {

--- a/web/app/scripts/views/dashboard/dashboard-controller.js
+++ b/web/app/scripts/views/dashboard/dashboard-controller.js
@@ -4,8 +4,9 @@
     /* ngInject */
     function DashboardController($scope, $state, $timeout,
                                  FilterState, InitialState, Records,
-                                 RecordSchemaState, RecordState, RecordAggregates) {
+                                 RecordSchemaState, RecordState, RecordAggregates, WebConfig) {
         var ctl = this;
+        ctl.showBlackSpots = WebConfig.blackSpots.visible;
 
         InitialState.ready().then(init);
 
@@ -43,13 +44,13 @@
         }
 
         /*
-         * Loads records for toddow
+         * Loads records for charts
          * @return {promise} Promise to load records
          */
         function loadRecords() {
             // We want to see only the last 90 days worth of records on the dashboard
             var now = new Date();
-            var duration = moment.duration({ days:90 });
+            var duration = moment.duration({ days: 90 });
             var today = now.toISOString();
             var threeMonthsBack = new Date(now - duration).toISOString();
 
@@ -60,13 +61,24 @@
             };
             /* jshint camelcase: true */
 
-            var filterConfig = { doAttrFilters: false,
-                                 doBoundaryFilter: true,
-                                 doJsonFilters: false, };
+            var filterConfig = {
+                doAttrFilters: false,
+                doBoundaryFilter: true,
+                doJsonFilters: false
+            };
 
             RecordAggregates.toddow(params, filterConfig).then(function(toddowData) {
                 ctl.toddow = toddowData;
             });
+
+            // The stepwise widget is only displayed when black spots are not visible
+            if (!ctl.showBlackSpots) {
+                RecordAggregates.stepwise(params).then(function(stepwiseData) {
+                    ctl.minDate = threeMonthsBack;
+                    ctl.maxDate = now;
+                    ctl.stepwise = stepwiseData;
+                });
+            }
         }
 
         function onRecordsLoaded() {

--- a/web/app/scripts/views/dashboard/dashboard-partial.html
+++ b/web/app/scripts/views/dashboard/dashboard-partial.html
@@ -1,37 +1,76 @@
 <main class="dashboard no-filterbar">
-    <div class="block block-1x2 quick-map">
-        <div class="block-inner">
-            <div class="map" driver-black-spots leaflet-map zoom-to-boundary></div>
-            <h3><span>{{ 'DASHBOARD.BLACK_SPOTS_BY_SEVERITY' | translate }}</span>
-                <a ui-sref="map" class="small pull-right">
-                    {{ 'DASHBOARD.ANALYZE_AND_FILTER' | translate }} »
-                </a>
-            </h3>
+
+    <div ng-if="ctl.showBlackSpots">
+        <div class="block block-1x2 quick-map">
+            <div class="block-inner">
+                <div class="map" driver-black-spots leaflet-map zoom-to-boundary></div>
+                <h3><span>{{ 'DASHBOARD.BLACK_SPOTS_BY_SEVERITY' | translate }}</span>
+                    <a ui-sref="map" class="small pull-right">
+                        {{ 'DASHBOARD.ANALYZE_AND_FILTER' | translate }} »
+                    </a>
+                </h3>
+            </div>
+        </div>
+        <div class="block block-1x2 quick-map">
+            <div class="block-inner">
+                <div class="map" leaflet-map recent-events zoom-to-boundary></div>
+                <h3><span>{{ ctl.recordType.plural_label }}: {{ 'DASHBOARD.RECENT_EVENTS_PERIOD' | translate }}</span>
+                    <a ui-sref="map" class="small pull-right">
+                        {{ 'DASHBOARD.VIEW_ALL' | translate }} {{ ctl.recordType.plural_label | lowercase }} »
+                    </a>
+                </h3>
+            </div>
+        </div>
+        <div class="block block-1x1 insights">
+            <driver-recent-proportions></driver-recent-proportions>
+        </div>
+        <div class="block block-1x1 counts">
+            <driver-recent-counts></driver-recent-counts>
+        </div>
+        <div class="block block-2x1 toddow">
+            <div class="block-inner">
+                <driver-toddow chart-data="ctl.toddow"></driver-toddow>
+                <h3>{{ 'DASHBOARD.TODDOW_TITLE' | translate }}</h3>
+            </div>
+        </div>
+        <div class="block block-2x1 filters">
+            <driver-saved-filters compact="true"></driver-saved-filters>
         </div>
     </div>
-    <div class="block block-1x2 quick-map">
-        <div class="block-inner">
-            <div class="map" leaflet-map recent-events zoom-to-boundary></div>
-            <h3><span>{{ ctl.recordType.plural_label }} {{ 'DASHBOARD.RECENT_EVENTS_PERIOD' | translate }}</span>
-                <a ui-sref="map" class="small pull-right">
-                    {{ 'DASHBOARD.VIEW_ALL' | translate }} {{ ctl.recordType.plural_label | lowercase }} »
-                </a>
-            </h3>
+
+    <div ng-if="!ctl.showBlackSpots" class="blackspots-disabled">
+        <div class="block block-1x2 toddow">
+            <div class="block-inner">
+                <driver-toddow chart-data="ctl.toddow"></driver-toddow>
+                <h3>{{ 'DASHBOARD.TODDOW_TITLE' | translate }}</h3>
+            </div>
+        </div>
+        <div class="block block-1x2 stepwise">
+            <div class="block-inner">
+                <driver-stepwise
+                   chart-data="ctl.stepwise"
+                   min-date="ctl.minDate"
+                   max-date="ctl.maxDate">
+                </driver-stepwise>
+                <h3>{{ 'DASHBOARD.STEPWISE_TITLE' | translate }}</h3>
+            </div>
+        </div>
+        <div class="block block-1x1 counts">
+            <driver-recent-counts></driver-recent-counts>
+        </div>
+        <div class="block block-1x1 quick-map">
+            <div class="block-inner">
+                <div class="map" leaflet-map recent-events zoom-to-boundary></div>
+                <h3><span>{{ ctl.recordType.plural_label }}: {{ 'DASHBOARD.RECENT_EVENTS_PERIOD' | translate }}</span>
+                    <a ui-sref="map" class="small pull-right">
+                        {{ 'DASHBOARD.VIEW_ALL' | translate }} {{ ctl.recordType.plural_label | lowercase }} »
+                    </a>
+                </h3>
+            </div>
+        </div>
+        <div class="block block-1x1 filters">
+            <driver-saved-filters compact="true"></driver-saved-filters>
         </div>
     </div>
-    <div class="block block-1x1 insights">
-        <driver-recent-proportions class=""></driver-recent-proportions>
-    </div>
-    <div class="block block-1x1 counts">
-        <driver-recent-counts class=""></driver-recent-counts>
-    </div>
-    <div class="block block-2x1 toddow">
-        <div class="block-inner">
-            <driver-toddow chart-data="ctl.toddow"></driver-toddow>
-            <h3>{{ 'DASHBOARD.TODDOW_TITLE' | translate }}</h3>
-        </div>
-    </div>
-    <div class="block block-2x1 filters">
-        <driver-saved-filters compact="true"></driver-saved-filters>
-    </div>
+
 </main>

--- a/web/app/styles/partials/_dashboard.scss
+++ b/web/app/styles/partials/_dashboard.scss
@@ -63,7 +63,7 @@
                     height: 24%;
                 }
             }
-            
+
             @media screen and (max-height: 768px) {
                 height: 32%;
                 top: 38%;
@@ -99,7 +99,7 @@
                 right: 10px;
                 width: auto;
                 margin: 14px 0;
-                font-size: 21px;
+                font-size: 20px;
 
                 span {
                     max-width: 65%;
@@ -156,7 +156,7 @@
                 font-weight: 700;
                 margin: 30px 0 10px;
                 color: #266DD3;
-                
+
                 @media screen and (max-width: 768px) {
                     font-size: 48px;
                 }
@@ -192,10 +192,10 @@
                 }
             }
         }
-        &.toddow {
+        &.toddow, &.stepwise {
             h3 {
                 margin: 0;
-                font-size: 21px;
+                font-size: 20px;
                 font-weight: 400;
             }
         }
@@ -235,6 +235,33 @@
         }
         a {
             cursor: pointer;
+        }
+    }
+
+    .blackspots-disabled {
+        .block {
+            &.block-1x2 {
+                width: 54%;
+            }
+
+            &.block-1x1 {
+                width: 40%;
+                left: 58%;
+
+                &:nth-child(3) {
+                    height: 25%;
+                }
+
+                &:nth-child(4) {
+                    top: 31%;
+                    height: 35%;
+                }
+
+                &:nth-child(5) {
+                    top: 68%;
+                    height: 28%;
+                }
+            }
         }
     }
 }

--- a/web/app/styles/partials/_rtl.scss
+++ b/web/app/styles/partials/_rtl.scss
@@ -9,6 +9,16 @@ body.rtl {
     float: left !important;
   }
 
+  .dashboard {
+      .blackspots-disabled {
+          .block {
+              &.block-1x1 {
+                  left: 2%;
+              }
+          }
+      }
+  }
+
   .navbar-header {
     float: right;
   }
@@ -107,4 +117,3 @@ body.rtl {
   }
 
 }
-

--- a/web/test/spec/views/dashboard/dashboard-directive.spec.js
+++ b/web/test/spec/views/dashboard/dashboard-directive.spec.js
@@ -27,10 +27,10 @@ describe('driver.views.dashboard: Dashboard', function () {
         var scope = $rootScope.$new();
         var element = $compile('<driver-dashboard></driver-dashboard>')(scope);
 
-        $httpBackend.expectGET(/\/api\/boundaries/)
-            .respond(ResourcesMock.GeographyResponse);
         $httpBackend.expectGET(/\/api\/recordtypes\//)
             .respond(200, ResourcesMock.RecordTypeResponse);
+        $httpBackend.expectGET(/\/api\/boundaries/)
+            .respond(ResourcesMock.GeographyResponse);
         $httpBackend.whenGET(/api\/boundarypolygons/)
             .respond(200, ResourcesMock.BoundaryNoGeomResponse);
 


### PR DESCRIPTION
When black spots visibility is disabled, the black spots
widget is not displayed, and the other widgets are shifted
around accordingly. Also some minor changes were made to
wording and font size for more consistency, and a greater
likelihood that the labels aren't cut off on small screen
sizes (tested with 1024x768).

Screenshot with blackspots enabled:
![optional-dashboard-with-blackspots](https://cloud.githubusercontent.com/assets/6386/15124835/ddbe71b6-15f7-11e6-859a-c87cb6bb5f1e.png)

Screenshot with blackspots disabled:
![optional-dashboard-no-blackspots](https://cloud.githubusercontent.com/assets/6386/15124834/ddbcf9ee-15f7-11e6-8377-d23e0f870e97.png)