### PR TITLE
Add monit service monitoring

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -79,3 +79,14 @@ keystore_password: 'driverkeystore'
 
 ## Django allowed hosts setting. Override when not in DEBUG mode.
 allowed_host: ''
+
+## Access settings for Monit admin interface. Note that this is
+## insecure; ideally, SSL should be used (which Monit supports).
+## An intermediate step would be to restrict the IPs from which
+## monit can be accessed via monit_allow_hosts
+## Username and Password MUST be defined in order for monit to work
+## but monit is restricted to requests coming from localhost by default
+monit_allow_hosts: []
+monit_allow_user: 'test'
+monit_allow_password: 'test'
+monit_enable_web_access: yes

--- a/deployment/ansible/roles/driver-celery.nginx/meta/main.yml
+++ b/deployment/ansible/roles/driver-celery.nginx/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - { role: "azavea.nginx", nginx_delete_default_site: True }
+  - { role: "driver.monit" }

--- a/deployment/ansible/roles/driver-celery.nginx/tasks/main.yml
+++ b/deployment/ansible/roles/driver-celery.nginx/tasks/main.yml
@@ -17,3 +17,8 @@
             dest=/etc/nginx/conf.d/log-format.conf
   notify:
     - Restart Nginx
+
+- name: Set up monit monitoring of celery nginx server
+  template: src=monit-driver-nginx-celery.cfg.j2 dest=/etc/monit/conf.d/driver-celery-nginx.cfg
+  notify:
+    - Restart monit

--- a/deployment/ansible/roles/driver-celery.nginx/templates/monit-driver-nginx-celery.cfg.j2
+++ b/deployment/ansible/roles/driver-celery.nginx/templates/monit-driver-nginx-celery.cfg.j2
@@ -1,0 +1,3 @@
+check process nginx with pidfile "/var/run/nginx.pid"
+  start program = "/etc/init.d/nginx start"
+  stop program = "/etc/init.d/nginx stop"

--- a/deployment/ansible/roles/driver.app/meta/main.yml
+++ b/deployment/ansible/roles/driver.app/meta/main.yml
@@ -3,3 +3,4 @@ dependencies:
   - { role: "driver.docker" }
   - { role: "driver.web"}
   - { role: "driver.windshaft" }
+  - { role: "driver.monit" }

--- a/deployment/ansible/roles/driver.app/tasks/main.yml
+++ b/deployment/ansible/roles/driver.app/tasks/main.yml
@@ -43,6 +43,11 @@
 - name: Ensure Driver application is running
   service: name=driver-app state=started
 
+- name: Set up monit monitoring of driver-app container
+  template: src=monit-driver-app.cfg.j2 dest=/etc/monit/conf.d/driver-app.cfg
+  notify:
+    - Restart monit
+
 - name: Run Django collectstatic
   command: >
     /usr/bin/docker exec -ti driver-app ./manage.py collectstatic --noinput

--- a/deployment/ansible/roles/driver.app/templates/monit-driver-app.cfg.j2
+++ b/deployment/ansible/roles/driver.app/templates/monit-driver-app.cfg.j2
@@ -1,0 +1,4 @@
+check program driver-app with path "/bin/sh -c 'docker top driver-app'"
+  if status != 0 then alert
+  start program = "/usr/sbin/service driver-app start"
+  stop program = "/usr/sbin/service driver-app stop"

--- a/deployment/ansible/roles/driver.celery/meta/main.yml
+++ b/deployment/ansible/roles/driver.celery/meta/main.yml
@@ -2,3 +2,4 @@
 dependencies:
   - { role: "driver.docker" }
   - { role: "driver.heimdall" }
+  - { role: "driver.monit" }

--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -29,6 +29,11 @@
 - name: Ensure Driver celery service is running
   service: name=driver-celery state=started
 
+- name: Set up monit monitoring of driver-celery container
+  template: src=monit-driver-celery.cfg.j2 dest=/etc/monit/conf.d/driver-celery.cfg
+  notify:
+    - Restart monit
+
 # TODO: uncomment and modify this when the final script is ready
 # - name: Add black spot calculation cronjob
 #   cron: name="black spot calculation"

--- a/deployment/ansible/roles/driver.celery/templates/monit-driver-celery.cfg.j2
+++ b/deployment/ansible/roles/driver.celery/templates/monit-driver-celery.cfg.j2
@@ -1,0 +1,4 @@
+check program driver-celery with path "/bin/sh -c 'docker top driver-celery'"
+  if status != 0 then alert
+  start program = "/usr/sbin/service driver-celery start"
+  stop program = "/usr/sbin/service driver-celery stop"

--- a/deployment/ansible/roles/driver.database/meta/main.yml
+++ b/deployment/ansible/roles/driver.database/meta/main.yml
@@ -4,4 +4,5 @@ dependencies:
   - { role: "azavea.postgresql" }
   - { role: "azavea.postgresql-support"}
   - { role: "azavea.postgis" }
-  - { role: "azavea.redis" }
+  - { role: "driver.redis" }
+  - { role: "driver.monit" }

--- a/deployment/ansible/roles/driver.database/tasks/main.yml
+++ b/deployment/ansible/roles/driver.database/tasks/main.yml
@@ -40,3 +40,8 @@
   become_user: postgres
   postgresql_db: name="{{ heimdall_lock_db }}"
                  owner="{{ heimdall_db_username }}"
+
+- name: Set up monit monitoring of PostgreSQL
+  template: src=monit-postgresql.cfg.j2 dest=/etc/monit/conf.d/postgresql.cfg
+  notify:
+    - Restart monit

--- a/deployment/ansible/roles/driver.database/templates/monit-postgresql.cfg.j2
+++ b/deployment/ansible/roles/driver.database/templates/monit-postgresql.cfg.j2
@@ -1,0 +1,3 @@
+check process postgresql with pidfile "/var/run/postgresql/{{ postgresql_version }}-main.pid"
+  start program = "/etc/init.d/postgresql start"
+  stop program = "/etc/init.d/postgresql stop"

--- a/deployment/ansible/roles/driver.gradle/meta/main.yml
+++ b/deployment/ansible/roles/driver.gradle/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - { role: "driver.docker" }
+  - { role: "driver.monit" }

--- a/deployment/ansible/roles/driver.gradle/tasks/main.yml
+++ b/deployment/ansible/roles/driver.gradle/tasks/main.yml
@@ -32,3 +32,8 @@
 
 - name: Ensure gradle service is running
   service: name=driver-gradle state=started
+
+- name: Set up monit monitoring of driver-gradle container
+  template: src=monit-driver-gradle.cfg.j2 dest=/etc/monit/conf.d/driver-gradle.cfg
+  notify:
+    - Restart monit

--- a/deployment/ansible/roles/driver.gradle/templates/monit-driver-gradle.cfg.j2
+++ b/deployment/ansible/roles/driver.gradle/templates/monit-driver-gradle.cfg.j2
@@ -1,0 +1,4 @@
+check program driver-gradle with path "/bin/sh -c 'docker top driver-gradle'"
+  if status != 0 then alert
+  start program = "/usr/sbin/service driver-gradle start"
+  stop program = "/usr/sbin/service driver-gradle stop"

--- a/deployment/ansible/roles/driver.monit/defaults/main.yml
+++ b/deployment/ansible/roles/driver.monit/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+monit_version: 5.17.1
+monit_httpd_port: 2812
+monit_allow_hosts: []
+monit_enable_web_access: no

--- a/deployment/ansible/roles/driver.monit/handlers/main.yml
+++ b/deployment/ansible/roles/driver.monit/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart monit
+  service: name=monit state=restarted 

--- a/deployment/ansible/roles/driver.monit/tasks/main.yml
+++ b/deployment/ansible/roles/driver.monit/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Download monit
+  get_url: >
+    url=https://mmonit.com/monit/dist/binary/{{ monit_version }}/monit-{{ monit_version }}-linux-x64.tar.gz
+    dest=/usr/local/src/monit-{{ monit_version }}-linux-x64.tar.gz
+
+- name: Extract monit
+  unarchive: src=/usr/local/src/monit-{{ monit_version }}-linux-x64.tar.gz
+             dest=/usr/local/src
+             copy=no
+             creates=/usr/local/src/monit-{{ monit_version }}
+
+- name: Symlink monit into /usr/bin
+  file: >
+    src=/usr/local/src/monit-{{ monit_version }}/bin/monit
+    dest=/usr/bin/monit
+    state=link
+
+- name: Create necessary monit directories
+  file: path={{ item }} state=directory
+  with_items:
+    - /etc/monit
+    - /etc/monit/conf.d
+    - /var/lib/monit
+
+# We normally use upstart, but in the interest of time, this reuses
+# the init script that is packaged with the Trusty package for monit.
+- name: Create monit init script
+  template: src=init-monit.j2
+    dest=/etc/init.d/monit
+    mode=0755
+
+- name: Create monit init script defaults file
+  template: src=defaults-monit.j2 dest=/etc/default/monit
+
+- name: Create monit default configuration file
+  template: src=monitrc.j2 dest=/etc/monit/monitrc
+    mode=0600
+  notify:
+    - Restart monit
+
+- name: Symlink monit configuration to path expected by monit
+  file: src=/etc/monit/monitrc dest=/etc/monitrc state=link
+
+- name: Configure monit web interface
+  template: src=monit-enable-httpd.cfg.j2 dest=/etc/monit/conf.d/monit-enable-httpd.cfg
+  when: "{{ monit_enable_web_access }}"
+  notify:
+    - Restart monit

--- a/deployment/ansible/roles/driver.monit/templates/defaults-monit.j2
+++ b/deployment/ansible/roles/driver.monit/templates/defaults-monit.j2
@@ -1,0 +1,10 @@
+# /etc/default/monit
+
+# Defaults for monit initscript.  This file is sourced by
+# /bin/sh from /etc/init.d/monit.
+
+# Set START to yes to start the monit
+START=yes
+
+# Options to pass to monit
+#MONIT_OPTS=

--- a/deployment/ansible/roles/driver.monit/templates/init-monit.j2
+++ b/deployment/ansible/roles/driver.monit/templates/init-monit.j2
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          monit
+# Required-Start:    $remote_fs
+# Required-Stop:     $remote_fs
+# Should-Start:      $all
+# Should-Stop:       $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: service and resource monitoring daemon
+# Description:       monit is a utility for managing and monitoring
+#                    processes, programs, files, directories and filesystems
+#                    on a Unix system. Monit conducts automatic maintenance
+#                    and repair and can execute meaningful causal actions
+#                    in error situations.
+### END INIT INFO
+
+set -e
+
+. /lib/lsb/init-functions
+
+DAEMON=/usr/bin/monit
+CONFIG=/etc/monit/monitrc
+NAME=monit
+DESC="daemon monitor"
+MONIT_OPTS=
+PID="/run/$NAME.pid"
+
+# Check if DAEMON binary exist
+[ -f $DAEMON ] || exit 0
+
+[ -f "/etc/default/$NAME" ] && . /etc/default/$NAME
+
+MONIT_OPTS="-c $CONFIG $MONIT_OPTS"
+
+monit_not_configured () {
+  if [ "$1" != "stop" ]
+  then
+    printf "\tplease configure $NAME and then edit /etc/default/$NAME\n"
+    printf "\tand set the \"START\" variable to \"yes\" in order to allow\n"
+    printf "\t$NAME to start\n"
+  fi
+  exit 0
+}
+
+monit_checks () {
+  # Check if START variable is set to "yes", if not we exit.
+  if [ "$START" != "yes" ]
+  then
+    monit_not_configured $1
+  fi
+}
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC" "$NAME"
+    monit_checks $1
+    if start-stop-daemon --start --quiet --oknodo --pidfile $PID --exec $DAEMON -- $MONIT_OPTS 1>/dev/null
+    then
+      log_end_msg 0
+    else
+      log_end_msg 1
+    fi
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC" "$NAME"
+    if start-stop-daemon --retry TERM/5/KILL/5 --oknodo --stop --quiet --pidfile $PID 1>/dev/null
+    then
+      log_end_msg 0
+    else
+      log_end_msg 1
+    fi
+    ;;
+  reload)
+    log_daemon_msg "Reloading $DESC configuration" "$NAME"
+    if start-stop-daemon --stop --signal HUP --quiet --oknodo --pidfile $PID --exec $DAEMON -- $MONIT_OPTS 1>/dev/null
+    then
+      log_end_msg 0
+    else
+      log_end_msg 1
+	fi
+    ;;
+  restart|force-reload)
+    log_daemon_msg "Restarting $DESC" "$NAME"
+    start-stop-daemon --retry TERM/5/KILL/5 --oknodo --stop --quiet --pidfile $PID 1>/dev/null
+    if start-stop-daemon --start --quiet --oknodo --pidfile $PID --exec $DAEMON -- $MONIT_OPTS 1>/dev/null
+    then
+      log_end_msg 0
+    else
+      log_end_msg 1
+    fi
+    ;;
+  syntax)
+    $DAEMON $MONIT_OPTS -t
+    ;;
+  status)
+    status_of_proc -p $PID $DAEMON $NAME
+    ;;
+  *)
+    log_action_msg "Usage: /etc/init.d/$NAME {start|stop|reload|restart|force-reload|syntax|status}"
+    ;;
+esac
+
+exit 0

--- a/deployment/ansible/roles/driver.monit/templates/monit-enable-httpd.cfg.j2
+++ b/deployment/ansible/roles/driver.monit/templates/monit-enable-httpd.cfg.j2
@@ -1,0 +1,7 @@
+set httpd port {{ monit_httpd_port }}
+  allow localhost
+  {% for host in monit_allow_hosts -%}
+  allow {{ host }}
+  {% endfor -%}
+  allow {{ monit_allow_user }}:"{{ monit_allow_password }}"
+

--- a/deployment/ansible/roles/driver.monit/templates/monitrc.j2
+++ b/deployment/ansible/roles/driver.monit/templates/monitrc.j2
@@ -1,0 +1,36 @@
+###############################################################################
+## Monit control file
+###############################################################################
+##
+## Comments begin with a '#' and extend through the end of the line. Keywords
+## are case insensitive. All path's MUST BE FULLY QUALIFIED, starting with '/'.
+##
+## Below you will find examples of some frequently used statements. For 
+## information about the control file and a complete list of statements and 
+## options, please have a look in the Monit manual.
+  set daemon 120            # check services at 2-minute intervals
+#   with start delay 240    # optional: delay the first check by 4-minutes (by 
+#                           # default Monit check immediately after Monit start)
+#
+# set logfile syslog facility log_daemon
+  set logfile /var/log/monit.log
+#
+# set idfile /var/.monit.id
+  set idfile /var/lib/monit/id
+#
+  set statefile /var/lib/monit/state
+#
+#
+  set eventqueue
+      basedir /var/lib/monit/events # set the base directory where events will be stored
+      slots 100                     # optionally limit the queue size
+#
+###############################################################################
+## Includes
+###############################################################################
+##
+## It is possible to include additional configuration parts from other files or
+## directories.
+#
+   include /etc/monit/conf.d/*
+#

--- a/deployment/ansible/roles/driver.nginx/meta/main.yml
+++ b/deployment/ansible/roles/driver.nginx/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - { role: "azavea.nginx", nginx_delete_default_site: True }
+  - { role: "driver.monit" }

--- a/deployment/ansible/roles/driver.nginx/tasks/main.yml
+++ b/deployment/ansible/roles/driver.nginx/tasks/main.yml
@@ -17,3 +17,8 @@
             dest=/etc/nginx/conf.d/log-format.conf
   notify:
     - Restart Nginx
+
+- name: Set up monit monitoring of nginx for app
+  template: src=monit-nginx-app.cfg.j2 dest=/etc/monit/conf.d/driver-app-nginx.cfg
+  notify:
+    - Restart monit

--- a/deployment/ansible/roles/driver.nginx/templates/monit-nginx-app.cfg.j2
+++ b/deployment/ansible/roles/driver.nginx/templates/monit-nginx-app.cfg.j2
@@ -1,0 +1,3 @@
+check process nginx with pidfile "/var/run/nginx.pid"
+  start program = "/etc/init.d/nginx start"
+  stop program = "/etc/init.d/nginx stop"

--- a/deployment/ansible/roles/driver.redis/meta/main.yml
+++ b/deployment/ansible/roles/driver.redis/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.redis" }

--- a/deployment/ansible/roles/driver.redis/tasks/main.yml
+++ b/deployment/ansible/roles/driver.redis/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Set up monit monitoring of Redis
+  template: src=monit-redis.cfg.j2 dest=/etc/monit/conf.d/redis.cfg
+  notify:
+    - Restart monit

--- a/deployment/ansible/roles/driver.redis/templates/monit-redis.cfg.j2
+++ b/deployment/ansible/roles/driver.redis/templates/monit-redis.cfg.j2
@@ -1,0 +1,3 @@
+check process redis-server with pidfile "/var/run/redis/redis-server.pid"
+  start program = "/etc/init.d/redis-server start"
+  stop program = "/etc/init.d/redis-server stop"

--- a/deployment/ansible/roles/driver.windshaft/meta/main.yml
+++ b/deployment/ansible/roles/driver.windshaft/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - { role: "driver.docker" }
+  - { role: "driver.monit" }

--- a/deployment/ansible/roles/driver.windshaft/tasks/main.yml
+++ b/deployment/ansible/roles/driver.windshaft/tasks/main.yml
@@ -27,3 +27,8 @@
 
 - name: Ensure Windshaft application is running
   service: name=windshaft state=started
+
+- name: Set up monit monitoring
+  template: src=monit-windshaft.cfg.j2 dest=/etc/monit/conf.d/windshaft.cfg
+  notify:
+    - Restart monit

--- a/deployment/ansible/roles/driver.windshaft/templates/monit-windshaft.cfg.j2
+++ b/deployment/ansible/roles/driver.windshaft/templates/monit-windshaft.cfg.j2
@@ -1,0 +1,4 @@
+check program windshaft with path "/bin/sh -c 'docker top windshaft'"
+  if status != 0 then alert
+  start program = "/usr/sbin/service windshaft start"
+  stop program = "/usr/sbin/service windshaft stop"


### PR DESCRIPTION
This installs monit on all VMs and sets it up to monitor all the services that we run. Although there are a lot of files here, the general gist is that I added a role to install monit, and then added configuration files to the various service roles that enable monit to monitor the services activated by each role. Monit doesn't attempt to try to restart services if they fail since we usually handle that within upstart, so this is strictly to provide a relatively straightforward interface that can be used by admins to view service status and basic system statistics.

Unless / until we get SSL going, it's not safe to open monit to the outside world since the authentication passwords are sent in plaintext, so I've limited monit to be accessible from localhost only by default; additional access sources can be added by group_vars.

@hectcastro may also want to take a quick look although I think the primary thing that's interesting here is the strategy for determining if a docker container is running from monit. Docker's equivalent of pidfiles don't really seem to be usable as such because they don't automatically disappear when a container is stopped.