### PR TITLE
Add date translation service and translations

### DIFF
--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -174,6 +174,7 @@
 
     <script src="scripts/localization/module.js"></script>
     <script src="scripts/localization/local-date-time.js"></script>
+    <script src="scripts/localization/date-utils.js"></script>
 
     <script src="scripts/details/module.js"></script>
     <script src="scripts/details/details-field-controller.js"></script>

--- a/web/app/scripts/details/details-constants-partial.html
+++ b/web/app/scripts/details/details-constants-partial.html
@@ -3,9 +3,9 @@
         {{ 'RECORD.OCCURRED' | translate }}
     </label>
     <div class="value constant date occurred">
-        {{ ::ctl.record.occurred_from | localDateTime : ctl.dateFormat }}
+        {{ ::ctl.record.occurred_from | localizeRecordDate: 'long':'time'}}
         <span ng-if="::ctl.record.isSecondary && ctl.record.occurred_to">
-         - {{ ::ctl.record.occurred_to | localDateTime : ctl.dateFormat }}
+         - {{ ::ctl.record.occurred_to | localizeRecordDate: 'long':'time'}}
         </span>
     </div>
 </div>
@@ -14,7 +14,7 @@
         {{ 'RECORD.CREATED' | translate }}
     </label>
     <div class="value constant date created">
-        {{ ::ctl.record.created | localDateTime: ctl.dateFormat }}
+        {{ ::ctl.record.created | localizeRecordDate: 'long':'time'}}
     </div>
 </div>
 <div class="col-sm-12">

--- a/web/app/scripts/localization/date-utils.js
+++ b/web/app/scripts/localization/date-utils.js
@@ -1,0 +1,106 @@
+(function() {
+    'use strict';
+
+    /* ngInject */
+    function DateUtils(LanguageState, WebConfig) {
+        /* jshint quotmark: false */
+        var languageMap = {
+            'ar-sa': {
+                language: 'ar',
+                calendar: 'ummalqura',
+                formats: {
+                    'short': 'M Y',
+                    'longNoTime': 'd MM, Y',
+                    'long': 'd MM, Y',
+                    'numeric': 'dd/mm/yyyy'
+                }
+            },
+            'en-us': {
+                language: 'en',
+                calendar: 'gregorian',
+                formats: {
+                    'short': 'M Y',
+                    'long': 'MM d, Y',
+                    'numeric': 'mm/dd/yyyy'
+                }
+            },
+            'exclaim': {
+                language: 'en',
+                calendar: 'gregorian',
+                formats: {
+                    'short': "'!'M Y",
+                    'longNoTime': "'!'MM d, Y",
+                    'long': "'!'MM d,Y",
+                    'numeric': "'!'mm/dd/yyyy"
+                }
+            }
+        };
+        /* jshint quotmark: single */
+
+        var module = {
+            getLocalizedDateString: getLocalizedDateString
+        };
+        return module;
+
+        /*
+         * Get a localized date string for a date, using the LanguageState to
+         * choose the correct language. LanguageState is set using the language
+         * selector in the navbar
+         *
+         * Args:
+         *     date (Date): the date to process
+         *     format (string): which string format to process the date into.
+         *                      Formats are defined per language in the languageMap
+         *     includeTime (string): Include the time in the returned string
+         */
+        function getLocalizedDateString(date, format, includeTime) {
+            var localizedDate = moment(date).tz(WebConfig.localization.timeZone).toDate();
+            if (isNaN(localizedDate.getDate())) {
+                return '';
+            }
+            var selected = LanguageState.getSelected();
+            var language = selected.id;
+            if (!language) {
+                language = 'exclaim';
+            }
+            var isRtl = selected.rtl;
+            var conversion = languageMap[language];
+            var convertedDate = $.calendars.instance(conversion.calendar, conversion.language)
+                .fromJSDate(localizedDate);
+            var datestring = convertedDate.formatDate(conversion.formats[format], convertedDate);
+            if (includeTime) {
+                var minutes = localizedDate.getMinutes() + '';
+                if (minutes.length < 2) {
+                    minutes = '0' + minutes;
+                }
+                var hours = localizedDate.getHours() + '';
+                if (hours.length < 2) {
+                    hours = '0' + hours;
+                }
+                var seconds = localizedDate.getSeconds() + '';
+                if (seconds.length < 2) {
+                    seconds = '0' + seconds;
+                }
+                if (isRtl) {
+                    datestring = hours + ':' + minutes + ':' + seconds + ' - ' + datestring;
+                } else {
+                    datestring = datestring + ' - ' + hours + ':' + minutes + ':' + seconds;
+                }
+            }
+            return datestring;
+        }
+    }
+
+    /* ngInject */
+    function LocalizeDateFilter(DateUtils) {
+        function module(d, format, includeTime) {
+            return DateUtils.getLocalizedDateString(new Date(Date.parse(d)), format, includeTime === 'time');
+        }
+        return module;
+    }
+
+
+    angular.module('driver.localization')
+        .factory('DateUtils', DateUtils)
+        .filter('localizeRecordDate', LocalizeDateFilter);
+})();

--- a/web/app/scripts/stepwise/module.js
+++ b/web/app/scripts/stepwise/module.js
@@ -7,6 +7,7 @@
 
     angular.module('driver.stepwise', [
         'driver.state',
+        'driver.localization',
         'ui.router',
         'ui.bootstrap'
     ]).config(DirectiveConfig);

--- a/web/app/scripts/stepwise/stepwise-directive.js
+++ b/web/app/scripts/stepwise/stepwise-directive.js
@@ -8,7 +8,7 @@
     'use strict';
 
     /* ngInject */
-    function Stepwise($translate, $window, LanguageState) {
+    function Stepwise($translate, $window, LanguageState, DateUtils) {
         var module = {
             restrict: 'E',
             scope: {
@@ -132,7 +132,9 @@
                 function createXAxis(tScale) {
                     var xAxis = d3.svg.axis()
                         .scale(tScale)
-                        .tickFormat(d3.time.format('%b %y'))
+                        .tickFormat(function(d) {
+                            return DateUtils.getLocalizedDateString(d, 'short');
+                        })
                         .ticks(5)
                         .tickSize(1)
                         .orient('bottom');
@@ -215,7 +217,7 @@
                         return '<strong>' +
                             $translate.instant('RECORD.WEEK_OF') +
                             ': </strong>' +
-                            d.dt.toLocaleDateString() +
+                            DateUtils.getLocalizedDateString(d.dt, 'long') +
                             '</br><strong>' +
                             $translate.instant('RECORD.EVENT_COUNT') +
                             ':</strong> <span>' +

--- a/web/app/scripts/views/duplicates/duplicates-list-partial.html
+++ b/web/app/scripts/views/duplicates/duplicates-list-partial.html
@@ -16,7 +16,7 @@
                 <tbody>
                     <tr ng-repeat="dup in ctl.duplicates.results">
                         <td ng-repeat-start="record in [dup.record, dup.duplicate_record]" class="date">
-                            {{ ::record.occurred_to | localDateTime }}
+                            {{ ::record.occurred_to | localizeRecordDate: 'numeric':'time' }}
                         </td>
                         <td ng-repeat-end class="detail">
                             {{ ::record.location_text }}

--- a/web/app/scripts/views/duplicates/module.js
+++ b/web/app/scripts/views/duplicates/module.js
@@ -15,6 +15,7 @@
         'ngSanitize',
         'ase.auth',
         'driver.config',
+        'driver.localization',
         'driver.resources',
         'driver.state',
         'ui.bootstrap',

--- a/web/app/scripts/views/record/list-partial.html
+++ b/web/app/scripts/views/record/list-partial.html
@@ -20,7 +20,7 @@
                     </div>
                     <tr ng-if="!ctl.loadingRecords" ng-repeat="record in ctl.records.results">
                         <td class="date">
-                            {{ ::record.occurred_to | localDateTime }}
+                            {{ ::record.occurred_to | localizeRecordDate: 'numeric':'time' }}
                         </td>
                         <td class="detail" ng-repeat="headerKey in ctl.headerKeys | limitTo : ctl.maxDataColumns">
                             <driver-details-field


### PR DESCRIPTION
Add translations for stepwise graph
Add date translations to list and detail views

Service contains translations for en-us, ar-sa, and exclaim (any unknown language will show en-us dates with an exclaim in front)