### PR TITLE
Remove invalid docker tag option to fix deployment

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -6,7 +6,7 @@ set -x
 for image in app editor web gradle analysis;
 do
   docker push "quay.io/azavea/driver-${image}:${TRAVIS_COMMIT:0:7}"
-  docker tag -f "quay.io/azavea/driver-${image}:${TRAVIS_COMMIT:0:7}" "quay.io/azavea/driver-${image}:latest"
+  docker tag "quay.io/azavea/driver-${image}:${TRAVIS_COMMIT:0:7}" "quay.io/azavea/driver-${image}:latest"
   docker push "quay.io/azavea/driver-${image}:latest"
 done
 


### PR DESCRIPTION
The `-f` option was marked as deprecated a while ago, but it appears
it's now officially phased out and will not run if specified.