### PR TITLE
Fix cronjob logging, add logging docs

### DIFF
--- a/deployment/ansible/roles/driver.celery/defaults/main.yml
+++ b/deployment/ansible/roles/driver.celery/defaults/main.yml
@@ -37,3 +37,5 @@ root_static_dir: "{{ root_www_dir }}/static"
 root_media_dir: "{{ root_www_dir }}/media"
 
 heimdall_db_connection: "postgres://{{ heimdall_db_user }}:{{ heimdall_db_password }}@{{ postgresql_host }}:{{ postgresql_port }}/{{ heimdall_lock_db }}"
+
+driver_cron_log_dir: "/var/log/driver-tasks"

--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -34,6 +34,9 @@
   notify:
     - Restart monit
 
+- name: Create a directory for scheduled task logs
+  file: path={{ driver_cron_log_dir }} state=directory
+
 # TODO: uncomment and modify this when the final script is ready
 # - name: Add black spot calculation cronjob
 #   cron: name="black spot calculation"
@@ -42,7 +45,8 @@
 #         --namespace records
 #         --name find_duplicates
 #         --timeout 300
-#         docker exec $(docker ps -q -f name=driver-celery) ./manage.py calculate_black_spots"
+#         docker exec $(docker ps -q -f name=driver-celery) ./manage.py calculate_black_spots
+#         >> {{ driver_cron_log_dir }}/calculate_black_spots.log 2>&1"
 #         hour=19 minute=10  # 3:10am in UTC+8
 
 - name: Add find duplicate records cronjob
@@ -52,10 +56,12 @@
         --namespace records
         --name find_duplicates
         --timeout 300
-        docker exec $(docker ps -q -f name=driver-celery) ./manage.py find_duplicate_records"
+        docker exec $(docker ps -q -f name=driver-celery) ./manage.py find_duplicate_records
+        >> {{ driver_cron_log_dir }}/find_duplicates.log 2>&1"
         hour=17 minute=10  # 1:10am in UTC+8
 
 - name: Clean up CSV export files cronjob
   cron: name="export file cleanup"
-        job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py remove_old_exports"
+        job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py remove_old_exports
+        >> {{ driver_cron_log_dir }}/remove_old_exports.log 2>&1"
         minute=10

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -1,0 +1,56 @@
+# System administration: Logging
+
+DRIVER is composed of a number of separate services; all of these services must be operating in
+order for DRIVER to work properly. In order to diagnose potential problems with the system, it may
+be necessary to use log files on the system to view output from these services.
+
+## Database (PostgreSQL)
+Database host
+
+Path: `/var/log/postgresql/postgresql-9.4-main.log`
+
+## Cache (Redis)
+Database host
+
+Path: `/var/log/redis/redis-server.log`
+
+## Tile server (Windshaft)
+App host
+
+Path: `/var/log/upstart/windshaft.log`
+
+## Web proxy (Nginx)
+App host
+
+Paths:
+- `/var/log/nginx/driver-app.access.log` (log rotation appends `.1`, `.2`, etc.)
+- `/var/log/nginx/error.log` (log rotation as above)
+
+## Web application (Django)
+App host
+
+Path: `/var/log/upstart/driver-app.log`
+
+## Android JAR creation (Gradle)
+Celery host
+
+Path: `/var/log/upstart/driver-gradle.log`
+
+## File download server (Nginx)
+Celery host
+
+Paths:
+- `/var/log/nginx/driver-celery.access.log` (log rotation appends `.1`, `.2`, etc)
+- `/var/log/nginx/error.log` (log rotation as above)
+
+
+## Scheduled tasks (cron)
+Celery host
+
+Path: `/var/log/driver-tasks/*.log`
+
+## Asynchronous jobs (Celery)
+This includes CSV exports and other asynchronous tasks triggered by the web UI and/or Android application.
+Celery host
+
+Path: `/var/log/upstart/driver-celery.log`


### PR DESCRIPTION
This adds documentation for the location of log files, and also ensures that logging for Celery tasks is written to a specified location on the Celery host.