### PR TITLE
Add CertBot to Ansible

### DIFF
--- a/deployment/ansible/app.yml
+++ b/deployment/ansible/app.yml
@@ -13,15 +13,6 @@
 
   become: True
 
-  vars:
-    letsencrypt_certs:
-      -
-        name: "driver-ssl-cert"
-        keypath: "{{ letsencrypt_key_dir }}/driver-ssl-cert.key"
-        certpath: "{{ letsencrypt_certs_dir }}/driver-ssl-cert.cert"
-        fullchainedcertpath: "{{ letsencrypt_certs_dir }}/driver-ssl-cert-full.cert"
-        host: "{{ allowed_host }}"
-
   pre_tasks:
     - name: Update APT cache
       apt: update_cache=yes
@@ -33,7 +24,6 @@
     - { role: "driver.windshaft" }
     - { role: "driver.app" }
     - { role: "driver.nginx" }
-    - { role: "azavea.letsencrypt", when: staging or production }
 
 - hosts: database-servers
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -14,5 +14,3 @@
   version: 0.1.1
 - src: azavea.redis
   version: 0.1.0
-- src: azavea.letsencrypt
-  version: v11.3

--- a/deployment/ansible/roles/driver.letsencrypt/defaults/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+certbot_version: "v0.20.0"
+letsencrypt_root: "/etc/letsencrypt"
+letsencrypt_cert_root: "{{ letsencrypt_root }}/live/{{ allowed_host }}"
+
+letsencrypt_options_ssl_nginx_url: "https://raw.githubusercontent.com/certbot/certbot/{{certbot_version}}/certbot-nginx/certbot_nginx/options-ssl-nginx.conf"
+letsencrypt_options_ssl_nginx_path: "{{ letsencrypt_root }}/options-ssl-nginx.conf"
+
+letsencrypt_dhparams_url: "https://raw.githubusercontent.com/certbot/certbot/{{ certbot_version }}/certbot/ssl-dhparams.pem"
+letsencrypt_dhparams_path: "{{ letsencrypt_root }}/ssl-dhparams.pem"

--- a/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# Set up certificates on the machine using CertBot
+- name: Install CertBot dependencies
+  apt:
+    pkg: software-properties-common
+    state: present
+
+- name: Add CertBot repository
+  apt_repository:
+    repo: "ppa:certbot/certbot"
+    state: present
+
+- name: Install CertBot
+  apt:
+    pkg: certbot
+    state: present
+
+# The nginx role will assume that this cert exists when configuring.
+- name: Use CertBot to obtain certificate
+  command: certbot certonly --standalone -n --agree-tos --email {{ driver_admin_email }} --domains {{ allowed_host }}
+  args:
+    creates: "{{ letsencrypt_cert_root }}/fullchain.pem"
+
+# The existence of these files is assumed by the nginx role as well.
+# This isn't a great option, but it roughly approximates what the certbot-nginx code does:
+# these files are included directly in the python package and copied into place.
+# certbot-nginx got really confused by our nginx config, so this seemed like the easier route
+- name: Download CertBot nginx SSL config
+  get_url:
+    url: "{{ letsencrypt_options_ssl_nginx_url }}"
+    dest: "{{ letsencrypt_options_ssl_nginx_path }}"
+
+- name: Download CertBot Diffie-Hellman Params
+  get_url:
+    url: "{{ letsencrypt_dhparams_url }}"
+    dest: "{{ letsencrypt_dhparams_path }}"
+
+# Copied from old azavea.letsencrypt role
+- name: Install cronjob for cert renewal
+  cron:
+    job: "certbot renew"
+    day: "1,11,21"
+    hour: 4
+    minute: 30
+    state: present
+    name: "letsencrypt certificate renewal"

--- a/deployment/ansible/roles/driver.nginx/meta/main.yml
+++ b/deployment/ansible/roles/driver.nginx/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 dependencies:
   - { role: "azavea.nginx", nginx_delete_default_site: True }
+  - { role: "driver.letsencrypt", when: staging or production }
   - { role: "driver.monit" }

--- a/deployment/ansible/roles/driver.nginx/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/driver.nginx/templates/nginx-app.conf.j2
@@ -1,11 +1,12 @@
 server {
 
 {% if staging or production %}
-    listen 443 default_server;
-
     ssl on;
-    ssl_certificate {{ letsencrypt_certs_dir }}/driver-ssl-cert-full.cert;
-    ssl_certificate_key {{ letsencrypt_key_dir }}/driver-ssl-cert.key;
+    listen 443 default_server ssl;
+    ssl_certificate {{ letsencrypt_cert_root }}/fullchain.pem;
+    ssl_certificate_key {{ letsencrypt_cert_root }}/privkey.pem;
+    include {{ letsencrypt_options_ssl_nginx_path }};
+    ssl_dhparam {{ letsencrypt_dhparams_path }};
 {% else %}
    listen 80 default_server;
 {% endif %}
@@ -139,11 +140,6 @@ server {
 server {
     listen 80;
     server_name _;
-
-    # Used for letsencrypt domain name ownership validation
-    location /.well-known/acme-challenge/ {
-        alias {{ acme_tiny_challenges_directory }}/;
-    }
 
     # Redirect all other http traffic to https
     location / {


### PR DESCRIPTION
# Overview
Adds Ansible role for management of Let's Encrypt certificates via CertBot.

# Testing instructions
- Log into the AWS demo account and bring up two EC2 machines based on the Ubuntu Trusty AMI, one for the web app and one for the database. They should be placed in the `DriverDemoAppSG` and `DriverDatabaseSG`, respectively. It may make things smoother to bump the boot volume size to 12GB from 8, but otherwise the defaults should be fine. These won't be actually used for anything except testing provisioning, so `t2.small`s should be enough horsepower.
- Attach the free Elastic IP address (there should only be one in the account) to the web app machine.
- Follow the instructions in [doc/system-administration.md](https://github.com/WorldBank-Transport/DRIVER/blob/feature/lets-encrypt-certbot/doc/system-administration.md) to get set up to do a deployment. The best way to get the `production` group_vars and inventory files is probably to grab the ones on the fileshare for the Thai instance. You will need to edit the group_vars file you use to add `app_version: 'latest'`, because that parameter has been added since the last time we launched an instance. You'll also need to edit the IP addresses to match the instances you brought up, and `s/thailand.roadsafety.io/certbot.roadsafety.io/g` (which is already set up in Route 53 to point to that Elastic IP).
- Run the `ansible-playbook` command from the system administration doc to deploy, but omit the `celery.yml` playbook to save time.
- It will fail 😞 on the `Set table-level access privileges for Windshaft DB role` task. The error message will vary depending on your version of Ansible, but the cause is that migrations haven't been run. SSH into the web instance, `sudo docker exec -ti driver-app ./manage.py migrate`. (It may be possible to avoid this step by commenting out line 58 in [roles/driver.app/tasks/main.yml](https://github.com/WorldBank-Transport/DRIVER/blob/feature/lets-encrypt-certbot/deployment/ansible/roles/driver.app/tasks/main.yml#L58) prior to running the deployment, but that's not how I did it). Also, I swear this used to work, so I'm not sure what changed, but there doesn't seem to be an easy way to specific cross-play dependencies in Ansible, so I haven't found an easy fix.
- Run provisioning all over again.
- Once it finishes, navigate to https://certbot.roadsafety.io , and you should get the login screen with a valid security certificate.
- Clean up by deleting the EC2 instances, and you can also get rid of the Elastic IP address and remove the test subdomain.