### PR TITLE
Make provisioning from scratch work

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,17 @@ telling it to communicate with the Docker daemon on the `app` virtual machine.
 
 ## Testing Data
 
-A CSV of historical data can be downloaded from the project /data folder (incidents_and_sites.csv).
+### Boundaries
+
+To load boundaries, upload the `regions.zip` and `states.zip` files to Ashlar.
+Ashlar is runs on localhost:7001. For each file, first upload the file, then select
+`name` as the display field, then hit save. Either refresh the page or
+navigate somewhere else in between any two uploads.
+
+### Records
+
+A CSV of historical data can be downloaded from the project /data folder.
+Good files are `<city or agency>_traffic.csv`.
 
 Once the app has been built, this data can be loaded.
 
@@ -87,7 +97,7 @@ Then open the network tab in web developer tools and reload the page. Inspect th
 from an API request and pull out the value of the `Authorization` header, for example
 `Token f1acac96cc79c4822e9010d23ab425231d580875`.
 
-Run `python scripts/load_incidents_v3.py --authz 'Token YOUR_AUTH_TOKEN' /path/to/incident_csvs`.
+Run `python scripts/load_incidents_v3.py --authz 'Token YOUR_AUTH_TOKEN' /path/to/directory_containing_incident_csvs`.
 Note that the import process will take roughly two hours for the full data set; you can cut down the
 number of records with `head` on the individual CSVs.
 
@@ -96,6 +106,17 @@ To load mock black spots, run `python scripts/load_black_spots.py --authz 'Token
 To load mock interventions, run `python scripts/load_interventions.py --authz 'Token YOUR_AUTH_TOKEN' /path/to/interventions_sample_pts.geojson`.
 
 To generate black spot and load forecast training inputs, run `python scripts/generate_training_input.py /path/to/roads.shp /path/to/records.csv`.
+
+### Costs
+
+You can't request records with associated costs successfully until you configure some costs.
+To do this, navigate to your editor (by default on `localhost:7001`), select "Incident" from
+record types in the menu on the left. Select "Cost aggregation settings", then:
+
+- choose a currency prefix in "Cost Prefix" (e.g., `$`, but anything is fine)
+- Select "Incident Details" in "Related Content Type"
+- Choose "Severity" in "Field"
+- then decide how much money you think human lives, human physical security, and property are worth
 
 ## Production
 

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -19,7 +19,7 @@ postgresql_port: 5432
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "9.5.*.pgdg14.04+1"
+postgresql_support_libpq_version: "9.3.4-1"
 postgresql_support_psycopg2_version: "2.6"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"

--- a/schema_editor/.bowerrc
+++ b/schema_editor/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "bower_components"
+  "directory": "bower_components",
+  "registry": "https://registry.bower.io"
 }

--- a/schema_editor/Dockerfile
+++ b/schema_editor/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/static-core:0.1.0
+FROM node:4-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ruby-dev \
   python \
   python-dev \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* && \
+  npm install -g --save grunt-cli bower
 
 RUN gem install sass -v 3.4.22
 RUN gem install compass

--- a/web/.bowerrc
+++ b/web/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "bower_components"
+  "directory": "bower_components",
+  "registry": "https://registry.bower.io"
 }

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/static-core:0.1.0
+FROM node:4-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ruby-dev \
   python \
   python-dev \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* && \
+  npm install -g --save bower grunt-cli
 
 RUN gem install sass -v 3.4.22
 RUN gem install compass

--- a/web/test/karma.conf.js
+++ b/web/test/karma.conf.js
@@ -80,6 +80,8 @@ module.exports = function(config) {
       'bower_components/world-calendars/jquery.calendars.picker-zh-CN.js',
       'bower_components/world-calendars/jquery.calendars-bn.js',
       'bower_components/world-calendars/jquery.calendars.picker-bn.js',
+      'bower_components/world-calendars/jquery.calendars-lo.js',
+      'bower_components/world-calendars/jquery.calendars.picker-lo.js',
       'bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'bower_components/jjv/lib/jjv.js',


### PR DESCRIPTION
Overview
-----

This PR makes several small changes to make provisioning from scratch cooperate given changes that have occurred in the state of dependencies since this project's dev environment was setup.

Specifically, it explicitly sets `bower`'s registry, separately installs `bower`, changes the `libpq` version to something that's in the postgresql PPA, upgrades the base images for some containers to `node:4-slim` from our old `static-core` containers.

Testing
-----

- `vagrant provision`
- it should succeed