### PR TITLE
Fix color alignment in incident record detail

### DIFF
--- a/web/app/scripts/details/details-text-controller.js
+++ b/web/app/scripts/details/details-text-controller.js
@@ -2,9 +2,22 @@
     'use strict';
 
     /* ngInject */
-    function DetailsTextController() {
+    function DetailsTextController($rootScope) {
         var ctl = this;
         ctl.maxLength = 20;
+
+        ctl.xShift = function() {
+            /**
+             * Magic numbers:
+             * 300 - 125 is svg-width - compact width
+             * 300 - 200 is svg.width - !compact width
+             */
+            if ($rootScope.isRightToLeft) {
+                return ctl.compact ? 300 - 125 : 300 - 200;
+            } else {
+                return 0;
+            }
+        };
     }
 
     angular.module('driver.details')

--- a/web/app/scripts/details/details-text-partial.html
+++ b/web/app/scripts/details/details-text-partial.html
@@ -6,7 +6,8 @@
     <div ng-switch on="ctl.property.format">
         <div ng-switch-when="color" class="value color">
             <svg>
-                <rect class="rectangle" rx="20" ry="20" style="fill:{{ ::ctl.data }};" />
+                <rect class="rectangle" rx="20" ry="20" style="fill:{{ ::ctl.data }};"
+                ng-attr-x="{{ ctl.xShift() }}"/>
             </svg>
         </div>
 


### PR DESCRIPTION
Right-to-left successfully flips all the text on the page,
but SVG coordinates are still in right-to-left, so vehicle color
rectangles wound up left-aligned in their enclosing SVGs, which was
way out of place.

This fix conditions a shift to the rectangles' x attributes that
conditions on right-to-left-ness and the size of the rectangle to
appropriately right-align the SVG elements.