### PR TITLE
Allow unicode in CSV filenames

### DIFF
--- a/app/data/views.py
+++ b/app/data/views.py
@@ -761,10 +761,10 @@ class RecordCsvExportViewSet(viewsets.ViewSet):
             # TODO: This won't work with multiple celery workers
             # TODO: We should add a cleanup task to prevent result files from accumulating
             # on the celery worker.
-            uri = '{scheme}://{host}{prefix}{file}'.format(scheme=request.scheme,
+            uri = u'{scheme}://{host}{prefix}{file}'.format(scheme=request.scheme,
                                                            host=request.get_host(),
                                                            prefix=settings.CELERY_DOWNLOAD_PREFIX,
-                                                           file=str(job_result.get()))
+                                                           file=job_result.get())
             return Response({'status': job_result.state, 'result': uri})
         return Response({'status': job_result.state, 'info': job_result.info})
 


### PR DESCRIPTION
Fixes #552 

This fixes the name of the exported CSV to allow unicode characters and the download is able to complete successfully. However, the names of the files within the zipfile and the columns in those zipfiles are still have some encoding problems, so Arabic characters won't be displayed properly. I'll open another issue to address that.

Going to merge this to be able to deploy and fix the CSV download error.