### PR TITLE
Fix gem install error on editor and web image builds

### DIFF
--- a/schema_editor/Dockerfile
+++ b/schema_editor/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* && \
   npm install -g --save grunt-cli bower
 
+RUN gem install ffi -v 1.9.18
 RUN gem install sass -v 3.4.22
 RUN gem install compass
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* && \
   npm install -g --save bower grunt-cli
 
+RUN gem install ffi -v 1.9.18
 RUN gem install sass -v 3.4.22
 RUN gem install compass
 


### PR DESCRIPTION
## Overview

The travis builds stopped working because the latest release of [ffi](https://github.com/ffi/ffi/releases) is broken. `gem install compass` in the [web Dockerfile](https://github.com/WorldBank-Transport/DRIVER/blob/master/web/Dockerfile#L15) and the [editor Dockerfile](https://github.com/WorldBank-Transport/DRIVER/blob/master/schema_editor/Dockerfile#L15) tries to install ffi and so we install and pin ffi to the latest working release.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Check travis