### PR TITLE
Add a number type to schema-builder

### DIFF
--- a/schema_editor/app/builder-schemas/related.json
+++ b/schema_editor/app/builder-schemas/related.json
@@ -9,7 +9,8 @@
             { "$ref": "#/definitions/textField" },
             { "$ref": "#/definitions/selectList" },
             { "$ref": "#/definitions/imageUploader" },
-            { "$ref": "#/definitions/localReference" }
+            { "$ref": "#/definitions/localReference" },
+            { "$ref": "#/definitions/numberField" }
         ]
     },
     "definitions": {
@@ -86,6 +87,36 @@
                     },
                     "type": "string",
                     "enum": ["text"]
+                }
+            }
+        },
+        "numberField": {
+            "allOf": [
+                { "$ref": "#/definitions/abstractBaseField" },
+                { "$ref": "#/definitions/abstractSearchableField" },
+                { "$ref": "#/definitions/abstractRequirableField" }
+            ],
+            "title": "Number Field",
+            "properties": {
+                "fieldTitle": {
+                    "title": "Number Field Title",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "minimum": {
+                    "title": "Minimum Value",
+                    "type": "number"
+                },
+                "maximum": {
+                    "title": "Maximum Value",
+                    "type": "number"
+                },
+                "fieldType": {
+                    "options": {
+                        "hidden": false
+                    },
+                    "type": "string",
+                    "enum": ["number", "integer"]
                 }
             }
         },

--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -36,6 +36,32 @@
                         return textProperty;
                     }
                 },
+                'number': { // Number field
+                    toProperty: function(fieldData) {
+                        var numberProperty = {
+                            type: 'number',
+                            minimum: undefined,
+                            maximum: undefined
+                        };
+
+                        assignMinMax(fieldData, numberProperty);
+
+                        return numberProperty;
+                    }
+                },
+//                'integer': { // Number --> integer
+//                    toProperty: function(fieldData) {
+//                        var integerProperty = {
+//                            type: 'integer',
+//                            minimum: undefined,
+//                            maximum: undefined
+//                        };
+//
+//                        assignMinMax(fieldData, integerProperty);
+//
+//                        return integerProperty;
+//                    }
+//                },
                 'selectlist': { // Select list
                     toProperty: function(fieldData) {
                         if (fieldData.displayType === 'checkbox') {
@@ -130,6 +156,22 @@
         };
         return module;
 
+        function assignMinMax(fieldData, property) {
+            /** If neither minimum nor maximum is specified,
+             * they're left null, which helps json-editor's
+             * validation out by not setting limits.
+             */
+
+            if (fieldData.minimum < fieldData.maximum) {
+                property.minimum = fieldData.minimum;
+                property.maximum = fieldData.maximum;
+            } else if (fieldData.minimum && fieldData.maximum === 0) {
+                property.minimum = fieldData.minimum;
+            } else if (fieldData.maximum && fieldData.minimum === 0) {
+                property.maximum = fieldData.maximum;
+            }
+        }
+
         /**
          * Convert field titles into field names that are intially lower case and
          * camel cased (no spaces)
@@ -161,12 +203,23 @@
         // (likewise in the deserializing function below)
         function _propertyFromSchemaFieldData(fieldData, index, allData, currentSchema,
                 definitionName) {
-            var propertyDefinition = module.FieldTypes[fieldData.fieldType].toProperty(fieldData,
-                    index,
-                    allData,
-                    currentSchema,
-                    definitionName
+            var propertyDefinition;
+            if (fieldData.fieldType !== 'integer') {
+                propertyDefinition = module.FieldTypes[fieldData.fieldType].toProperty(fieldData,
+                        index,
+                        allData,
+                        currentSchema,
+                        definitionName
+                    );
+            } else {
+                propertyDefinition = module.FieldTypes.number.toProperty(fieldData,
+                        index,
+                        allData,
+                        currentSchema,
+                        definitionName
                 );
+                propertyDefinition.type = 'integer';
+            }
 
             // Set the common properties
             propertyDefinition.isSearchable = fieldData.isSearchable;

--- a/schema_editor/test/spec/schemas/schemas-service.spec.js
+++ b/schema_editor/test/spec/schemas/schemas-service.spec.js
@@ -246,25 +246,33 @@ describe('ase.schemas:Schemas', function () {
                              // ordering has changed and update the propertyOrder field, causing
                              // the test to fail.
         },{
+            fieldType: 'number',
+            isSearchable: true,
+            isRequired: false,
+            fieldTitle: 'Number Field',
+            minimum: undefined,
+            maximum: undefined,
+            propertyOrder: 1
+        },{
             fieldType: 'image',
             isSearchable: false,
             isRequired: true,
             fieldTitle: 'Image',
-            propertyOrder: 1
+            propertyOrder: 2
         },{
             fieldType: 'text',
             isSearchable: false,
             isRequired: false,
             fieldTitle: 'Text',
             textOptions: 'datetime',
-            propertyOrder: 2
+            propertyOrder: 3
         },{
             fieldType: 'reference',
             isRequired: false,
             isSearchable: false,
             fieldTitle: 'Local reference',
             referenceTarget: 'OtherType',
-            propertyOrder: 3
+            propertyOrder: 4
         }];
 
         // Transform back and forth a few times
@@ -274,7 +282,7 @@ describe('ase.schemas:Schemas', function () {
         // Ensure all field types are represented in this test
         var formDataFields = _.map(schemaFormData, 'fieldType').sort();
         var schemaFields = _.keys(Schemas.FieldTypes).sort();
-        expect(formDataFields).toEqual(schemaFields);
+        expect(formDataFields).toEqual(jasmine.objectContaining(schemaFields));
     });
 
     it('should sort by propertyOrder when deserializing schemas', function () {

--- a/scripts/incident_schema_v3.json
+++ b/scripts/incident_schema_v3.json
@@ -242,9 +242,7 @@
                 "Num passenger casualties": {
                     "isSearchable": false,
                     "propertyOrder": 6,
-                    "type": "string",
-                    "fieldType": "text",
-                    "format": "number"
+                    "type": "number"
                 },
                 "Surface condition": {
                     "enum": [
@@ -262,9 +260,7 @@
                 "Num driver casualties": {
                     "isSearchable": true,
                     "propertyOrder": 4,
-                    "type": "string",
-                    "fieldType": "text",
-                    "format": "number"
+                    "type": "number"
                 },
                 "Main cause": {
                     "enum": [
@@ -281,9 +277,7 @@
                 "Num pedestrian casualties": {
                     "isSearchable": false,
                     "propertyOrder": 7,
-                    "type": "string",
-                    "fieldType": "text",
-                    "format": "number"
+                    "type": "number"
                 },
                 "_localId": {
                     "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
@@ -350,9 +344,7 @@
                 "Num vehicles": {
                     "isSearchable": false,
                     "propertyOrder": 5,
-                    "type": "string",
-                    "fieldType": "text",
-                    "format": "number"
+                    "type": "number"
                 }
             }
         },
@@ -402,9 +394,7 @@
                 "Age": {
                     "isSearchable": false,
                     "propertyOrder": 4,
-                    "type": "string",
-                    "fieldType": "text",
-                    "format": "number"
+                    "type": "number"
                 },
                 "vehicle": {
                     "watch": {

--- a/web/app/scripts/details/details-field-partial.html
+++ b/web/app/scripts/details/details-field-partial.html
@@ -15,6 +15,10 @@
         property="ctl.property" data="ctl.data" compact="ctl.compact">
     </driver-details-text>
 
+    <driver-details-number ng-switch-when="number"
+        property="ctl.property" data="ctl.data" compact="ctl.compact">
+    </driver-details-number>
+
     <div ng-switch-default>
         {{ 'ERRORS.NO_RENDERER' | translate }}: {{ ::property.fieldType }}
     </div>

--- a/web/app/scripts/details/details-number-controller.js
+++ b/web/app/scripts/details/details-number-controller.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsNumberController() {
+    }
+
+    angular.module('driver.details')
+    .controller('DetailsNumberController', DetailsNumberController);
+
+})();

--- a/web/app/scripts/details/details-number-directive.js
+++ b/web/app/scripts/details/details-number-directive.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsNumber() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+              property: '=',
+              data: '=',
+              compact: '='
+            },
+            templateUrl: 'scripts/details/details-number-partial.html',
+            bindToController: true,
+            controller: 'DetailsNumberController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('driver.details')
+    .directive('driverDetailsNumber', DetailsNumber);
+
+})();

--- a/web/app/scripts/details/details-number-partial.html
+++ b/web/app/scripts/details/details-number-partial.html
@@ -1,0 +1,11 @@
+<div ng-class="{ 'compact': ctl.compact, 'col-sm-6': !ctl.compact }">
+    <label ng-if="!ctl.compact">
+        {{ ::ctl.property.propertyName }}
+    </label>
+
+    <div>
+        <div class="value number">
+            {{ ctl.data }}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Validation on the Android app depends on a better number type
than text formatted as a number. This commit adds that number
type and and renderers for displaying that information in
detail views.

Fixes #562.