### PR TITLE
Fix various RTL styling issues

### DIFF
--- a/web/app/scripts/custom-reports/custom-report-partial.html
+++ b/web/app/scripts/custom-reports/custom-report-partial.html
@@ -1,10 +1,14 @@
 <cube-grid-spinner ng-if="ctl.loading"></cube-grid-spinner>
 <div class="table-view custom-report" ng-if="!ctl.loading">
     <table class="table" ng-repeat="table in ctl.report.tables">
-        <caption>
-            <h2>
+        <caption class="text-right-on-rtl">
+            <h2 ng-if="!isRightToLeft">
                 <span>{{ ::ctl.params.occurred_min | localDateTime : ctl.dateFormat }}</span> -
                 <span>{{ ::ctl.params.occurred_max | localDateTime : ctl.dateFormat }}</span>
+            </h2>
+            <h2 ng-if="isRightToLeft">
+                <span>{{ ::ctl.params.occurred_max | localDateTime : ctl.dateFormat }}</span> -
+                <span>{{ ::ctl.params.occurred_min | localDateTime : ctl.dateFormat }}</span>
             </h2>
             <h3>
                 {{ ctl.recordType.plural_label }}

--- a/web/app/scripts/filterbar/filterbar.html
+++ b/web/app/scripts/filterbar/filterbar.html
@@ -24,14 +24,14 @@
         <a ng-click="filterbar.showSavedFiltersModal()"
             class="btn btn-default btn-icon"
             tooltip-trigger
-            tooltip-placement="left"
+            tooltip-placement="{{ isRightToLeft ? 'right' : 'left' }}"
             tooltip-append-to-body
             tooltip-animation="false"
             tooltip="{{ 'SAVED_FILTERS.TITLE' | translate }}"><span class="glyphicon glyphicon-filter"></span></a>
         <a
             class="btn btn-default btn-icon"
             tooltip-trigger
-            tooltip-placement="left"
+            tooltip-placement="{{ isRightToLeft ? 'right' : 'left' }}"
             tooltip="{{ 'SAVED_FILTERS.CLEAR' | translate }}"
             tooltip-append-to-body
             tooltip-animation="false"
@@ -40,7 +40,7 @@
             ng-if="::filterbar.userCanAdd"
             class="btn btn-default btn-icon"
             tooltip-trigger
-            tooltip-placement="left"
+            tooltip-placement="{{ isRightToLeft ? 'right' : 'left' }}"
             tooltip="{{ 'NAV.ADD_A_RECORD' | translate }}"
             tooltip-append-to-body
             tooltip-animation="false"

--- a/web/app/scripts/views/dashboard/dashboard-partial.html
+++ b/web/app/scripts/views/dashboard/dashboard-partial.html
@@ -1,4 +1,4 @@
-<main class="dashboard no-filterbar">
+<main class="dashboard no-filterbar" ng-if="isRightToLeft !== undefined">
 
     <div ng-if="ctl.showBlackSpots">
         <div class="block block-1x2 quick-map">

--- a/web/app/styles/partials/_rtl.scss
+++ b/web/app/styles/partials/_rtl.scss
@@ -39,6 +39,11 @@ body.rtl {
     }
   }
 
+  .filterbar > .pull-right {
+    right: auto;
+    left: 10px;
+  }
+
   .navbar-right {
     float: left !important;
   }
@@ -116,4 +121,10 @@ body.rtl {
     border-radius: 0;
   }
 
+}
+
+.text-right-on-rtl {
+  .rtl & {
+    text-align: right !important;
+  }
 }

--- a/web/test/spec/views/dashboard/dashboard-directive.spec.js
+++ b/web/test/spec/views/dashboard/dashboard-directive.spec.js
@@ -25,6 +25,7 @@ describe('driver.views.dashboard: Dashboard', function () {
 
     it('should load directive', function () {
         var scope = $rootScope.$new();
+        scope.isRightToLeft = false;
         var element = $compile('<driver-dashboard></driver-dashboard>')(scope);
 
         $httpBackend.expectGET(/\/api\/recordtypes\//)


### PR DESCRIPTION
 * Filterbar tooltips have been placed on the right side
 * Custom reports title/caption has been right aligned
 * Custom reports date range order has been switched
 * The dashboard has a weird animation that occurs when
   loading it directly. Made a change to reduce the
   duration of it (by using ng-if and waiting for the
   isRightToLeft variable to be defined. This makes the
   animation more tolerable, but it is still there a
   little, so we may want to look into fully removing it.
   Using ng-hide removes it completely, but then the map
   doesn't load properly. Also tried using ng-class to
   instead change `visibility` (as opposed to `display`
   with ng-hide), but it also didn't quite work.

These are pretty trivial styling changes, merging.