### PR TITLE
Make more fixes to deployment

### DIFF
--- a/deployment/ansible/roles/driver.app/tasks/firewall.yml
+++ b/deployment/ansible/roles/driver.app/tasks/firewall.yml
@@ -1,7 +1,4 @@
 ---
-- name: Enable firewall
-  ufw: state=enabled policy=reject
-
 - name: Allow ssh access
   ufw: rule=allow port=22
 
@@ -37,3 +34,6 @@
 - name: Allow Livereload - web access
   ufw: rule=allow port=35732
   when: developing
+
+- name: Enable firewall
+  ufw: state=enabled policy=reject

--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -34,11 +34,11 @@ exec /usr/bin/docker run \
   --env DJANGO_SETTINGS_MODULE=driver.settings_dev \
   {% endif -%}
   {% for k,v in driver_conf.items() -%}
-  --env {{ k }}="{{ v }}" \
+  --env {{ k }}='{{ v }}' \
   {% endfor -%}
-  --env DRIVER_READ_ONLY_GROUP="{{ driver_read_only_group }}" \
-  --env DRIVER_READ_WRITE_GROUP="{{ driver_read_write_group }}" \
-  --env DRIVER_ADMIN_GROUP="{{ driver_admin_group }}" \
+  --env DRIVER_READ_ONLY_GROUP='{{ driver_read_only_group }}' \
+  --env DRIVER_READ_WRITE_GROUP='{{ driver_read_write_group }}' \
+  --env DRIVER_ADMIN_GROUP='{{ driver_admin_group }}' \
   --log-driver syslog \
 {% if celery %} --entrypoint '/bin/bash -c' \
 {% endif %}  quay.io/azavea/driver-app:latest {% if celery %} \

--- a/deployment/ansible/roles/driver.celery/tasks/firewall.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/firewall.yml
@@ -1,7 +1,4 @@
 ---
-- name: Enable firewall
-  ufw: state=enabled policy=reject
-
 - name: Allow ssh access
   ufw: rule=allow port=22
 
@@ -15,3 +12,6 @@
 - name: Allow https connections from app machines (e.g. for CSV downloads)
   ufw: rule=allow port=443 from_ip={{ item }}
   with_items: "{{ ip_addresses_app }}"
+
+- name: Enable firewall
+  ufw: state=enabled policy=reject

--- a/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
+++ b/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
@@ -32,7 +32,7 @@ exec /usr/bin/docker run \
   --env DJANGO_SETTINGS_MODULE=driver.settings_dev \
   {% endif -%}
   {% for k,v in driver_conf.items() -%}
-  --env {{ k }}="{{ v }}" \
+  --env {{ k }}='{{ v }}' \
   {% endfor -%}
   --log-driver syslog \
   --entrypoint 'celery' \

--- a/deployment/ansible/roles/driver.database/tasks/firewall.yml
+++ b/deployment/ansible/roles/driver.database/tasks/firewall.yml
@@ -1,7 +1,4 @@
 ---
-- name: Enable firewall
-  ufw: state=enabled policy=reject
-
 - name: Allow ssh access
   ufw: rule=allow port=22
 
@@ -23,3 +20,6 @@
 - name: Allow redis connections from celery machines
   ufw: rule=allow port={{ redis_port }} from_ip={{ item }}
   with_items: "{{ ip_addresses_celery }}"
+
+- name: Enable firewall
+  ufw: state=enabled policy=reject

--- a/deployment/ansible/roles/driver.gradle/tasks/main.yml
+++ b/deployment/ansible/roles/driver.gradle/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Configure gradle service definition
   template: src=upstart-gradle.conf.j2 dest=/etc/init/driver-gradle.conf
   notify:
-    - Restart driver-gradle
+    - Restart Gradle
 
 - name: Ensure gradle service is running
   service: name=driver-gradle state=started

--- a/deployment/ansible/roles/driver.nginx/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/driver.nginx/templates/nginx-app.conf.j2
@@ -10,7 +10,7 @@ server {
    listen 80 default_server;
 {% endif %}
 
-    server_name _;
+    server_name {{ allowed_host }};
     root {{ web_build_dir }};
     index index.html;
 

--- a/deployment/ansible/roles/driver.windshaft/templates/upstart-windshaft.conf.j2
+++ b/deployment/ansible/roles/driver.windshaft/templates/upstart-windshaft.conf.j2
@@ -28,7 +28,7 @@ exec /usr/bin/docker run \
   --volume {{ root_windshaft_dir }}/alphamarker.png:{{ root_windshaft_dir }}/alphamarker.png \
   --volume {{ root_windshaft_dir }}/server.js:{{ root_windshaft_dir }}/server.js \
   {% for k,v in driver_conf.items() -%}
-  --env {{ k }}="{{ v }}" \
+  --env {{ k }}='{{ v }}' \
   {% endfor -%}
   --log-driver syslog \
   quay.io/azavea/windshaft:0.1.0 server.js


### PR DESCRIPTION
- Don't enable firewall until it has been configured to allow SSH access
- Use single-quoting in Upstart scripts so that dollar-signs don't cause
  attempted variable insertion
- Specify server_name in Nginx to make working with certbot a bit easier

# Testing instructions
- This shouldn't break local provisioning, but real deployment isn't quite functional enough yet to test this any other way.