### PR TITLE
Fix problems with black spots calculation task

### DIFF
--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -132,7 +132,7 @@ USE_TZ = True
 OSM_EXTRACT_URL = os.environ.get('DRIVER_OSM_EXTRACT_URL',
                                  'https://download.geofabrik.de/asia/philippines-latest.osm.pbf')
 
-BLACKSPOT_RECORD_TYPE_LABEL = os.environ.get('BLACKSPOT_RECORD_TYPE_LABEL', 'Accident')
+BLACKSPOT_RECORD_TYPE_LABEL = os.environ.get('BLACKSPOT_RECORD_TYPE_LABEL', 'Incident')
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 

--- a/deployment/ansible/roles/driver.celery/defaults/main.yml
+++ b/deployment/ansible/roles/driver.celery/defaults/main.yml
@@ -24,6 +24,8 @@ driver_conf:
   DJANGO_POSTGIS_VERSION: "{{ driver_postgis_version }}"
   DJANGO_SECRET_KEY: "{{ postgresql_password | md5 }}"
   DJANGO_ENV: "{% if developing %}development{% elif staging %}staging{% else %}production{% endif %}"
+  DRIVER_OSM_EXTRACT_URL: "{{ osm_extract_url }}"
+  BLACKSPOT_RECORD_TYPE_LABEL: "{{ web_js_record_type_primary_label }}"
   ALLOWED_HOST: "{{ allowed_host }}"
 
 driver_postgis_version: 2.1.3


### PR DESCRIPTION
These fixes allow the task to run to completion with a smaller
OSM input. Optimizations for a larger input will be done in a
separate PR. This was tested by setting `osm_extract_url` to:
'http://osm-extracted-metros.s3.amazonaws.com/manila.osm.pbf',
which uses the Manila boundary (rather than the full Philippines).