### PR TITLE
Cost Config Model

### DIFF
--- a/app/black_spots/migrations/0007_auto_20160525_0320.py
+++ b/app/black_spots/migrations/0007_auto_20160525_0320.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('black_spots', '0006_auto_20160525_0111'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='blackspotconfig',
+            name='id',
+        ),
+        migrations.AddField(
+            model_name='blackspotconfig',
+            name='created',
+            field=models.DateTimeField(default=datetime.datetime(2016, 5, 24, 19, 19, 56, 339703, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='blackspotconfig',
+            name='modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 5, 24, 19, 20, 3, 683051, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='blackspotconfig',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True),
+        ),
+    ]

--- a/app/black_spots/models.py
+++ b/app/black_spots/models.py
@@ -39,7 +39,7 @@ class BlackSpotSet(AshlarModel):
     record_type = models.ForeignKey('ashlar.RecordType')
 
 
-class BlackSpotConfig(models.Model):
+class BlackSpotConfig(AshlarModel):
     """Holds user-configurable settings for how black spot generation should work"""
     #: Blackspot severity percentile cutoff; segments with forecast severity above this threshold
     #: will be considered blackspots.

--- a/app/data/migrations/0007_auto_20160525_0156.py
+++ b/app/data/migrations/0007_auto_20160525_0156.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.contrib.postgres.operations import HStoreExtension
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data', '0006_dedupejob_celery_task'),
+    ]
+
+    operations = [
+        HStoreExtension()
+    ]

--- a/app/data/migrations/0008_recordcostconfig.py
+++ b/app/data/migrations/0008_recordcostconfig.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.contrib.postgres.fields.hstore
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ashlar', '0022_record_archived'),
+        ('data', '0007_auto_20160525_0156'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RecordCostConfig',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('content_type_key', models.TextField()),
+                ('property_key', models.TextField()),
+                ('enum_costs', django.contrib.postgres.fields.hstore.HStoreField()),
+                ('record_type', models.ForeignKey(to='ashlar.RecordType')),
+            ],
+        ),
+    ]

--- a/app/data/migrations/0009_auto_20160525_0320.py
+++ b/app/data/migrations/0009_auto_20160525_0320.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data', '0008_recordcostconfig'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='recordcostconfig',
+            name='id',
+        ),
+        migrations.AddField(
+            model_name='recordcostconfig',
+            name='created',
+            field=models.DateTimeField(default=datetime.datetime(2016, 5, 24, 19, 20, 20, 589258, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='recordcostconfig',
+            name='modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 5, 24, 19, 20, 28, 596369, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='recordcostconfig',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True),
+        ),
+    ]

--- a/app/data/models.py
+++ b/app/data/models.py
@@ -1,9 +1,10 @@
 import uuid
 
 from django.db import models
+from django.contrib.postgres.fields import HStoreField
 from django.contrib.auth.models import User
 
-from ashlar.models import AshlarModel, Record
+from ashlar.models import AshlarModel, Record, RecordType
 
 
 class RecordAuditLogEntry(models.Model):
@@ -78,3 +79,29 @@ class RecordDuplicate(AshlarModel):
     score = models.FloatField(default=0)
     resolved = models.BooleanField(default=False)
     job = models.ForeignKey(DedupeJob)
+
+
+class RecordCostConfig(AshlarModel):
+    """Store a configuration for calculating costs of incidents.
+
+    This takes the form of a reference to an enum field on a RecordType, along with user-
+    configurable mapping of societal costs for each possible value of that enum.
+    """
+    #: The record type whose records should be cost-aggregated
+    # This will likely need to be set automatically by the front-end
+    record_type = models.ForeignKey(RecordType)
+
+    #: Key of the schema property to access (Related Content Type, e.g.'accidentDetails')
+    # This will also likely need to be set automatically by the front-end, or at least filtered so
+    # that users cannot select content types which allow multiple entries
+    content_type_key = models.TextField()
+
+    #: Key of the content type property to access (e.g. 'Severity')
+    # This will need to be filtered on the front-end to enums which use select dropdowns (not
+    # checkbox).
+    property_key = models.TextField()
+
+    #: Mappings between enumerations and cost values (e.g. {'Fatal': 1000000,
+    #                                                       'Serious injury': 50000, ...})
+    # This should be auto-populated by the front-end once a property_key is selected.
+    enum_costs = HStoreField()

--- a/app/data/serializers.py
+++ b/app/data/serializers.py
@@ -7,7 +7,7 @@ from rest_framework.serializers import ModelSerializer, SerializerMethodField, V
 from ashlar import serializers
 from ashlar import serializer_fields
 
-from models import RecordAuditLogEntry, RecordDuplicate
+from models import RecordAuditLogEntry, RecordDuplicate, RecordCostConfig
 
 from django.conf import settings
 
@@ -66,3 +66,8 @@ class RecordDuplicateSerializer(ModelSerializer):
 
     class Meta:
         model = RecordDuplicate
+
+
+class RecordCostConfigSerializer(ModelSerializer):
+    class Meta:
+        model = RecordCostConfig

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -49,10 +49,10 @@ from driver_auth.permissions import (IsAdminOrReadOnly,
 from data.tasks import export_csv
 
 import filters
-from models import RecordAuditLogEntry, RecordDuplicate
+from models import RecordAuditLogEntry, RecordDuplicate, RecordCostConfig
 from serializers import (DriverRecordSerializer, DetailsReadOnlyRecordSerializer,
                          DetailsReadOnlyRecordSchemaSerializer, RecordAuditLogEntrySerializer,
-                         RecordDuplicateSerializer)
+                         RecordDuplicateSerializer, RecordCostConfigSerializer)
 import transformers
 from driver import mixins
 
@@ -738,6 +738,11 @@ class DriverRecordDuplicateViewSet(viewsets.ModelViewSet):
             resolved_ids = [str(uuid) for uuid in resolved_dup_qs.values_list('pk', flat=True)]
             resolved_dup_qs.update(resolved=True)
         return Response({'resolved': resolved_ids})
+
+
+class DriverRecordCostConfigViewSet(viewsets.ModelViewSet):
+    queryset = RecordCostConfig.objects.all()
+    serializer_class = RecordCostConfigSerializer
 
 
 class RecordCsvExportViewSet(viewsets.ViewSet):

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.admin',
     'django.contrib.gis',
+    'django.contrib.postgres',
     'corsheaders',
     'rest_framework',
     'rest_framework.authtoken',

--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -21,6 +21,7 @@ router.register('jars', data_views.AndroidSchemaModelsViewSet, base_name='jars')
 router.register('records', data_views.DriverRecordViewSet)
 router.register('recordschemas', data_views.DriverRecordSchemaViewSet)
 router.register('recordtypes', data_views.DriverRecordTypeViewSet)
+router.register('recordcosts', data_views.DriverRecordCostConfigViewSet)
 router.register('duplicates', data_views.DriverRecordDuplicateViewSet)
 router.register('userfilters', filt_views.SavedFilterViewSet, base_name='userfilters')
 


### PR DESCRIPTION
Creates a RecordCostConfig model which can be used for storing a configuration that allows calculating the social cost of records. This should be ready to merge on its own, but I'm going to hold off until I've started writing some of the aggregation endpoint, which is the other half of this on the backend. If that requires major surgery to this model then I may supersede this PR.

I also noticed that the BlackSpotConfig class didn't inherit from AshlarModel, so I fixed that as well so that it's more consistent with the rest of the API.

This can be tested by navigating to `/api/recordcosts/` and interacting with the API. The browsable API doesn't handle the HStore field correctly unless you use the raw data entry field to put in JSON manually, unfortunately.