### PR TITLE
Add propertyOrder on properties field

### DIFF
--- a/schema_editor/app/scripts/views/recordtype/related-add-directive.js
+++ b/schema_editor/app/scripts/views/recordtype/related-add-directive.js
@@ -21,21 +21,21 @@
 
         /**
          * Updates related definitions to include a property order attribute
-         * @param {object} definitions to check for propertyOrder attribute
+         * @param {object} properties to update propertyOrder attribute
          */
-        function addPropertyOrdertoDefinitions(definitions) {
+        function addPropertyOrder(properties) {
             var currentPropertyOrder = 0;
-            _.mapValues(definitions, function(definition) {
-                var propertyOrder = definition.propertyOrder;
+            _.mapValues(properties, function(property) {
+                var propertyOrder = property.propertyOrder;
                 if (propertyOrder && propertyOrder > currentPropertyOrder) {
                     currentPropertyOrder = propertyOrder;
                 }
             });
 
-            _.forEach(definitions, function(definition) {
-                if (!definition.propertyOrder && definition.propertyOrder !== 0) {
+            _.forEach(properties, function(property) {
+                if (!property.propertyOrder && property.propertyOrder !== 0) {
                     currentPropertyOrder = currentPropertyOrder + 1;
-                    definition.propertyOrder = currentPropertyOrder;
+                    property.propertyOrder = currentPropertyOrder;
                 }
             });
         }
@@ -73,7 +73,7 @@
                 collapsed: true
             };
 
-            addPropertyOrdertoDefinitions(ctl.currentSchema.schema.definitions);
+            addPropertyOrder(ctl.currentSchema.schema.properties);
 
             RecordSchemas.create({
                 /* jshint camelcase:false */


### PR DESCRIPTION
Previously the `propertyOrder` was being added to `definitions`, but other parts
of the UI and the Android app assume that it is on `properties`, so this
moves it there.

This can be tested by adding a related content type in the Ashlar editor to any existing schema; after that, all of the `properties` on that schema will have a defined `propertyOrder`.

We will need to manually update the schema on the Saudi demo instance with their preferred ordering once this is deployed.