### PR TITLE
Fix Vietnamese translation for "EMPTY"

### DIFF
--- a/web/app/i18n/vi.json
+++ b/web/app/i18n/vi.json
@@ -237,7 +237,7 @@
         "DAWN": "B\u00ecnh minh",
         "DAY": "Ng\u00e0y",
         "DUSK": "B\u1ee5i",
-        "EMPTY": null,
+        "EMPTY": " ",
         "FOG": "S\u01b0\u01a1ng m\u00f9",
         "HAIL": "M\u01b0a \u0111\u00e1",
         "NIGHT": "\u0110\u00eam quang m\u00e2y",


### PR DESCRIPTION
Trivial change. Having a null value for a translation was causing the rendering code to blow up and print a console error.