### PR TITLE
Fix directory used for writing black spot output

### DIFF
--- a/app/black_spots/tasks/calculate_black_spots.py
+++ b/app/black_spots/tasks/calculate_black_spots.py
@@ -69,7 +69,7 @@ def calculate_black_spots(history_length=datetime.timedelta(days=5 * 365 + 1), r
 
     # - Run Rscript to output CSV
     segments_csv = BlackSpotTrainingCsv.objects.get(pk=blackspots_output).csv.path
-    forecasts_csv = forecast_segment_incidents(segments_csv, '/opt/app/forecasts.csv')
+    forecasts_csv = forecast_segment_incidents(segments_csv, '/var/www/media/forecasts.csv')
     # - Load blackspot geoms from shapefile and CSV
     # The shapefile is stored as a gzipped tarfile so we need to extract it
     tar_output_dir = tempfile.mkdtemp()

--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -15,7 +15,7 @@ pre-start script
   /usr/bin/docker kill driver-app || true
   /usr/bin/docker rm driver-app || true
 
-  {% if 'staging' in group_names -%}
+  {% if 'development' not in group_names -%}
   /usr/bin/docker pull quay.io/azavea/driver-app:latest
   {% endif %}
 end script

--- a/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
+++ b/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
@@ -15,7 +15,7 @@ pre-start script
   /usr/bin/docker kill driver-celery || true
   /usr/bin/docker rm driver-celery || true
 
-  {% if 'staging' in group_names -%}
+  {% if 'development' not in group_names -%}
   /usr/bin/docker pull quay.io/azavea/driver-app:latest
   {% endif %}
 end script

--- a/deployment/ansible/roles/driver.gradle/templates/upstart-gradle.conf.j2
+++ b/deployment/ansible/roles/driver.gradle/templates/upstart-gradle.conf.j2
@@ -15,7 +15,7 @@ pre-start script
   /usr/bin/docker kill driver-gradle || true
   /usr/bin/docker rm driver-gradle || true
 
-  {% if 'staging' in group_names -%}
+  {% if 'development' not in group_names -%}
   /usr/bin/docker pull quay.io/azavea/driver-gradle:latest
   {% endif %}
 end script

--- a/deployment/ansible/roles/driver.windshaft/templates/upstart-windshaft.conf.j2
+++ b/deployment/ansible/roles/driver.windshaft/templates/upstart-windshaft.conf.j2
@@ -15,7 +15,7 @@ pre-start script
   /usr/bin/docker kill windshaft || true
   /usr/bin/docker rm windshaft || true
 
-  {% if 'staging' in group_names -%}
+  {% if 'development' not in group_names -%}
   /usr/bin/docker pull quay.io/azavea/windshaft:0.1.0
   {% endif %}
 end script


### PR DESCRIPTION
The shared directory being used to communicate the R output back
to the celery task (/opt/app) was only valid while in development.
In order to work in staging/production this has been switched to
the media directory, which is available in both development and
staging/production, and is actually where all the other batch
output files were already being written.

Going to merge this in so I can test black spots in production.
