### PR TITLE
Restart nginx after certbot task

### DIFF
--- a/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
@@ -40,6 +40,11 @@
     url: "{{ letsencrypt_dhparams_url }}"
     dest: "{{ letsencrypt_dhparams_path }}"
 
+- name: Start nginx
+  service:
+    name: nginx
+    state: started
+
 # Copied from old azavea.letsencrypt role
 - name: Install cronjob for cert renewal
   cron:


### PR DESCRIPTION
### Overview

Nginx was being stopped before certbot tasks are run, but then it was never restarted. This fixes that.

### Testing

Not feasible since this task only runs in staging or production. I'm going to merge this and ensure it succeeds when deploying to staging.