### PR TITLE
Fix building tagged images on deployment

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -5,7 +5,7 @@ set -x
 
 for image in app editor web gradle analysis;
 do
-  docker push "quay.io/azavea/driver-${image}:${TRAVIS_TAG}"
-  docker tag "quay.io/azavea/driver-${image}:${TRAVIS_TAG}" "quay.io/azavea/driver-${image}:${TRAVIS_TAG}"
+  docker push "quay.io/azavea/driver-${image}:${TRAVIS_COMMIT:0:7}"
+  docker tag "quay.io/azavea/driver-${image}:${TRAVIS_COMMIT:0:7}" "quay.io/azavea/driver-${image}:${TRAVIS_TAG}"
   docker push "quay.io/azavea/driver-${image}:${TRAVIS_TAG}"
 done


### PR DESCRIPTION
# Overview
The CI process builds images that are [tagged based on the `TRAVIS_COMMIT` environment variable](https://github.com/WorldBank-Transport/DRIVER/blob/develop/.travis.yml#L17). The [deployment script](https://github.com/WorldBank-Transport/DRIVER/blob/develop/.travis/deploy.sh) needs to push and tag these images onto Quay before attempting to push the versioned images, otherwise it receives an error that the specified tag doesn't exist.

# Testing
Tough to do, but verify that this makes sense according to the files linked above. Also maybe take a look at [where I messed this up in the first place](https://github.com/WorldBank-Transport/DRIVER/pull/656/files#diff-f4c51f90a624a1de355553a544440125R8) and make sure you agree that the new changes are more faithful to what the original functionality was.

# Notes
I thought about targeting this to `master` since it's more of a bugfix, but since our changelog generation relies on GitHub, I decided to make a PR to `develop` first so that it'd get picked up. That's a little off from traditional git-flow, but I'm not sure it's any worse. I'm happy to retarget this if we decide we want to do things differently, I'm not sure we've discussed how the bugfix process should work yet.