### PR TITLE
Bring back staging environment

### DIFF
--- a/.travis/deploy_staging.sh
+++ b/.travis/deploy_staging.sh
@@ -10,30 +10,30 @@ do
   docker push "quay.io/azavea/driver-${image}:latest"
 done
 
-# TODO: The below was for deploying to our staging environment, which we no longer have.
-# If staging is ever resurrected, we can re-enable this.
 # Set up group vars
-#echo "setting up group vars..."
-#set +x
-#grep -v nominatim_key deployment/ansible/group_vars/all.example \
-#    > deployment/ansible/group_vars/all
-#echo "web_js_nominatim_key: \"${NOMINATIM_API_KEY}\"" \
-#    >> deployment/ansible/group_vars/all
-#echo "oauth_client_id: \"${OAUTH_CLIENT_ID}\"" \
-#    >> deployment/ansible/group_vars/all
-#echo "oauth_client_secret: \"${OAUTH_CLIENT_SECRET}\"" \
-#    >> deployment/ansible/group_vars/all
-#echo "forecast_io_api_key: \"${FORECAST_IO_API_KEY}\"" \
-#    >> deployment/ansible/group_vars/all
-#echo "keystore_password: \"${DRIVER_KEYSTORE_PASSWORD}\"" \
-#    >> deployment/ansible/group_vars/all
-#set -x
+echo "setting up group vars..."
+set +x
+grep -v 'nominatim_key\|app_version:' deployment/ansible/group_vars/all.example \
+    > deployment/ansible/group_vars/all
+echo "app_version: \"latest\"" \
+    >> deployment/ansible/group_vars/all
+echo "web_js_nominatim_key: \"${NOMINATIM_API_KEY}\"" \
+    >> deployment/ansible/group_vars/all
+echo "oauth_client_id: \"${OAUTH_CLIENT_ID}\"" \
+    >> deployment/ansible/group_vars/all
+echo "oauth_client_secret: \"${OAUTH_CLIENT_SECRET}\"" \
+    >> deployment/ansible/group_vars/all
+echo "forecast_io_api_key: \"${FORECAST_IO_API_KEY}\"" \
+    >> deployment/ansible/group_vars/all
+echo "keystore_password: \"${DRIVER_KEYSTORE_PASSWORD}\"" \
+    >> deployment/ansible/group_vars/all
+set -x
 
-#ansible-galaxy install -f -r deployment/ansible/roles.yml -p deployment/ansible/roles
+ansible-galaxy install -f -r deployment/ansible/roles.yml -p deployment/ansible/roles
 
-#chmod 0600 deployment/driver.pem
+chmod 0600 deployment/driver.pem
 
-#ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
-#  -i deployment/ansible/inventory/staging \
-#  --private-key="${TRAVIS_BUILD_DIR}/deployment/driver.pem" \
-#  deployment/ansible/database.yml deployment/ansible/app.yml deployment/ansible/celery.yml
+ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
+  -i deployment/ansible/inventory/staging \
+  --private-key="${TRAVIS_BUILD_DIR}/deployment/driver.pem" \
+  deployment/ansible/database.yml deployment/ansible/app.yml deployment/ansible/celery.yml

--- a/deployment/ansible/inventory/staging
+++ b/deployment/ansible/inventory/staging
@@ -1,6 +1,6 @@
-app ansible_ssh_host=52.201.239.38 ansible_ssh_user=ubuntu
-database ansible_ssh_host=52.22.46.89 ansible_ssh_user=ubuntu
-celery ansible_ssh_host=54.88.149.207 ansible_ssh_user=ubuntu
+app ansible_ssh_host=52.201.236.109 ansible_ssh_user=ubuntu
+database ansible_ssh_host=34.203.36.37 ansible_ssh_user=ubuntu
+celery ansible_ssh_host=34.229.58.2 ansible_ssh_user=ubuntu
 
 [app-servers]
 app

--- a/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
@@ -15,6 +15,11 @@
     pkg: certbot
     state: present
 
+- name: Stop nginx
+  service:
+    name: nginx
+    state: stopped
+
 # The nginx role will assume that this cert exists when configuring.
 - name: Use CertBot to obtain certificate
   command: certbot certonly --standalone -n --agree-tos --email {{ driver_admin_email }} --domains {{ allowed_host }}


### PR DESCRIPTION
Overview
-----

This PR brings back the parts of the `deploy_staging.sh` script that had been removed.
They should work now because the instances they care about are (probably) back.

It also corrects the IP addresses in the staging inventory file.

Testing
-----

- confirm that `.travis` deployed to staging successfully from this branch