### PR TITLE
Make permission groups configurable

### DIFF
--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -218,7 +218,11 @@ DEFAULT_ADMIN_EMAIL = os.environ.get("DRIVER_ADMIN_EMAIL", 'systems+driver@azave
 DEFAULT_ADMIN_USERNAME = os.environ.get("DRIVER_ADMIN_USERNAME", 'admin')
 DEFAULT_ADMIN_PASSWORD = os.environ.get("DRIVER_ADMIN_PASSWORD", 'admin')
 # the client keeps these group names in the editor's config.js
-DRIVER_GROUPS = {'READ_ONLY': 'public', 'READ_WRITE': 'analyst', 'ADMIN': 'admin'}
+DRIVER_GROUPS = {
+    'READ_ONLY': os.environ.get('DRIVER_READ_ONLY_GROUP', 'public'),
+    'READ_WRITE': os.environ.get('DRIVER_READ_WRITE_GROUP', 'analyst'),
+    'ADMIN': os.environ.get('DRIVER_ADMIN_GROUP', 'admin')
+}
 
 # Django Rest Framework
 # http://www.django-rest-framework.org/

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -96,3 +96,8 @@ ip_addresses_app:
     - 192.168.12.102
 ip_addresses_celery:
     - 192.168.12.103
+
+## Permission overrides
+driver_read_only_group: "public"
+driver_read_write_group: "analyst"
+driver_admin_group: "admin"

--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -36,6 +36,9 @@ exec /usr/bin/docker run \
   {% for k,v in driver_conf.items() -%}
   --env {{ k }}="{{ v }}" \
   {% endfor -%}
+  --env DRIVER_READ_ONLY_GROUP="{{ driver_read_only_group }}" \
+  --env DRIVER_READ_WRITE_GROUP="{{ driver_read_write_group }}" \
+  --env DRIVER_ADMIN_GROUP="{{ driver_admin_group }}" \
   --log-driver syslog \
 {% if celery %} --entrypoint '/bin/bash -c' \
 {% endif %}  quay.io/azavea/driver-app:latest {% if celery %} \

--- a/deployment/ansible/roles/driver.web/templates/editor-config-js.j2
+++ b/deployment/ansible/roles/driver.web/templates/editor-config-js.j2
@@ -20,9 +20,9 @@
             hostname: '{{ editor_js_api_hostname }}',
             // These group names are defined server-side in settings.py
             groups: {
-                admin: 'admin',
-                readOnly: 'public',
-                readWrite: 'analyst'
+                admin: '{{ driver_admin_group }}',
+                readOnly: '{{ driver_read_only_group }}',
+                readWrite: '{{ driver_read_write_group }}'
             }
         }
     };


### PR DESCRIPTION
# Testing
- Copy the additions to `group_vars/all.example` into your local `group_vars/all`, change the read-write permissions to `public` rather than `analyst`, and reprovision.
- Log in with a public user (create one first if necessary). Note that you should have the ability to add and edit records, and to view all fields of a record.
- Change the read-write permission back to `analyst`, reprovision, and confirm that the same user can no longer modify records.