### PR TITLE
Fix several bugs in blackspot training and CSV export [#155363953]

### DIFF
--- a/app/black_spots/tasks/forecast_segment_incidents.py
+++ b/app/black_spots/tasks/forecast_segment_incidents.py
@@ -1,8 +1,6 @@
 import subprocess
 import os
 
-from django.conf import settings
-
 from celery import shared_task
 from celery.utils.log import get_task_logger
 
@@ -22,7 +20,7 @@ def forecast_segment_incidents(segments_csv, output_path):
     analysis_container = 'quay.io/azavea/driver-analysis'
     docker_repository = os.environ.get('DOCKER_REPOSITORY')
     if docker_repository is not None:
-        analysis_container = docker_repository + '/driver-analysis'
+        analysis_container = docker_repository + 'driver-analysis'
     cmd = ['docker',
            'run',
            '--rm',

--- a/app/black_spots/tasks/generate_training_input.py
+++ b/app/black_spots/tasks/generate_training_input.py
@@ -340,6 +340,12 @@ def get_segments_with_data(combined_segments, segments_with_records, min_occurre
     # Figure out the number of full years of data we have so we can create offset aggregations.
     # A year is defined here as 52 weeks, in case we eventually want to do week/month aggregations.
     num_years = (max_occurred - min_occurred).days / (52 * 7)
+    desired_years = 4
+    if num_years < desired_years:  # The R script expects at least 4 years of data
+        logger.info('Fewer than 4 years of data found; outputting zeroes for extra years')
+        diff = desired_years - num_years
+        num_years = desired_years
+        min_occurred = min_occurred - relativedelta(years=diff)
 
     # Create the set of year ranges
     year_ranges = [

--- a/app/black_spots/tasks/get_segments.py
+++ b/app/black_spots/tasks/get_segments.py
@@ -141,9 +141,12 @@ def get_record_buffers(road_srid, records_csv_uuid):
         records_csv.open('rb')
         try:
             for row in csv.DictReader(records_csv):
-                record_point = transform(project, Point(float(row[RECORD_COL_X]),
-                                                        float(row[RECORD_COL_Y])))
-                record_buffers.append(record_point.buffer(MATCH_TOLERANCE))
+                try:
+                    record_point = transform(project, Point(float(row[RECORD_COL_X]),
+                                                            float(row[RECORD_COL_Y])))
+                    record_buffers.append(record_point.buffer(MATCH_TOLERANCE))
+                except RuntimeError:
+                    continue
         finally:
             records_csv.close()
 

--- a/app/data/tasks/fetch_record_csv.py
+++ b/app/data/tasks/fetch_record_csv.py
@@ -67,11 +67,11 @@ def export_records(occurred_min, occurred_max, record_type_id):
     }
     details_key = details.keys()[0]
     record_detail_fields = [
-        key for key, val in details[details_key]['properties'].viewitems()
+        to_utf8(key) for key, val in details[details_key]['properties'].viewitems()
         if (
-                'options' not in val or
-                'hidden' not in val['options'] or
-                val['options']['hidden'] is False
+            'options' not in val or
+            'hidden' not in val['options'] or
+            val['options']['hidden'] is False
         ) and (
             key not in DROPPED_KEYS
         )


### PR DESCRIPTION
## Overview

When investigating the problems running blackspots for the Philippines that we've previously identified, I found a number of problems with blackspots that this fixes. Specifically:
- Having less than four years' worth of events used to reduce the number of columns in the training data, which would cause the R script to raise an exception. The training data is now extended with zero columns to ensure that the correct columns exist for training to succeed (although the results will definitely not be as good as they could be with more data).
- Errors while transforming record points into the road segments' CRS are now caught and ignored (this was exposed by a bad point in the production Philippines instance; I'm not sure how it got there, but I manually geocoded it to the correct location as best I could).
- Record field names are now converted to UTF8 before being outputted in CSV exports. We have a pretty robust UTF-8 conversion function in the CSV export task, but we were only using for the field values, not the field names themselves. I think the existence of this problem implies that CSV exports are currently non-functional on demo instances with schemas translated into non-Latin scripts. This was exposed by some test data on my local instance and shouldn't be affecting the Philippines.
- There was a leftover trailing slash issue with the R container from our refactor of the docker image repository handling.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

- I haven't been able to test these fixes on the Philippines instance because the Celery worker disappeared out from under me while I was attempting to manually run blackspots training, and has remained inaccessible (`no route to host`).
- The actual issue with the Philippines instance was that the road segments shapefile it had generated was somehow corrupt. When iterating through it with `fiona`, it returned 0 features. I deleted the file and kicked it off again. However, the host disappeared during the middle of that process, so I am not sure whether it completed successfully. I tried testing the same thing on my local instance, which exposed the other issues that this addresses. Once I resolved those problems, I was able to run a successful blackspots calculation start to finish. My current guess is that there was some kind of network problem while the extract was being downloaded, which caused the segments shapefile to be corrupt, but I'm not sure.


## Testing Instructions

 * The command for running black spots, when SSHed into the Celery VM, is `/usr/local/bin/heimdall --database 'postgres://heimdall:heimdall@192.168.12.101:5432/lockspace' --namespace records --name calculate_black_spots --timeout 7200 docker exec $(docker ps -q -f name=driver-celery) ./manage.py calculate_black_spots`
 * Simply running that command should at least verify that the R container path is correct and that the error handling I've added didn't break anything.
 * If you want to add data that would previously have triggered failures, instructions are below. You may want to check out `develop` to verify that these cause failures there:
   * Use the Postgresql or Django shell to manually edit a record to have a location with coordinates that are outside the bounds of latitude / longitude.
   * Edit your schema to add a field in the details that includes non-Latin characters in its name, and make sure that at least one Record has data in that field.


Closes #155363953
