### PR TITLE
Add side-by-side detailed view to duplicate modal

### DIFF
--- a/web/app/scripts/details/details-constants-partial.html
+++ b/web/app/scripts/details/details-constants-partial.html
@@ -26,7 +26,7 @@
         <label>
             {{ 'RECORD.MODIFIED_BY' | translate }}
         </label>
-        <div class="value constant">
+        <div class="value constant modifiedby">
             {{ ctl.record.modified_by }}
         </div>
     </div>

--- a/web/app/scripts/views/duplicates/resolve-duplicate-modal-partial.html
+++ b/web/app/scripts/views/duplicates/resolve-duplicate-modal-partial.html
@@ -8,11 +8,11 @@
     <div class="modal-body">
         <div class="duplicate-details"
              ng-repeat="record in [modal.params.duplicate.record, modal.params.duplicate.duplicate_record]">
-            <driver-details-single
-                data="record.data[modal.params.propertyKey]"
-                properties="modal.params.properties"
-                record="record">
-            </driver-details-single>
+            <driver-details-tabs
+                record-schema="modal.params.recordSchema"
+                record="record"
+                user-can-write="false">
+            </driver-details-tabs>
         </div>
     </div>
     <div class="modal-footer">

--- a/web/app/styles/partials/_duplicates.scss
+++ b/web/app/styles/partials/_duplicates.scss
@@ -84,3 +84,11 @@ driver-duplicates-list {
         }
     }
 }
+
+.map {
+    min-height: 200px;
+}
+
+.modifiedby {
+    word-break: break-all;
+}


### PR DESCRIPTION
## Overview

Add side-by-side detailed view to duplicate modal.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1680" alt="screen shot 2018-02-28 at 2 12 29 pm" src="https://user-images.githubusercontent.com/3959096/36807690-8b20095e-1c91-11e8-988b-f5527d9a18e0.png">


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * Mark 2 records as duplicates on the Django shell
 * Go to the duplicates view and click resolve on a duplicate pair
 * View the side-by-side detail view