### PR TITLE
Tweak styling for enforcer assignments

### DIFF
--- a/app/black_spots/models.py
+++ b/app/black_spots/models.py
@@ -24,6 +24,18 @@ class BlackSpot(AshlarModel):
     #: The set of black spots this belongs to
     black_spot_set = models.ForeignKey('BlackSpotSet')
 
+    #: The latitude of the black spot's centroid
+    @property
+    def latitude(self):
+        """Gets the latitude of the black spot's centroid"""
+        return self.geom.centroid.y
+
+    #: The longitude of the black spot's centroid
+    @property
+    def longitude(self):
+        """Gets the longitude of the black spot's centroid"""
+        return self.geom.centroid.x
+
 
 class BlackSpotSet(AshlarModel):
     """A grouping of black spots generated at one time"""

--- a/app/black_spots/serializers.py
+++ b/app/black_spots/serializers.py
@@ -31,6 +31,7 @@ class EnforcerAssignmentSerializer(ModelSerializer):
     """Serializer for enforcer assignments"""
     class Meta:
         model = BlackSpot
+        fields = ('black_spot_set', 'geom', 'latitude', 'longitude', 'severity_score',)
         read_only_fields = ('uuid',)
 
 class EnforcerAssignmentInputSerializer():

--- a/web/app/i18n/ar-sa.json
+++ b/web/app/i18n/ar-sa.json
@@ -74,6 +74,20 @@
         "SATURDAY": "السبت",
         "SUNDAY": "الأحد"
     },
+    "ENFORCERS": {
+        "ASSIGNMENT": "!Assignment",
+        "ASSIGNMENTS": "!Assignments",
+        "ASSIGNMENTS_TITLE": "!Traffic Enforcement Assignments",
+        "BOUNDARY_NOTICE": "!To select a different boundary, cancel and make adjustments on the map page",
+        "CUSTOM_BOUNDARY": "!Hand-drawn polygon filter will be applied",
+        "FORECAST_SEVERITY": "!Forecast occurrences",
+        "NUM_PERSONNEL": "!Number of personnel",
+        "PRINT": "!Print",
+        "SELECTED_BOUNDARY": "!Selected boundary",
+        "SHIFT_END": "!Shift end",
+        "SHIFT_LENGTH_ERROR": "!Shift cannot be more than 24 hours long",
+        "SHIFT_START": "!Shift start"
+    },
     "ERRORS": {
         "CREATING_RECORD": "خطأ أثناء إنشاء السجل",
         "END_BEFORE_START": "تاريخ النهاية لا يمكن أن يكون قبل تاريخ البداية",
@@ -200,19 +214,6 @@
         "ORGANIZE_ROWS": "تنظيم التقرير أفقي",
         "PAGES": "صفحات",
         "TITLE": "تقرير مخصص"
-    },
-    "ENFORCERS": {
-        "ASSIGNMENTS_TITLE": "!Traffic Enforcement Assignments",
-        "ASSIGNMENT": "!Assignment",
-        "ASSIGNMENTS": "!Assignments",
-        "FORECAST_SEVERITY": "!Forecast occurrences",
-        "SHIFT_LENGTH_ERROR": "!Shift cannot be more than 24 hours long",
-        "SELECTED_BOUNDARY": "!Selected boundary",
-        "BOUNDARY_NOTICE": "!To select a different boundary, cancel and make adjustments on the map page",
-        "SHIFT_START": "!Shift start",
-        "SHIFT_END": "!Shift end",
-        "NUM_PERSONNEL": "!Number of personnel",
-        "CUSTOM_BOUNDARY": "!Hand-drawn polygon filter will be applied"
     },
     "SAVED_FILTERS": {
         "ADD_NEW": "أضف تصنيف محفوظ جديد",

--- a/web/app/i18n/en-us.json
+++ b/web/app/i18n/en-us.json
@@ -54,7 +54,6 @@
         "SOCIAL_COSTS_TEXT": "Total economic loss and societal harm",
         "SOCIAL_COSTS_90DAYS": "Last 90 days",
         "SOCIAL_COSTS_CONFIG_WARN": "Cost calculation may be misconfigured. Please notify your administrator.",
-        "RECENT_PROPORTIONS_TEXT": "of all traffic incidents involved",
         "STEPWISE_TITLE": "Weekly Counts: Last 90 Days",
         "TODDOW_TITLE": "Time of Day, Day of Week: Last 90 Days",
         "VIEW_ALL": "View all"
@@ -74,6 +73,20 @@
         "FRIDAY": "Friday",
         "SATURDAY": "Saturday",
         "SUNDAY": "Sunday"
+    },
+    "ENFORCERS": {
+        "ASSIGNMENT": "Assignment",
+        "ASSIGNMENTS": "Assignments",
+        "ASSIGNMENTS_TITLE": "Traffic Enforcement Assignments",
+        "BOUNDARY_NOTICE": "To select a different boundary, make adjustments on the map page",
+        "CUSTOM_BOUNDARY": "Hand-drawn polygon filter will be applied",
+        "FORECAST_SEVERITY": "Forecast occurrences",
+        "NUM_PERSONNEL": "Number of personnel",
+        "PRINT": "Print",
+        "SELECTED_BOUNDARY": "Selected boundary",
+        "SHIFT_END": "Shift end",
+        "SHIFT_LENGTH_ERROR": "Shift cannot be more than 24 hours long",
+        "SHIFT_START": "Shift start"
     },
     "ERRORS": {
         "CREATING_RECORD": "Error creating record",
@@ -201,19 +214,6 @@
         "ORGANIZE_ROWS": "Organize Report By (rows)",
         "PAGES": "pages",
         "TITLE": "Custom Report"
-    },
-    "ENFORCERS": {
-        "ASSIGNMENTS_TITLE": "Traffic Enforcement Assignments",
-        "ASSIGNMENT": "Assignment",
-        "ASSIGNMENTS": "Assignments",
-        "FORECAST_SEVERITY": "Forecast occurrences",
-        "SHIFT_LENGTH_ERROR": "Shift cannot be more than 24 hours long",
-        "SELECTED_BOUNDARY": "Selected boundary",
-        "BOUNDARY_NOTICE": "To select a different boundary, cancel and make adjustments on the map page",
-        "SHIFT_START": "Shift start",
-        "SHIFT_END": "Shift end",
-        "NUM_PERSONNEL": "Number of personnel",
-        "CUSTOM_BOUNDARY": "Hand-drawn polygon filter will be applied"
     },
     "SAVED_FILTERS": {
         "ADD_NEW": "Add New Saved Filter",

--- a/web/app/i18n/exclaim.json
+++ b/web/app/i18n/exclaim.json
@@ -74,6 +74,20 @@
         "SATURDAY": "!Saturday",
         "SUNDAY": "!Sunday"
     },
+    "ENFORCERS": {
+        "ASSIGNMENT": "!Assignment",
+        "ASSIGNMENTS": "!Assignments",
+        "ASSIGNMENTS_TITLE": "!Traffic Enforcement Assignments",
+        "BOUNDARY_NOTICE": "!To select a different boundary, make adjustments on the map page",
+        "CUSTOM_BOUNDARY": "!Hand-drawn polygon filter will be applied",
+        "FORECAST_SEVERITY": "!Forecast occurrences",
+        "NUM_PERSONNEL": "!Number of personnel",
+        "PRINT": "!Print",
+        "SELECTED_BOUNDARY": "!Selected boundary",
+        "SHIFT_END": "!Shift end",
+        "SHIFT_LENGTH_ERROR": "!Shift cannot be more than 24 hours long",
+        "SHIFT_START": "!Shift start"
+    },
     "ERRORS": {
         "CREATING_RECORD": "!Error creating record",
         "END_BEFORE_START": "!End date cannot be before start date.",
@@ -200,19 +214,6 @@
         "ORGANIZE_ROWS": "!Organize Report By (rows)",
         "PAGES": "!pages",
         "TITLE": "!Custom Report"
-    },
-    "ENFORCERS": {
-        "ASSIGNMENTS_TITLE": "!Traffic Enforcement Assignments",
-        "ASSIGNMENT": "!Assignment",
-        "ASSIGNMENTS": "!Assignments",
-        "FORECAST_SEVERITY": "!Forecast occurrences",
-        "SHIFT_LENGTH_ERROR": "!Shift cannot be more than 24 hours long",
-        "SELECTED_BOUNDARY": "!Selected boundary",
-        "BOUNDARY_NOTICE": "!To select a different boundary, cancel and make adjustments on the map page",
-        "SHIFT_START": "!Shift start",
-        "SHIFT_END": "!Shift end",
-        "NUM_PERSONNEL": "!Number of personnel",
-        "CUSTOM_BOUNDARY": "!Hand-drawn polygon filter will be applied"
     },
     "SAVED_FILTERS": {
         "ADD_NEW": "!Add New Saved Filter",

--- a/web/app/scripts/enforcers/enforcer-assignments-controller.js
+++ b/web/app/scripts/enforcers/enforcer-assignments-controller.js
@@ -6,8 +6,8 @@
      */
 
     /* ngInject */
-    function EnforcerAssignmentsController($state, $stateParams, $q, $translate, RecordState,
-                                           Assignments) {
+    function EnforcerAssignmentsController($state, $stateParams, $q, $translate, $window,
+                                           RecordState, Assignments) {
         var ctl = this;
 
         $translate.onReady(init);
@@ -16,6 +16,7 @@
             ctl.loading = true;
             ctl.params = $stateParams;
             ctl.dateFormat = 'long';
+            ctl.printPage = printPage;
 
             Assignments.query(ctl.params).$promise.then(function(assignments) {
                 ctl.assignments = assignments;
@@ -25,6 +26,10 @@
             }).finally(function () {
                 ctl.loading = false;
             });
+        }
+
+        function printPage() {
+            $window.print();
         }
     }
 

--- a/web/app/scripts/enforcers/enforcer-assignments-partial.html
+++ b/web/app/scripts/enforcers/enforcer-assignments-partial.html
@@ -1,22 +1,31 @@
 <cube-grid-spinner ng-if="ctl.loading"></cube-grid-spinner>
 <div class="enforcer-assignments print-view" ng-if="!ctl.loading">
   <div class="assignments-header">
-    <h2>{{ 'ENFORCERS.ASSIGNMENTS_TITLE' | translate }}</h2>
-    <h3 ng-if="!isRightToLeft">
-        <span>{{ ::ctl.params.shift_start | localizeRecordDate :ctl.dateFormat :'time' }}</span> &ndash;
-        <span>{{ ::ctl.params.shift_end | localizeRecordDate :ctl.dateFormat :'time' }}</span>
-    </h3>
-    <h3 ng-if="isRightToLeft">
-        <span>{{ ::ctl.params.shift_end | localizeRecordDate :ctl.dateFormat :'time' }}</span> &ndash;
-        <span>{{ ::ctl.params.shift_start | localizeRecordDate :ctl.dateFormat :'time' }}</span>
-    </h3>
+    <h2>
+      {{ 'ENFORCERS.ASSIGNMENTS_TITLE' | translate }}
+      <button ng-click="ctl.printPage()">
+        {{ 'ENFORCERS.PRINT' | translate }}
+      </button>
+    </h2>
   </div>
   <div ng-repeat="assignment in ctl.assignments" class="enforcer-assignment">
-    <h3>{{ 'ENFORCERS.ASSIGNMENT' | translate }} {{$index + 1}}</h3>
+    <div ng-if="$index % 3 === 0">
+      <h3 ng-if="!isRightToLeft">
+          <span>{{ ::ctl.params.shift_start | localizeRecordDate :ctl.dateFormat :'time' :'noseconds' }}</span> &ndash;
+          <span>{{ ::ctl.params.shift_end | localizeRecordDate :ctl.dateFormat :'time' :'noseconds' }}</span>
+      </h3>
+      <h3 ng-if="isRightToLeft">
+          <span>{{ ::ctl.params.shift_end | localizeRecordDate :ctl.dateFormat :'time' :'noseconds' }}</span> &ndash;
+          <span>{{ ::ctl.params.shift_start | localizeRecordDate :ctl.dateFormat :'time' :'noseconds' }}</span>
+      </h3>
+    </div>
     <div class="assignment-details">
-      <span class="forecast-severity">
-        {{ 'ENFORCERS.FORECAST_SEVERITY' | translate }}: {{ assignment.severity_score | number }}
-      </span>
+      <div>
+        {{ 'ENFORCERS.ASSIGNMENT' | translate }} {{$index + 1}}
+      </div>
+      <div class="latlon">
+        {{ assignment.latitude | number }}, {{ assignment.longitude | number }}
+      </div>
     </div>
     <div class="map assignment-map" leaflet-map assignment-map geom="assignment.geom.coordinates"></div>
   </div>

--- a/web/app/scripts/localization/date-utils.js
+++ b/web/app/scripts/localization/date-utils.js
@@ -74,8 +74,9 @@
          *     format (string): which string format to process the date into.
          *                      Formats are defined per language in the languageMap
          *     includeTime (string): Include the time in the returned string
+         *     excludeSeconds (string): Exclude seconds in the returned string
          */
-        function getLocalizedDateString(date, format, includeTime) {
+        function getLocalizedDateString(date, format, includeTime, excludeSeconds) {
             var localizedMoment = moment(date).tz(WebConfig.localization.timeZone);
             var localizedDate = new Date(localizedMoment.format('MMM DD YYYY'));
             if (isNaN(localizedDate.getDate())) {
@@ -92,7 +93,7 @@
                 .fromJSDate(localizedDate);
             var datestring = convertedDate.formatDate(conversion.formats[format], convertedDate);
             if (includeTime) {
-                var hms = localizedMoment.format('H:mm:ss');
+                var hms = localizedMoment.format(excludeSeconds ? 'H:mm' : 'H:mm:ss');
 
                 if (isRtl) {
                     datestring = hms + ', ' + datestring;
@@ -133,11 +134,12 @@
 
     /* ngInject */
     function LocalizeDateFilter(DateLocalization) {
-        function module(d, format, includeTime) {
+        function module(d, format, includeTime, excludeSeconds) {
             return DateLocalization.getLocalizedDateString(
                 new Date(Date.parse(d)),
                 format,
-                includeTime
+                includeTime,
+                excludeSeconds
             );
         }
         return module;

--- a/web/app/scripts/localization/datetime-picker-directive.js
+++ b/web/app/scripts/localization/datetime-picker-directive.js
@@ -24,10 +24,15 @@
         ctl.$onInit = initialize();
 
         function initialize() {
+            // We don't want minutes or seconds in the default datetime
+            var defaultDateTime = new Date();
+            defaultDateTime.setMinutes(0);
+            defaultDateTime.setSeconds(0);
+
             ctl.updateDate = updateDate;
             ctl.updateTime = updateTime;
-            ctl.date = new Date();
-            ctl.time = new Date();
+            ctl.date = defaultDateTime;
+            ctl.time = defaultDateTime;
             updateDateTime();
         }
 

--- a/web/app/styles/partials/_assignments-view.scss
+++ b/web/app/styles/partials/_assignments-view.scss
@@ -21,7 +21,6 @@
         margin-left: auto;
         margin-right: auto;
         margin-top: 50px;
-        width: 50%;
         .assignment-map {
             width: 500px;
             height: 500px;


### PR DESCRIPTION
Some small changes were made and items have been added to allow for
better styling by a designer. Changes include:
 * Added print button
 * Header displayed every 3 assignments (useful for printing)
 * Removed some of the text, such as forecast occurrences
 * Added lat/lon of assignment centroid
 * Don't show seconds
 * Default shift start/end minutes to zero