### PR TITLE
Ensure that fieldnames are valid java identifiers

### DIFF
--- a/schema_editor/app/scripts/schemas/schemas-service.js
+++ b/schema_editor/app/scripts/schemas/schemas-service.js
@@ -131,15 +131,21 @@
         return module;
 
         /**
-         * Convert field titles into field names that are intially lower case and
-         * camel cased (no spaces)
+         * Convert field titles into field names that are valid java identifiers
+         * by doing the following:
+         *
+         *  - strip out control characters
+         *  - prepend name with driver to ensure whitelisted words are excluded
+         *  - convert to camel case
          *
          * @param {string} "Example Field Name"
-         * @return {string} "exampleFieldName"
+         * @return {string} "driverExampleFieldName_udb234"
          */
         function generateFieldName(str) {
+            // Remove control characters with regular expression
+            var strippedStr = 'driver ' + str.replace(/[\x00-\x1F\x7F-\x9F]/g, '');
             // http://stackoverflow.com/questions/2970525/converting-any-string-into-camel-case
-            return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
+            return strippedStr.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
                 if (+match === 0) {
                     return '';
                 }

--- a/schema_editor/app/scripts/views/recordtype/related-add-directive.js
+++ b/schema_editor/app/scripts/views/recordtype/related-add-directive.js
@@ -34,7 +34,6 @@
 
             _.forEach(definitions, function(definition) {
                 if (!definition.propertyOrder && definition.propertyOrder !== 0) {
-                    $log.debug('Adding property order for ' + definition.title);
                     currentPropertyOrder = currentPropertyOrder + 1;
                     definition.propertyOrder = currentPropertyOrder;
                 }

--- a/schema_editor/test/spec/views/recordtype/add-controller.spec.js
+++ b/schema_editor/test/spec/views/recordtype/add-controller.spec.js
@@ -48,15 +48,15 @@ describe('ase.views.recordtype: AddController', function () {
                 plural_title: '',
                 description: '',
                 properties: {
-                    'incidentDetails': {
-                        $ref: '#/definitions/incidentDetails',
+                    'driverIncidentDetails': {
+                        $ref: '#/definitions/driverIncidentDetails',
                         options: {
                             collapsed: true
                         }
                     }
                 },
                 definitions: {
-                    'incidentDetails': {
+                    'driverIncidentDetails': {
                         type: 'object',
                         title: 'Incident Details',
                         plural_title: 'Incident Details',

--- a/scripts/incident_schema_v3.json
+++ b/scripts/incident_schema_v3.json
@@ -3,7 +3,7 @@
     "title": "",
     "plural_title": "",
     "definitions": {
-        "photo": {
+        "driverPhoto": {
             "multiple": true,
             "description": "Pictures of the incident",
             "title": "Photo",
@@ -41,7 +41,7 @@
                 }
             }
         },
-        "vehicle": {
+        "driverVehicle": {
             "multiple": true,
             "description": "A vehicle involved in the incident",
             "title": "Vehicle",
@@ -202,7 +202,7 @@
                 }
             }
         },
-        "incidentDetails": {
+        "driverIncidentDetails": {
             "multiple": false,
             "description": "Details for Incident",
             "title": "Incident Details",
@@ -356,7 +356,7 @@
                 }
             }
         },
-        "person": {
+        "driverPerson": {
             "multiple": true,
             "description": "A person involved in the incident",
             "title": "Person",
@@ -508,9 +508,9 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {
-        "photo": {
+        "driverPhoto": {
             "items": {
-                "$ref": "#/definitions/photo"
+                "$ref": "#/definitions/driverPhoto"
             },
             "type": "array",
             "options": {
@@ -518,9 +518,9 @@
             },
             "propertyOrder": 3
         },
-        "vehicle": {
+        "driverVehicle": {
             "items": {
-                "$ref": "#/definitions/vehicle"
+                "$ref": "#/definitions/driverVehicle"
             },
             "type": "array",
             "options": {
@@ -528,16 +528,16 @@
             },
             "propertyOrder": 1
         },
-        "incidentDetails": {
+        "driverIncidentDetails": {
             "propertyOrder": 0,
             "options": {
                 "collapsed": true
             },
-            "$ref": "#/definitions/incidentDetails"
+            "$ref": "#/definitions/driverIncidentDetails"
         },
-        "person": {
+        "driverPerson": {
             "items": {
-                "$ref": "#/definitions/person"
+                "$ref": "#/definitions/driverPerson"
             },
             "type": "array",
             "options": {


### PR DESCRIPTION
Closes #575 

This commit changes the field name generation to strip any control
characters and prevent the use of reserved words in generated field
names.

Rather than use a complicated regular expression that would be difficult
to match unicode characters with, field name generation now strips out
non-ascii characters, prepends 'driver' to the field name, then appends
an '_<random string>' to generated identifiers.

![valid-identifiers](https://cloud.githubusercontent.com/assets/898060/16381501/ea9e0c74-3c4a-11e6-95e4-85c0b53eeaf6.png)
