### PR TITLE
Pin Ashlar version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,8 +59,8 @@ Vagrant.configure("2") do |config|
     database.hostmanager.aliases = %w(database.service.driver.internal redis.service.driver.internal)
     database.vm.network "private_network", ip: "192.168.12.101"
 
-    # For PGAdmin access
-    database.vm.network "forwarded_port", guest: 5432, host: Integer(ENV.fetch("DRIVER_DATABASE_PORT_5432", 5432))
+    # For PGAdmin access, uncomment and `vagrant reload`
+    # database.vm.network "forwarded_port", guest: 5432, host: Integer(ENV.fetch("DRIVER_DATABASE_PORT_5432", 5432))
 
     database.vm.synced_folder ".", "/vagrant", disabled: true
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -15,7 +15,7 @@ python-dateutil==2.4.2
 pytz==2015.7
 mock==1.3.0
 djangorestframework-csv==1.4.1
-git+https://github.com/azavea/ashlar.git@develop#egg=ashlar
+git+https://github.com/azavea/ashlar.git@legacy#egg=ashlar
 # Dependencies for generate_training_input script
 argparse==1.2.1
 Fiona==1.6.3


### PR DESCRIPTION
@flibbertigibbet I assigned you because I thought this would jive well with your work to get your dev environment running again but I'm happy to reassign if necessary, just let me know!

## Overview
We may be embarking on further development of the Ashlar library, so to
prevent any breaking changes there from propagating to existing DRIVER
instances, this pins DRIVER to the existing state of Ashlar.

See https://github.com/azavea/ashlar/pull/79 for further discussion.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * `vagrant up --provision` and confirm everything still works.
