### PR TITLE
Bump letsencrypt role

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -101,3 +101,6 @@ ip_addresses_celery:
 driver_read_only_group: "public"
 driver_read_write_group: "analyst"
 driver_admin_group: "admin"
+
+## Reload the nginx config after an SSL certificate is renewed
+letsencrypt_post_renew_cmd: "service nginx reload"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -13,4 +13,4 @@
 - src: azavea.redis
   version: 0.1.0
 - src: azavea.letsencrypt
-  version: v11.2
+  version: v11.3


### PR DESCRIPTION
This allows restarting `nginx` after a renewal.

Trivial change, no formal testing necessary. Assigning for visibility.