### PR TITLE
Display modified-by info in record details

### DIFF
--- a/web/app/i18n/ar-sa.json
+++ b/web/app/i18n/ar-sa.json
@@ -181,6 +181,8 @@
         "BUTTON_DELETE_ROW_TITLE": "!Delete \\{\\{0\\}\\}",
         "BUTTON_EXPAND": "!Expand",
         "CREATED": "أضاف",
+        "MODIFIED": "!Modified",
+        "MODIFIED_BY": "!Modified by",
         "DATE_AND_TIME": "اليوم والوقت",
         "DATE_FILTER": "تصنيف الأحداث حسب تاريخ القوع",
         "DETAILS": "تفاصيل",

--- a/web/app/i18n/bn.json
+++ b/web/app/i18n/bn.json
@@ -181,6 +181,8 @@
         "BUTTON_DELETE_ROW_TITLE": "মুছে ফেলুন \\{\\{0\\}\\}",
         "BUTTON_EXPAND": "বিস্তৃত করা",
         "CREATED": "তৈরী করা",
+        "MODIFIED": "!Modified",
+        "MODIFIED_BY": "!Modified by",
         "DATE_AND_TIME": "তারিখ ও সময়",
         "DATE_FILTER": "ঘটনার তারিখ অনুসারে ঘটনা ফিল্টার করুন",
         "DETAILS": "বিস্তারিত",

--- a/web/app/i18n/en-us.json
+++ b/web/app/i18n/en-us.json
@@ -181,6 +181,8 @@
         "BUTTON_DELETE_ROW_TITLE": "Delete \\{\\{0\\}\\}",
         "BUTTON_EXPAND": "Expand",
         "CREATED": "Created",
+        "MODIFIED": "Modified",
+        "MODIFIED_BY": "Modified by",
         "DATE_AND_TIME": "Date & Time",
         "DATE_FILTER": "Filter events by date of occurence",
         "DETAILS": "Details",

--- a/web/app/i18n/es.json
+++ b/web/app/i18n/es.json
@@ -182,6 +182,8 @@
         "BUTTON_DELETE_ROW_TITLE": "Borrar \\{\\{0\\}\\}",
         "BUTTON_EXPAND": "Expandir",
         "CREATED": "Creado",
+        "MODIFIED": "!Modified",
+        "MODIFIED_BY": "!Modified by",
         "DATE_AND_TIME": "Fecha y hora",
         "DATE_FILTER": "Filtrar eventos por fecha de ocurrencia",
         "DETAILS": "Detalles",

--- a/web/app/i18n/exclaim.json
+++ b/web/app/i18n/exclaim.json
@@ -181,6 +181,8 @@
         "BUTTON_DELETE_ROW_TITLE": "!Delete \\{\\{0\\}\\}",
         "BUTTON_EXPAND": "!Expand",
         "CREATED": "!Created",
+        "MODIFIED": "!Modified",
+        "MODIFIED_BY": "!Modified by",
         "DATE_AND_TIME": "!Date & Time",
         "DATE_FILTER": "!Filter events by date of occurence",
         "DETAILS": "!Details",

--- a/web/app/i18n/lo.json
+++ b/web/app/i18n/lo.json
@@ -181,6 +181,8 @@
         "BUTTON_DELETE_ROW_TITLE": "ລົບອອກ \\{\\{0\\}\\}",
         "BUTTON_EXPAND": "ການຂະຫຍາຍ",
         "CREATED": "ສ້າງຂຶ້ນແລ້ວ",
+        "MODIFIED": "!Modified",
+        "MODIFIED_BY": "!Modified by",
         "DATE_AND_TIME": "ວັນທີ ແລະ ເວລາ",
         "DATE_FILTER": "ການຈັດ​ລຽງເຫດການໂດຍວັນທີີ່ເກີດຂຶ້ນ",
         "DETAILS": "ລາຍລະອຽດ",

--- a/web/app/i18n/pt-br.json
+++ b/web/app/i18n/pt-br.json
@@ -181,6 +181,8 @@
         "BUTTON_DELETE_ROW_TITLE": "Apagar \\{\\{0\\}\\}",
         "BUTTON_EXPAND": "Expandir",
         "CREATED": "Criado",
+        "MODIFIED": "!Modified",
+        "MODIFIED_BY": "!Modified by",
         "DATE_AND_TIME": "Data & Hora",
         "DATE_FILTER": "Filtrar eventos por dia do acontecimento",
         "DETAILS": "Detalhes",

--- a/web/app/i18n/vi.json
+++ b/web/app/i18n/vi.json
@@ -181,6 +181,8 @@
         "BUTTON_DELETE_ROW_TITLE": "X\u00f3a [\u0110i\u1ec1n t\u00ean d\u00f2ng]",
         "BUTTON_EXPAND": "M\u1edf r\u1ed9ng",
         "CREATED": "\u0110\u00e3 \u0111\u01b0\u1ee3c t\u1ea1o",
+        "MODIFIED": "!Modified",
+        "MODIFIED_BY": "!Modified by",
         "DATE_AND_TIME": "Ng\u00e0y & Gi\u1edd",
         "DATE_FILTER": "L\u1ecdc c\u00e1c s\u1ef1 ki\u1ec7n theo ng\u00e0y x\u1ea3y ra",
         "DETAILS": "Chi ti\u1ebft",

--- a/web/app/i18n/zh.json
+++ b/web/app/i18n/zh.json
@@ -181,6 +181,8 @@
         "BUTTON_DELETE_ROW_TITLE": "删除 \\{\\{0\\}\\}",
         "BUTTON_EXPAND": "展开",
         "CREATED": "创建的",
+        "MODIFIED": "!Modified",
+        "MODIFIED_BY": "!Modified by",
         "DATE_AND_TIME": "日期和时间",
         "DATE_FILTER": "通过日期过滤事件",
         "DETAILS": "细节",

--- a/web/app/scripts/details/details-constants-directive.js
+++ b/web/app/scripts/details/details-constants-directive.js
@@ -6,7 +6,7 @@
         var module = {
             restrict: 'AE',
             scope: {
-                record: '='
+                record: '<'
             },
             templateUrl: 'scripts/details/details-constants-partial.html',
             bindToController: true,

--- a/web/app/scripts/details/details-constants-partial.html
+++ b/web/app/scripts/details/details-constants-partial.html
@@ -8,6 +8,12 @@
          - {{ ::ctl.record.occurred_to | localizeRecordDate: ctl.dateFormat : true }}
         </span>
     </div>
+    <label>
+        {{ 'RECORD.MODIFIED' | translate }}
+    </label>
+    <div class="value constant date">
+        {{ ::ctl.record.modified | localizeRecordDate: ctl.dateFormat : true }}
+    </div>
 </div>
 <div class="col-sm-6">
     <label>
@@ -15,6 +21,14 @@
     </label>
     <div class="value constant date created">
         {{ ::ctl.record.created | localizeRecordDate: 'long':'time'}}
+    </div>
+    <div ng-if="ctl.record.modified_by">
+        <label>
+            {{ 'RECORD.MODIFIED_BY' | translate }}
+        </label>
+        <div class="value constant">
+            {{ ctl.record.modified_by }}
+        </div>
     </div>
 </div>
 <div class="col-sm-12">

--- a/web/app/scripts/details/details-single-directive.js
+++ b/web/app/scripts/details/details-single-directive.js
@@ -6,10 +6,10 @@
         var module = {
             restrict: 'AE',
             scope: {
-                data: '=',
-                properties: '=',
-                record: '=',
-                definition: '='
+                data: '<',
+                properties: '<',
+                record: '<',
+                definition: '<'
             },
             templateUrl: 'scripts/details/details-single-partial.html',
             bindToController: true,

--- a/web/app/scripts/details/details-tabs-partial.html
+++ b/web/app/scripts/details/details-tabs-partial.html
@@ -7,7 +7,7 @@
             ng-if="!definition.multiple"
             data="::ctl.record.data[definition.propertyKey]"
             properties="::properties"
-            record="::ctl.record"
+            record="ctl.record"
             definition="::definition">
         </driver-details-single>
 


### PR DESCRIPTION
# Overview
Displays Modified-By information in the record details pane

# Testing
- Run the development frontend server (`./scripts/grunt.sh web serve`) and then access the app at `http://localhost:7002`
- Log in with an admin/analyst user and navigate to a record's details. Verify that new sections for "Modified" and "Modified by" show up.
- Log out and log in again with a public user. Verify that the new sections don't appear.

# Demo
<img width="612" alt="screen shot 2017-12-05 at 10 41 39 am" src="https://user-images.githubusercontent.com/447977/33615737-e8bd4378-d9a8-11e7-8b91-373dcf0cb755.png">

# Notes
- There are a bunch of one-time bindings in the record details display; this initially prevented the `modified_by` attribute from being bound correctly because it is populated from the list view. The list view doesn't request the `modified_by` information because it isn't used there and would require 2 additional database queries per record. I converted the necessary one-time bindings into regular bindings so that the `modified_by` field now updates once the API request to get the record details returns a response. While I was in there, I also refactored some of the record detail directives to use one-_way_ bindings, since that is our current best practice (and these directives are all display-only).
- @tgilcrest this changes the translation files, so we should update our translation spreadsheet and potentially request new translations.