### PR TITLE
Deployment updates

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -10,28 +10,30 @@ do
   docker push "quay.io/azavea/driver-${image}:latest"
 done
 
+# TODO: The below was for deploying to our staging environment, which we no longer have.
+# If staging is ever resurrected, we can re-enable this.
 # Set up group vars
-echo "setting up group vars..."
-set +x
-grep -v nominatim_key deployment/ansible/group_vars/all.example \
-    > deployment/ansible/group_vars/all
-echo "web_js_nominatim_key: \"${NOMINATIM_API_KEY}\"" \
-    >> deployment/ansible/group_vars/all
-echo "oauth_client_id: \"${OAUTH_CLIENT_ID}\"" \
-    >> deployment/ansible/group_vars/all
-echo "oauth_client_secret: \"${OAUTH_CLIENT_SECRET}\"" \
-    >> deployment/ansible/group_vars/all
-echo "forecast_io_api_key: \"${FORECAST_IO_API_KEY}\"" \
-    >> deployment/ansible/group_vars/all
-echo "keystore_password: \"${DRIVER_KEYSTORE_PASSWORD}\"" \
-    >> deployment/ansible/group_vars/all
-set -x
+#echo "setting up group vars..."
+#set +x
+#grep -v nominatim_key deployment/ansible/group_vars/all.example \
+#    > deployment/ansible/group_vars/all
+#echo "web_js_nominatim_key: \"${NOMINATIM_API_KEY}\"" \
+#    >> deployment/ansible/group_vars/all
+#echo "oauth_client_id: \"${OAUTH_CLIENT_ID}\"" \
+#    >> deployment/ansible/group_vars/all
+#echo "oauth_client_secret: \"${OAUTH_CLIENT_SECRET}\"" \
+#    >> deployment/ansible/group_vars/all
+#echo "forecast_io_api_key: \"${FORECAST_IO_API_KEY}\"" \
+#    >> deployment/ansible/group_vars/all
+#echo "keystore_password: \"${DRIVER_KEYSTORE_PASSWORD}\"" \
+#    >> deployment/ansible/group_vars/all
+#set -x
 
-ansible-galaxy install -f -r deployment/ansible/roles.yml -p deployment/ansible/roles
+#ansible-galaxy install -f -r deployment/ansible/roles.yml -p deployment/ansible/roles
 
-chmod 0600 deployment/driver.pem
+#chmod 0600 deployment/driver.pem
 
-ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
-  -i deployment/ansible/inventory/staging \
-  --private-key="${TRAVIS_BUILD_DIR}/deployment/driver.pem" \
-  deployment/ansible/database.yml deployment/ansible/app.yml deployment/ansible/celery.yml
+#ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
+#  -i deployment/ansible/inventory/staging \
+#  --private-key="${TRAVIS_BUILD_DIR}/deployment/driver.pem" \
+#  deployment/ansible/database.yml deployment/ansible/app.yml deployment/ansible/celery.yml

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -21,8 +21,8 @@ postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
 postgresql_support_libpq_version: "9.3.4-1"
 postgresql_support_psycopg2_version: "2.6"
-postgis_version: "2.1"
-postgis_package_version: "2.1.*.pgdg14.04+1"
+postgis_version: "2.3"
+postgis_package_version: "2.3.*.pgdg14.04+1"
 
 ## TABLES USED BY WINDSHAFT
 windshaft_tables:

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,3 +1,5 @@
+- src: azavea.python-security
+  version: 0.1.0
 - src: azavea.postgresql
   version: 0.3.4
 - src: azavea.postgresql-support

--- a/deployment/ansible/roles/driver.database/meta/main.yml
+++ b/deployment/ansible/roles/driver.database/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 # Dependencies for driver.database role
 dependencies:
+  - { role: "azavea.python-security" }
   - { role: "azavea.postgresql" }
   - { role: "azavea.postgresql-support"}
   - { role: "azavea.postgis" }


### PR DESCRIPTION
Changes that I had to make in order to get a fresh stack to deploy, along with disabling Travis attempting to deploy to staging, which no longer exists. This should get us to successful CI builds now.

# Testing
- If you really want you could spin up three EC2 instances running Ubuntu 14.04 and follow the [deployment instructions](https://github.com/WorldBank-Transport/DRIVER/blob/feature/deployment-updates/doc/system-administration.md). It should successfully provision the database. However, the app server will still fail because of outstanding issues with Let's Encrypt, so this isn't a great test.
- `vagrant provision` (it should at the very least not break local provisioning).
- And we'll verify that the deployment phase of Travis works now once this is merged.