### PR TITLE
Fix provisioning of app VM

### DIFF
--- a/app/dev-requirements.txt
+++ b/app/dev-requirements.txt
@@ -1,3 +1,3 @@
 ipython==3.0.0
 ipdb==0.8.1
--e git+https://github.com/azavea/ashlar.git@develop#egg=ashlar
+-e git+https://github.com/azavea/ashlar.git@legacy#egg=ashlar


### PR DESCRIPTION
## Overview

Fix provisioning of app VM.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

This issue was difficult to track down. Initially as I was trying to get ansible to provision `app` successfully, I was running into strange issues that I didn't understand (eg. Python code changes to make sure the app was loaded before importing signals or user models) given that we hadn't done any work on DRIVER recently. As it turns out, we in fact did a lot of work to ashlar, and in `app/dev-requirements.txt` we were still pinned to the `develop` branch which had undergone extensive changes, including upgrading Django.

## Testing Instructions

* `vagrant destroy -f && vagrant up` should succeed.

