### PR TITLE
Fix setup issues and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,55 @@ DRIVER - Data for Road Incident Visualization, Evaluation, and Reporting
 
 ## Developing
 
-Requires Vagrant 1.5+, Ansible 1.8+ and the following plugins:
-  - `vagrant-hostmanager`
+### Installation
+
+1. Install Vagrant 1.5+
+
+1. Install Ansible 1.8+
+
+1. Install `vagrant-hostmanager` plugin via:
+
+    ```
+    vagrant plugin install vagrant-hostmanager
+    ```
+
+1. Create `gradle/data/driver.keystore`
+
+    To run in development without support for JAR file building, `touch gradle/data/driver.keystore`. (If you just want to install the DRIVER web interface, do this. You can add Android integration later.)
+
+    To build schema model JAR files for the Android app, copy the signing keystore to `gradle/data/driver.keystore`
+    and set the password for the keystore under `keystore_password` in `deployment/ansible/group_vars/all`.
+
+1. Copy `deployment/ansible/group_vars/all.example` to `deployment/ansible/group_vars/all`
+
+1. Install [NFS](https://en.wikipedia.org/wiki/Network_File_System). On Debian/Ubuntu, run:
+
+    ```
+    sudo apt-get install nfs-common nfs-kernel-server
+    ```
+
+1. Clone the [Ashlar](https://github.com/azavea/ashlar) project such that it is a sibling of DRIVER (Ashlar is needed for generating dynamic schemas used by DRIVER).
+
+    An example setup might be as follows:
+    ```
+    /home/username/
+      git
+        DRIVER
+        ashlar
+    ```
+
+1. Run `vagrant up`
+
+    If you run into issues provisioning the VMs or forget a step, try re-provisioning via `vagrant provision <vm-name>` as needed.
+
+### Pickpoint
 
 Obtain a pickpoint api key from https://pickpoint.io.
 
 Copy `deployment/ansible/group_vars/all.example` to `deployment/ansible/group_vars/all`
 and add the API key for pickpoint under `web_js_nominatim_key`.
 
-To build schema model jar files for the Android app, copy the signing keystore to `gradle/data/driver.keystore`
-and set the password for the keystore under `keystore_password` in `deployment/ansible/group_vars/all`.
-To run in development without support for jar file building, `touch gradle/data/driver.keystore`.
-
-Install plugins before `vagrant up` via: `vagrant plugin install <plugin-name>`
+### Running & Configuration
 
 The app runs on localhost on port 7000. The schema editor is available at /editor/.
 
@@ -27,11 +63,11 @@ A default django superuser will be created, but only on a development provision:
 
 A default OAuth2 application will be created, but only on a development provision.
 Navigate to http://localhost:7000/o/applications/ to retrieve the client id/secret after
-logging in via http://localhost:70000/admin/
+logging in via http://localhost:7000/admin/
 
-Then run `vagrant up` from the DRIVER repository.
+### Frontend
 
-For development, ssh into the app vm with `vagrant ssh app`.
+For frontend development, ssh into the app vm with `vagrant ssh app`.
 
 Then, the Angular schema editor is located at: `/opt/schema_editor`
 The application Angular frontend is located at: `/opt/web`.

--- a/deployment/ansible/database.yml
+++ b/deployment/ansible/database.yml
@@ -7,6 +7,7 @@
   pre_tasks:
     - name: Gather EC2 facts
       action: ec2_facts
+      when: staging
 
 - hosts: database-servers
 

--- a/deployment/ansible/roles/driver.nginx/defaults/main.yml
+++ b/deployment/ansible/roles/driver.nginx/defaults/main.yml
@@ -31,3 +31,5 @@ root_www_dir: "/var/www"
 root_windshaft_dir: "/opt/windshaft"
 root_static_dir: "{{ root_www_dir }}/static"
 root_media_dir: "{{ root_www_dir }}/media"
+
+nginx_server_name: "{% if allowed_host %}{{ allowed_host }}{% else %}_{% endif %}"

--- a/deployment/ansible/roles/driver.nginx/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/driver.nginx/templates/nginx-app.conf.j2
@@ -10,7 +10,7 @@ server {
    listen 80 default_server;
 {% endif %}
 
-    server_name {{ allowed_host }};
+    server_name {{ nginx_server_name }};
     root {{ web_build_dir }};
     index index.html;
 


### PR DESCRIPTION
## Overview
This PR fixes a couple of issues I had getting set up and updates the README to make it easier to get DRIVER running for development.

## Testing Instructions
`vagrant destroy` and follow the new README installation instructions to get the VMs set up again.