### PR TITLE
Always migrate during deployments

### DIFF
--- a/deployment/ansible/roles/driver.app/tasks/main.yml
+++ b/deployment/ansible/roles/driver.app/tasks/main.yml
@@ -55,6 +55,5 @@
 - name: Run Django migrations
   command: >
     /usr/bin/docker exec -i driver-app ./manage.py migrate
-  when: developing_or_staging
 
 - { include: firewall.yml }


### PR DESCRIPTION
# Overview
This is a small change but it may require some discussion. During the recent demo deployments, I have run into problems with the [database permissions task](https://github.com/WorldBank-Transport/DRIVER/blob/develop/deployment/ansible/roles/driver.access/tasks/main.yml). The problem occurs because migrations aren't run for production deployments, but the tables that the task tries to create permissions for don't exist until after migrations are run. This has caused the database permissions task to fail, which requires SSHing into the instances, manually running migrations, and re-running Ansible.

I looked for a way to encode this dependency in Ansible, but because the dependencies cross plays, I wasn't able to find an easy way to do it. Instead, I changed the deployment to always run migrations, in all environments. I _think_ this is safe now that we have version numbers because:
- Users doing initial deploys will want migrations to run
- Users reprovisioning to change configuration on the same version number will never have unexpected migrations
- Users who change the version number will need to run migrations.

The only potential issue I can imagine is if there is some kind of complicated migration that requires user input to run. Due to the planned decentralized nature of this application, we should probably do our best to avoid those.

# Testing instructions
- Make sure the rationale above makes sense and that I haven't missed anything.
- I tested this while setting up the Mumbai demo instance and it worked, so it's probably not necessary to re-test.