### PR TITLE
Add function to add property order before saving

### DIFF
--- a/schema_editor/app/scripts/views/recordtype/related-add-directive.js
+++ b/schema_editor/app/scripts/views/recordtype/related-add-directive.js
@@ -19,6 +19,28 @@
             });
         }
 
+        /**
+         * Updates related definitions to include a property order attribute
+         * @param {object} definitions to check for propertyOrder attribute
+         */
+        function addPropertyOrdertoDefinitions(definitions) {
+            var currentPropertyOrder = 0;
+            _.mapValues(definitions, function(definition) {
+                var propertyOrder = definition.propertyOrder;
+                if (propertyOrder && propertyOrder > currentPropertyOrder) {
+                    currentPropertyOrder = propertyOrder;
+                }
+            });
+
+            _.forEach(definitions, function(definition) {
+                if (!definition.propertyOrder && definition.propertyOrder !== 0) {
+                    $log.debug('Adding property order for ' + definition.title);
+                    currentPropertyOrder = currentPropertyOrder + 1;
+                    definition.propertyOrder = currentPropertyOrder;
+                }
+            });
+        }
+
         function submitForm() {
             var key = Schemas.generateFieldName(ctl.definition.title);
             if (ctl.currentSchema.schema.definitions[key]) {
@@ -51,6 +73,8 @@
             ctl.currentSchema.schema.properties[key].options = {
                 collapsed: true
             };
+
+            addPropertyOrdertoDefinitions(ctl.currentSchema.schema.definitions);
 
             RecordSchemas.create({
                 /* jshint camelcase:false */

--- a/scripts/incident_schema_v3.json
+++ b/scripts/incident_schema_v3.json
@@ -12,6 +12,7 @@
                 "Picture"
             ],
             "plural_title": "Photos",
+            "propertyOrder": 3,
             "definitions": {},
             "type": "object",
             "properties": {
@@ -48,6 +49,7 @@
                 "_localId"
             ],
             "plural_title": "Vehicles",
+            "propertyOrder": 1,
             "definitions": {},
             "type": "object",
             "properties": {
@@ -362,6 +364,7 @@
                 "_localId"
             ],
             "plural_title": "People",
+            "propertyOrder": 2,
             "definitions": {},
             "type": "object",
             "properties": {


### PR DESCRIPTION
Closes #573

Adds property order to related schema definitions before saving to any
related definitions that do not have one.

Also adds property order to the development schema.

## Testing
Add a new related schema to incidents in the editor. After saving, look at the schema returned from the API and the related schema definitions should now all have `propertyOrder` defined.