### PR TITLE
Ensure that services restart after Docker

### DIFF
--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -1,6 +1,6 @@
 description "driver-app"
 
-start on (filesystem and started docker)
+start on started docker
 stop on stopping docker
 
 kill timeout 20

--- a/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
+++ b/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
@@ -1,6 +1,6 @@
 description "driver-celery"
 
-start on (filesystem and started docker)
+start on started docker
 stop on stopping docker
 
 kill timeout 20

--- a/deployment/ansible/roles/driver.gradle/templates/upstart-gradle.conf.j2
+++ b/deployment/ansible/roles/driver.gradle/templates/upstart-gradle.conf.j2
@@ -1,6 +1,6 @@
 description "driver-gradle"
 
-start on (filesystem and started docker)
+start on started docker
 stop on stopping docker
 
 kill timeout 20

--- a/deployment/ansible/roles/driver.windshaft/templates/upstart-windshaft.conf.j2
+++ b/deployment/ansible/roles/driver.windshaft/templates/upstart-windshaft.conf.j2
@@ -1,6 +1,6 @@
 description "windshaft"
 
-start on (filesystem and started docker)
+start on started docker
 stop on stopping docker
 
 kill timeout 20


### PR DESCRIPTION
The way we were doing this previously follows the example given in the Docker documentation, but Docker itself relies on the filesystem being started (`start on (filesystem and net-device-up IFACE!=lo)`), so there was no extra safety added by having these services rely on the filesystem too, and the extra condition was preventing them from re-starting if docker was restarted.

Aside from that, I wasn't able to trigger any problems by stopping and starting docker.

# Testing
- Reprovision
- `vagrant up`
- SSH into both the `app` and `celery` VMs and make sure that `initctl status <name>` returns `start/running` for all of `driver-app`, `windshaft`, `driver-gradle`, and `driver-celery`.
- Manually run `sudo initctl restart docker` (or `sudo initctl stop docker` followed by `sudo initctl start docker`) and confirm that the services come back up.
- Confirm that you can access the API after all this stopping / starting.