### PR TITLE
Update python_security configs in all.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To generate black spot and load forecast training inputs, run `python scripts/ge
 
 You can't request records with associated costs successfully until you configure some costs.
 To do this, navigate to your editor (by default on `localhost:7001`), select "Incident" from
-record types in the menu on the left. Select "Cost aggregation settings", then:
+record types in the menu on the left. (If there are multiple record types named "Incident", delete all but one.) Select "Cost aggregation settings", then:
 
 - choose a currency prefix in "Cost Prefix" (e.g., `$`, but anything is fine)
 - Select "Incident Details" in "Related Content Type"

--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -19,6 +19,9 @@ docker_image_tag: "{% if developing %}latest{% else %}{{app_version}}{% endif %}
 python_version: "2.7.*"
 pip_version: "1.*"
 
+python_security_ndghttpsclient_version: 0.4.3
+python_security_pyasn1_version: 0.4.2
+
 postgresql_host: "database.service.driver.internal"
 postgresql_port: 5432
 


### PR DESCRIPTION
## Overview 
Update the `all.example` file in `group_vars` to add lines for python security. Add clarification to README for loading test data. 

## Testing
Provision VMs using the new `all` file.