### PR TITLE
Ensure that Windshaft respawns if no Redis

### DIFF
--- a/deployment/ansible/roles/driver.windshaft/templates/upstart-windshaft.conf.j2
+++ b/deployment/ansible/roles/driver.windshaft/templates/upstart-windshaft.conf.j2
@@ -34,6 +34,7 @@ exec /usr/bin/docker run \
   quay.io/azavea/windshaft:0.1.0 server.js
 
 post-stop script
-  /usr/bin/docker kill windshaft
+  /usr/bin/docker kill windshaft || true
   /usr/bin/docker rm windshaft
+  sleep 5
 end script


### PR DESCRIPTION
# Overview
Ensures that Windshaft will restart even if redis is not available for an extended period of time.

# Testing
- If you want to verify the previous behavior, it can be triggered by bringing up the `app` VM first without the database, and then bringing up the database, i.e. `vagrant up app` followed by `vagrant up database` rather than just `vagrant up`. The map tiles will never load, even after the `database` VM has been started.
- Update the Upstart init script for Windshaft, either by re-provisioning your `app` VM, or simply editing `/etc/init/windshaft.conf` to add the lines from this PR (probably faster).
- Run `vagrant up app`.
- Once the `app` VM is running, run `vagrant up database`. Once the `database` VM has started, verify that map tiles load.

# Notes
The fix here may be applicable to some of our other Upstart jobs as well, but given that we think there may be other problems with some of those jobs, such as gradle, I didn't want to complicate diagnosis of those problems by adding this everywhere. But we may need to add `|| true` to other `post-stop` scripts in order to get those jobs to respawn successfully.