### PR TITLE
Update base Django container image

### DIFF
--- a/app/Dockerfile.base
+++ b/app/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/django:0.1.1
+FROM quay.io/azavea/django:1.8-python2.7-slim
 
 # N.B. This will not work for docker versions above 1.10.x; Docker 1.11 and above contain
 # multiple binaries in a tarball; if we upgrade Docker to the 1.11 branch or beyond then
@@ -8,7 +8,10 @@ ENV DOCKER_VERSION 1.10.3
 # install dependencies for django-oidc
 RUN apt-get update && apt-get install -y \
     libffi-dev \
-    python-dev
+    python-dev \
+    git \
+    libssl-dev \
+    build-essential
 
 # install dependencies for generate_training_input script
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Overview

This puts us on a more up-to-date version of Django and the operating system, and fixes an issue that was occurring with SSL handshakes during the SSO process (brought on by out-of-date libraries mixed with Google disabling SSLv3). 

## Testing

I've tested this locally by shelling into the container and issuing a `requests` `get` call against `https://accounts.google.com`. Before applying this fix, there was a `SSL3_GET_SERVER_CERTIFICATE` error. Afterwards, a `200` is returned. All pages on the app have been tested to ensure the updated Django version didn't break anything. @ddohler and I have gone through this testing in-person, so no further testing is needed here.

Merging this to test futher on a demo server.
