### PR TITLE
Move to older jasmine version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -31,6 +31,7 @@
     "grunt-translate-sync": "0.3.0",
     "grunt-usemin": "~3.0.0",
     "grunt-wiredep": "^2.0.0",
+    "jasmine-core": "2.99.1",
     "jshint-stylish": "^1.0.0",
     "karma-jasmine": "*",
     "karma-ng-html2js-preprocessor": "^0.1.2",


### PR DESCRIPTION
## Overview

Our frontend tests for `web` are broken. This PR fixes them by pinning `jasmine-core` to `2.99.1`. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

Strongly recommend moving to yarn. I realized we use npm and bower right now, and our builds will keep breaking for no fault of our own unless we move to yarn and webpack. 

## Testing Instructions

 * Travis