### PR TITLE
Add basic firewall rules

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -90,3 +90,9 @@ monit_allow_hosts: []
 monit_allow_user: 'test'
 monit_allow_password: 'test'
 monit_enable_web_access: yes
+
+## IP addresses used to configure the firewall
+ip_addresses_app:
+    - 192.168.12.102
+ip_addresses_celery:
+    - 192.168.12.103

--- a/deployment/ansible/group_vars/staging
+++ b/deployment/ansible/group_vars/staging
@@ -45,3 +45,9 @@ local_center_lat_lon: [12.375, 121.5]
 
 ## Django allowed hosts setting. Overridden since staging runs in non-DEBUG mode.
 allowed_host: 'prs.azavea.com'
+
+## IP addresses used to configure the firewall
+ip_addresses_app:
+    - "{{ hostvars['app']['ansible_ec2_local_ipv4'] }}"
+ip_addresses_celery:
+    - "{{ hostvars['celery']['ansible_ec2_local_ipv4'] }}"

--- a/deployment/ansible/roles/driver.app/tasks/firewall.yml
+++ b/deployment/ansible/roles/driver.app/tasks/firewall.yml
@@ -1,0 +1,39 @@
+---
+- name: Enable firewall
+  ufw: state=enabled policy=reject
+
+- name: Allow ssh access
+  ufw: rule=allow port=22
+
+- name: Allow monit access
+  ufw: rule=allow port=2812
+
+- name: Allow http access
+  ufw: rule=allow port=80
+
+- name: Allow https access
+  ufw: rule=allow port=443
+
+- name: Allow Runserver access
+  ufw: rule=allow port=4000
+  when: developing
+
+- name: Allow Runserver interactive access
+  ufw: rule=allow port=8000
+  when: developing
+
+- name: Allow Grunt serve - schema editor access
+  ufw: rule=allow port=9000
+  when: developing
+
+- name: Allow Grunt serve - web app access
+  ufw: rule=allow port=9001
+  when: developing
+
+- name: Allow Livereload - editor access
+  ufw: rule=allow port=35731
+  when: developing
+
+- name: Allow Livereload - web access
+  ufw: rule=allow port=35732
+  when: developing

--- a/deployment/ansible/roles/driver.app/tasks/main.yml
+++ b/deployment/ansible/roles/driver.app/tasks/main.yml
@@ -56,3 +56,5 @@
   command: >
     /usr/bin/docker exec -i driver-app ./manage.py migrate
   when: developing_or_staging
+
+- { include: firewall.yml }

--- a/deployment/ansible/roles/driver.celery/tasks/firewall.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/firewall.yml
@@ -1,0 +1,17 @@
+---
+- name: Enable firewall
+  ufw: state=enabled policy=reject
+
+- name: Allow ssh access
+  ufw: rule=allow port=22
+
+- name: Allow monit access
+  ufw: rule=allow port=2812
+
+- name: Allow http connections from app machines (e.g. for CSV downloads)
+  ufw: rule=allow port=80 from_ip={{ item }}
+  with_items: "{{ ip_addresses_app }}"
+
+- name: Allow https connections from app machines (e.g. for CSV downloads)
+  ufw: rule=allow port=443 from_ip={{ item }}
+  with_items: "{{ ip_addresses_app }}"

--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -65,3 +65,5 @@
         job="docker exec $(docker ps -q -f name=driver-celery) ./manage.py remove_old_exports
         >> {{ driver_cron_log_dir }}/remove_old_exports.log 2>&1"
         minute=10
+
+- { include: firewall.yml }

--- a/deployment/ansible/roles/driver.database/tasks/firewall.yml
+++ b/deployment/ansible/roles/driver.database/tasks/firewall.yml
@@ -1,0 +1,25 @@
+---
+- name: Enable firewall
+  ufw: state=enabled policy=reject
+
+- name: Allow ssh access
+  ufw: rule=allow port=22
+
+- name: Allow monit access
+  ufw: rule=allow port=2812
+
+- name: Allow PostgreSQL connections from app machines
+  ufw: rule=allow port={{ postgresql_port }} from_ip={{ item }}
+  with_items: "{{ ip_addresses_app }}"
+
+- name: Allow PostgreSQL connections from celery machines
+  ufw: rule=allow port={{ postgresql_port }} from_ip={{ item }}
+  with_items: "{{ ip_addresses_celery }}"
+
+- name: Allow redis connections from app machines
+  ufw: rule=allow port={{ redis_port }} from_ip={{ item }}
+  with_items: "{{ ip_addresses_app }}"
+
+- name: Allow redis connections from celery machines
+  ufw: rule=allow port={{ redis_port }} from_ip={{ item }}
+  with_items: "{{ ip_addresses_celery }}"

--- a/deployment/ansible/roles/driver.database/tasks/main.yml
+++ b/deployment/ansible/roles/driver.database/tasks/main.yml
@@ -45,3 +45,5 @@
   template: src=monit-postgresql.cfg.j2 dest=/etc/monit/conf.d/postgresql.cfg
   notify:
     - Restart monit
+
+- { include: firewall.yml }


### PR DESCRIPTION
This commit restricts inbound connections to only the ports
(and where applicable, IPs) that are needed. Here are some details:
 * App -- http[s] is allowed, as are development ports when in develop mode
 * Celery -- http[s] is allowed only from App servers (e.g. for CSV downloads).
 * DB -- PostgreSQL and redis connections are allowed from App and Celery servers.
 * SSH is allowed
 * Everything else is blocked

There is room for improvement if we want to also restrict outbound access,
but this should be a good start.