### PR TITLE
Add an endpoint to perform record cost aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Both Angular apps can be run in development mode via:
 The frontend app will be available on port 7002 and the schema editor will be available on port
 7001. Both will reload automatically as changes are made.
 
+To make requests to a Django runserver directly (for example, to perform interactive debugging in
+the request-response cycle), run `./scripts/manage.sh runserver 0.0.0.0:8000`. You should then be
+able to access the Django runserver on port 3001 of the `app` VM.
+
 #### Updating existing translation files
 New angular translation tokens should be added to i18n/exclaim.json with a value of "!<english>".
 The English translation (en-us.json) is automatically built from exclaim.json. New tokens are also

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,6 +96,8 @@ Vagrant.configure("2") do |config|
     app.vm.network "forwarded_port", guest: 80, host: Integer(ENV.fetch("DRIVER_WEB_PORT_80", 7000))
     # Runserver
     app.vm.network "forwarded_port", guest: 4000, host: Integer(ENV.fetch("DRIVER_DJANGO_PORT_3000", 3000))
+    # Runserver interactive
+    app.vm.network "forwarded_port", guest: 8000, host: Integer(ENV.fetch("DRIVER_DJANGO_PORT_8000", 3001))
     # Grunt serve - schema editor
     app.vm.network "forwarded_port", guest: 9000, host: Integer(ENV.fetch("DRIVER_GRUNT_PORT_7001", 7001))
     # Grunt serve - web app

--- a/app/Dockerfile.development
+++ b/app/Dockerfile.development
@@ -1,5 +1,6 @@
 FROM quay.io/azavea/driver-app:latest
 
 RUN pip install --no-cache-dir --process-dependency-links --allow-external djsonb -r dev-requirements.txt --src /opt
+EXPOSE 8000
 
 CMD ["driver.wsgi", "-w1", "-b:4000", "--reload", "-kgevent"]

--- a/app/black_spots/migrations/0007_auto_20160525_0320.py
+++ b/app/black_spots/migrations/0007_auto_20160525_0320.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('black_spots', '0006_auto_20160525_0111'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='blackspotconfig',
+            name='id',
+        ),
+        migrations.AddField(
+            model_name='blackspotconfig',
+            name='created',
+            field=models.DateTimeField(default=datetime.datetime(2016, 5, 24, 19, 19, 56, 339703, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='blackspotconfig',
+            name='modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 5, 24, 19, 20, 3, 683051, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='blackspotconfig',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True),
+        ),
+    ]

--- a/app/black_spots/models.py
+++ b/app/black_spots/models.py
@@ -39,7 +39,7 @@ class BlackSpotSet(AshlarModel):
     record_type = models.ForeignKey('ashlar.RecordType')
 
 
-class BlackSpotConfig(models.Model):
+class BlackSpotConfig(AshlarModel):
     """Holds user-configurable settings for how black spot generation should work"""
     #: Blackspot severity percentile cutoff; segments with forecast severity above this threshold
     #: will be considered blackspots.

--- a/app/data/migrations/0007_auto_20160525_0156.py
+++ b/app/data/migrations/0007_auto_20160525_0156.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.contrib.postgres.operations import HStoreExtension
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data', '0006_dedupejob_celery_task'),
+    ]
+
+    operations = [
+        HStoreExtension()
+    ]

--- a/app/data/migrations/0008_recordcostconfig.py
+++ b/app/data/migrations/0008_recordcostconfig.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.contrib.postgres.fields.hstore
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ashlar', '0022_record_archived'),
+        ('data', '0007_auto_20160525_0156'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RecordCostConfig',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('content_type_key', models.TextField()),
+                ('property_key', models.TextField()),
+                ('enum_costs', django.contrib.postgres.fields.hstore.HStoreField()),
+                ('record_type', models.ForeignKey(to='ashlar.RecordType')),
+            ],
+        ),
+    ]

--- a/app/data/migrations/0009_auto_20160525_0320.py
+++ b/app/data/migrations/0009_auto_20160525_0320.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data', '0008_recordcostconfig'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='recordcostconfig',
+            name='id',
+        ),
+        migrations.AddField(
+            model_name='recordcostconfig',
+            name='created',
+            field=models.DateTimeField(default=datetime.datetime(2016, 5, 24, 19, 20, 20, 589258, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='recordcostconfig',
+            name='modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 5, 24, 19, 20, 28, 596369, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='recordcostconfig',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True),
+        ),
+    ]

--- a/app/data/models.py
+++ b/app/data/models.py
@@ -100,6 +100,11 @@ class RecordCostConfig(AshlarModel):
     # This will need to be filtered on the front-end to enums.
     property_key = models.TextField()
 
+    @property
+    def path(self):
+        """Gets the field path specified by this object within a schema"""
+        return [self.content_type_key, 'properties', self.property_key]
+
     #: Mappings between enumerations and cost values (e.g. {'Fatal': 1000000,
     #                                                       'Serious injury': 50000, ...})
     # This should be auto-populated by the front-end once a property_key is selected.

--- a/app/data/models.py
+++ b/app/data/models.py
@@ -97,8 +97,7 @@ class RecordCostConfig(AshlarModel):
     content_type_key = models.TextField()
 
     #: Key of the content type property to access (e.g. 'Severity')
-    # This will need to be filtered on the front-end to enums which use select dropdowns (not
-    # checkbox).
+    # This will need to be filtered on the front-end to enums.
     property_key = models.TextField()
 
     #: Mappings between enumerations and cost values (e.g. {'Fatal': 1000000,

--- a/app/data/models.py
+++ b/app/data/models.py
@@ -1,9 +1,10 @@
 import uuid
 
 from django.db import models
+from django.contrib.postgres.fields import HStoreField
 from django.contrib.auth.models import User
 
-from ashlar.models import AshlarModel, Record
+from ashlar.models import AshlarModel, Record, RecordType
 
 
 class RecordAuditLogEntry(models.Model):
@@ -78,3 +79,29 @@ class RecordDuplicate(AshlarModel):
     score = models.FloatField(default=0)
     resolved = models.BooleanField(default=False)
     job = models.ForeignKey(DedupeJob)
+
+
+class RecordCostConfig(AshlarModel):
+    """Store a configuration for calculating costs of incidents.
+
+    This takes the form of a reference to an enum field on a RecordType, along with user-
+    configurable mapping of societal costs for each possible value of that enum.
+    """
+    #: The record type whose records should be cost-aggregated
+    # This will likely need to be set automatically by the front-end
+    record_type = models.ForeignKey(RecordType)
+
+    #: Key of the schema property to access (Related Content Type, e.g.'accidentDetails')
+    # This will also likely need to be set automatically by the front-end, or at least filtered so
+    # that users cannot select content types which allow multiple entries
+    content_type_key = models.TextField()
+
+    #: Key of the content type property to access (e.g. 'Severity')
+    # This will need to be filtered on the front-end to enums which use select dropdowns (not
+    # checkbox).
+    property_key = models.TextField()
+
+    #: Mappings between enumerations and cost values (e.g. {'Fatal': 1000000,
+    #                                                       'Serious injury': 50000, ...})
+    # This should be auto-populated by the front-end once a property_key is selected.
+    enum_costs = HStoreField()

--- a/app/data/serializers.py
+++ b/app/data/serializers.py
@@ -7,7 +7,7 @@ from rest_framework.serializers import ModelSerializer, SerializerMethodField, V
 from ashlar import serializers
 from ashlar import serializer_fields
 
-from models import RecordAuditLogEntry, RecordDuplicate
+from models import RecordAuditLogEntry, RecordDuplicate, RecordCostConfig
 
 from django.conf import settings
 
@@ -66,3 +66,8 @@ class RecordDuplicateSerializer(ModelSerializer):
 
     class Meta:
         model = RecordDuplicate
+
+
+class RecordCostConfigSerializer(ModelSerializer):
+    class Meta:
+        model = RecordCostConfig

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -20,6 +20,7 @@ from django.db.models import (Case,
                               UUIDField,
                               Value,
                               Count,
+                              Sum,
                               Q)
 from django_redis import get_redis_connection
 
@@ -33,7 +34,7 @@ from rest_framework import renderers, status
 
 from rest_framework_csv import renderers as csv_renderer
 
-from ashlar.models import RecordSchema, RecordType, Record, BoundaryPolygon, Boundary
+from ashlar.models import RecordSchema, RecordType, BoundaryPolygon, Boundary
 from ashlar.views import (BoundaryPolygonViewSet,
                           RecordViewSet,
                           RecordTypeViewSet,
@@ -224,6 +225,89 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
         return Response(counts)
 
     @list_route(methods=['get'])
+    def costs(self, request):
+        """Return the costs for a set of records of a certain type
+
+        This endpoint requires the record_type query parameter. All other query parameters will be
+        used to filter the queryset before calculating costs.
+
+        There must be a RecordCostConfig associated with the RecordType passed, otherwise a 404
+        will be returned. If there are multiple RecordCostConfigs associated with a RecordType, the
+        most recently created one will be used.
+
+        Uses the most recent schema for the RecordType; if this doesn't match the fields in the
+        RecordCostConfig associated with the RecordType, an exception may be raised.
+
+        Returns a response of the form:
+        {
+            total: X,
+            subtotals: {
+                enum_choice1: A,
+                enum_choice2: B,
+                ...
+            }
+        }
+        """
+        record_type_id = request.query_params.get('record_type', None)
+        if not record_type_id:
+            raise ParseError(detail="The 'record_type' parameter is required")
+        cost_config = (RecordCostConfig.objects.filter(record_type_id=record_type_id)
+                       .order_by('-created').first())
+        if not cost_config:
+            return Response({'record_type': 'No cost configuration found for this record type.'},
+                            status_code=status.HTTP_404_NOT_FOUND)
+        schema = RecordType.objects.get(pk=record_type_id).get_current_schema()
+        path = [cost_config.content_type_key, 'properties', cost_config.property_key]
+        choices = self._get_schema_enum_choices(schema, path)
+        # `choices` may include user-entered data; to prevent users from entering column names
+        # that conflict with existing Record fields, we're going to use each choice's index as an
+        # alias instead.
+        choice_indices = {str(idx): choice for idx, choice in enumerate(choices)}
+        counts_queryset = self.get_filtered_queryset(request)
+        for idx, choice in choice_indices.items():
+            filter_rule = self.make_djsonb_containment_filter(path, choice)
+            # We want a column for each enum choice with a binary 1/0 indication of whether the row
+            # in question has that enum choice. This is to support checkbox fields which can have
+            # more than one selection from the enum per field. Then we're going to sum those to get
+            # aggregate counts for each enum choice.
+            choice_case = Case(When(data__jsonb=filter_rule, then=Value(1)), default=Value(0),
+                               output_field=IntegerField())
+            annotate_params = dict()
+            annotate_params[idx] = choice_case
+            counts_queryset = counts_queryset.annotate(**annotate_params)
+
+        # Do the summation
+        sum_ops = [Sum(key) for key in choice_indices.keys()]
+        sum_qs = counts_queryset.values(*choice_indices.keys()).aggregate(*sum_ops)
+        # sum_qs will now look something like this: {'0__sum': 20, '1__sum': 45, ...}
+        # so now we need to slot in the corresponding label from `choices` by pulling the
+        # corresponding value out of choices_indices.
+        sums = {}
+        for key, choice_sum in sum_qs.items():
+            index = key.split('_')[0]
+            choice = choice_indices[index]
+            sums[choice] = choice_sum
+        # Multiply sums by per-incident costs to get subtotal costs broken out by type
+        subtotals = dict()
+        # This is going to be extremely easy for users to break if they update a schema without
+        # updating the corresponding cost configuration; if things are out of sync, degrade
+        # gracefully by providing zeroes for keys that don't match and set a flag so that the
+        # front-end can alert users if needed.
+        found_missing_choices = False
+        for key, value in sums.items():
+            try:
+                subtotals[key] = value * int(cost_config.enum_costs[key])
+            except KeyError:
+                logger.warn('Schema and RecordCostConfig out of sync; %s missing from cost config',
+                            key)
+                found_missing_choices = True
+                subtotals[key] = 0
+        total = sum(subtotals.values())
+        # Return breakdown costs and sum
+        return Response({'total': total, 'subtotals': subtotals,
+                         'outdated_cost_config': found_missing_choices})
+
+    @list_route(methods=['get'])
     def crosstabs(self, request):
         """Returns a columnar aggregation of event totals; this is essentially a generalized ToDDoW
 
@@ -408,7 +492,7 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
                 'lookup': lambda x: {'occurred_from__week_day': x},
                 'label': lambda x: [
                     {
-                        'text': 'DAY.{}'.format(calendar.day_name[x-1].upper()),
+                        'text': 'DAY.{}'.format(calendar.day_name[x - 1].upper()),
                         'translate': True
                     }
                 ]
@@ -588,6 +672,26 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             (Case, labels), where Case is a Django Case object with the choice of each record,
             and labels is a dict matching choices to their labels (currently the same).
         """
+        choices = self._get_schema_enum_choices(schema, path)
+        whens = []
+        for choice in choices:
+            filter_rule = self.make_djsonb_containment_filter(path, choice)
+            whens.append(When(data__jsonb=filter_rule, then=Value(choice)))
+        labels = [
+            {'key': choice, 'label': [{'text': choice, 'translate': False}]}
+            for choice in choices
+        ]
+        return (Case(*whens, output_field=CharField()), labels)
+
+    def _get_schema_enum_choices(self, schema, path):
+        """Returns the choices in a schema enum field at path
+
+        Args:
+            schema (RecordSchema): A RecordSchema to get properties from
+            path (list): A list of path fragments to navigate to the desired property
+        Returns:
+            choices, where choices is a list of strings representing the valid values of the enum.
+        """
         # Walk down the schema using the path components
         obj = schema.schema['definitions']  # 'definitions' is the root of all schema paths
         try:
@@ -600,26 +704,30 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
         choices = obj.get('enum', None)
         if not choices:
             raise ParseError(detail="The property at choices_path is missing required 'enum' field")
+        return choices
+
+    def make_djsonb_containment_filter(self, path, value):
+        """Returns a djsonb containment filter for a path to contain a value
+
+        Args:
+            path (list): A list of strings denoting the path
+            value (String): The value to match on
+        Returns:
+            A dict representing a valid djsonb containment filter specification that matches if the
+            field at path contains value
+        """
         # Build the djsonb filter specification from the inside out, and skip schema-only keys, i.e.
         # 'properties' and 'items'.
         filter_path = [component for component in reversed(path)
                        if component not in ['properties', 'items']]
-        whens = []
-        for choice in choices:
-            filter_rule = dict(_rule_type='containment', contains=[choice])
-            for component in filter_path:
-                # Nest filter inside itself so we eventually get something like:
-                # {"incidentDetails": {"severity": {"_rule_type": "containment"}}}
-                tmp = dict()
-                tmp[component] = filter_rule
-                filter_rule = tmp
-            whens.append(When(data__jsonb=filter_rule, then=Value(choice)))
-        labels = [
-            {'key': choice, 'label': [{'text': choice, 'translate': False}]}
-            for choice in choices
-        ]
-
-        return (Case(*whens, output_field=CharField()), labels)
+        filter_rule = dict(_rule_type='containment', contains=[value])
+        for component in filter_path:
+            # Nest filter inside itself so we eventually get something like:
+            # {"incidentDetails": {"severity": {"_rule_type": "containment"}}}
+            tmp = dict()
+            tmp[component] = filter_rule
+            filter_rule = tmp
+        return filter_rule
 
 
 class DriverRecordAuditLogViewSet(viewsets.ModelViewSet):

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -49,10 +49,10 @@ from driver_auth.permissions import (IsAdminOrReadOnly,
 from data.tasks import export_csv
 
 import filters
-from models import RecordAuditLogEntry, RecordDuplicate
+from models import RecordAuditLogEntry, RecordDuplicate, RecordCostConfig
 from serializers import (DriverRecordSerializer, DetailsReadOnlyRecordSerializer,
                          DetailsReadOnlyRecordSchemaSerializer, RecordAuditLogEntrySerializer,
-                         RecordDuplicateSerializer)
+                         RecordDuplicateSerializer, RecordCostConfigSerializer)
 import transformers
 from driver import mixins
 
@@ -738,6 +738,11 @@ class DriverRecordDuplicateViewSet(viewsets.ModelViewSet):
             resolved_ids = [str(uuid) for uuid in resolved_dup_qs.values_list('pk', flat=True)]
             resolved_dup_qs.update(resolved=True)
         return Response({'resolved': resolved_ids})
+
+
+class DriverRecordCostConfigViewSet(viewsets.ModelViewSet):
+    queryset = RecordCostConfig.objects.all()
+    serializer_class = RecordCostConfigSerializer
 
 
 class RecordCsvExportViewSet(viewsets.ViewSet):

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.admin',
     'django.contrib.gis',
+    'django.contrib.postgres',
     'corsheaders',
     'rest_framework',
     'rest_framework.authtoken',

--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -21,6 +21,7 @@ router.register('jars', data_views.AndroidSchemaModelsViewSet, base_name='jars')
 router.register('records', data_views.DriverRecordViewSet)
 router.register('recordschemas', data_views.DriverRecordSchemaViewSet)
 router.register('recordtypes', data_views.DriverRecordTypeViewSet)
+router.register('recordcosts', data_views.DriverRecordCostConfigViewSet)
 router.register('duplicates', data_views.DriverRecordDuplicateViewSet)
 router.register('userfilters', filt_views.SavedFilterViewSet, base_name='userfilters')
 

--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -23,6 +23,9 @@ end script
 exec /usr/bin/docker run \
   --name driver-app \
   --publish 4000:4000 \
+  {% if 'development' in group_names -%}
+  --publish 8000:8000 \
+  {% endif %}
   --volume {{ root_static_dir }}:{{ root_static_dir }} \
   --volume {{ root_media_dir }}:{{ root_media_dir }} \
   {% if 'development' in group_names -%}


### PR DESCRIPTION
This supersedes #550.

Changes:
- Add a `RecordCostConfig` Django model for configuring how the cost of `Records` should be calculated, as well as API endpoints for interacting with RecordCostConfigs. The API endpoints perform validation to ensure that the `RecordCostConfig` is valid at the time it is generated, although it may become outdated if the schema is modified later.
- Make it easier to launch an interactive Django `runserver` session, e.g. if you need to interactively debug views.
- Add a new endpoint, `/api/records/costs` for aggregating the social cost of records.

Testing:
1. Checkout and run migrations
2. Use the API to construct a new RecordCostConfig linked with the active RecordType for your app. The request will need to look something like the following, although it needs to match the active schema, so this may not be exactly accurate: 
```json
{
    "content_type_key": "accidentDetails",
    "property_key": "Severity",
    "enum_costs": {
        "Fatal": "13",
         "Injury": "7",
         "Property": "3"
     },
    "record_type": "75903939-0ab0-4de8-9e21-dc92631975d5"
}
```
3. <-- actually 3. Visit `/api/records/costs/`. As with other endpoints on the `/records/` ViewSet, you can specify filter parameters to reduce the scope of the events that are returned. The `record_type` parameter is required, however, and must match the `record_type` parameter used when creating the RecordCostConfig in step 2. A full URL might be `http://localhost:7000/api/records/costs/?archived=False&details_only=True&jsonb=%7B%22accidentDetails%22:%7B%22Num+driver+casualties%22:%7B%22_rule_type%22:%22intrange%22,%22min%22:null,%22max%22:null%7D%7D%7D&limit=50&occurred_max=2016-10-15T15:59:59.000Z&occurred_min=2015-09-30T16:00:00.000Z&record_type=75903939-0ab0-4de8-9e21-dc92631975d5`. You should received a response that looks something like:
```json
{
    "total": 171,
    "outdated_cost_config": false,
    "subtotals": {
        "Fatal": 0,
        "Injury": 63,
        "Property": 108
    }
}
```