### PR TITLE
Only convert key to camelCase

### DIFF
--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -131,21 +131,20 @@
         return module;
 
         /**
-         * Convert field titles into field names that are intially lower case,
-         * camel cased (no spaces), and escaped for use in URIs.
+         * Convert field titles into field names that are intially lower case and
+         * camel cased (no spaces)
          *
          * @param {string} "Example Field Name"
          * @return {string} "exampleFieldName"
          */
         function generateFieldName(str) {
-            // based on:
             // http://stackoverflow.com/questions/2970525/converting-any-string-into-camel-case
-            return encodeURIComponent(str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
+            return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
                 if (+match === 0) {
                     return '';
                 }
                 return index === 0 ? match.toLowerCase() : match.toUpperCase();
-            }));
+            });
         }
 
         /**

--- a/schema_editor/app/scripts/views/recordtype/add-controller.js
+++ b/schema_editor/app/scripts/views/recordtype/add-controller.js
@@ -41,7 +41,7 @@
             var key = Schemas.generateFieldName(definition.title);
             schema.definitions[key] = definition;
             schema.properties[key] = {
-                $ref: '#/definitions/' + key,
+                $ref: '#/definitions/' + encodeURIComponent(key),
 
                 // Set the collapsed option of the details option to true so it starts collapsed
                 options: {

--- a/schema_editor/app/scripts/views/recordtype/related-add-directive.js
+++ b/schema_editor/app/scripts/views/recordtype/related-add-directive.js
@@ -29,7 +29,7 @@
             ctl.currentSchema.schema.definitions[key] = ctl.definition;
 
             // Use an array or object depending on the 'multiple' setting
-            var ref = '#/definitions/' + key;
+            var ref = '#/definitions/' + encodeURIComponent(key);
             if (ctl.definition.multiple) {
                 ctl.currentSchema.schema.properties[key] = {
                     type: 'array',


### PR DESCRIPTION
Closes #570

This commit switches the behavior of the `generateFieldName` function
slightly by only removing whitespace and converting to camelCase (except
for unicode). When the key/name is used in a URI path it is still
encoded properly.

## Testing

Add a new record type or related record type where the title is unicode. After generation, the field property name should not be encoded, but its URI component should be.

See screenshot for an example with `доллар`

![encoding](https://cloud.githubusercontent.com/assets/898060/16159166/2772d742-348f-11e6-9dac-77443cd0ddb7.png)
