### PR TITLE
Add Mapillary to record popup and blackspot popup

### DIFF
--- a/deployment/ansible/group_vars/all.example
+++ b/deployment/ansible/group_vars/all.example
@@ -61,6 +61,9 @@ web_js_record_type_secondary_label: "Intervention"
 web_js_blackspots_visible: "true"
 web_js_heatmap_visible: "true"
 web_js_interventions_visible: "true"
+web_js_mapillary: "false"
+web_js_mapillary_client_id: ""
+web_js_mapillary_range: 10
 editor_js_html5mode: "{{ js_html5mode }}"
 editor_js_html5mode_prefix: "{{ js_html5mode_prefix }}"
 

--- a/deployment/ansible/roles/driver.web/templates/web-config-js.j2
+++ b/deployment/ansible/roles/driver.web/templates/web-config-js.j2
@@ -50,6 +50,11 @@
             /*jshint quotmark: double */
             languages: {{ languages | to_json }}
             /*jshint quotmark: single */
+        },
+        mapillary: {
+            enabled: {{ web_js_mapillary }},
+            clientId: '{{ web_js_mapillary_client_id }}',
+            range: {{ web_js_mapillary_range }}
         }
     };
 

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -685,6 +685,13 @@
             });
         }
 
+        function getMapillaryHtmlString() {
+            return '<img id="mapillaryimg" />' +
+                '<p id="mapillaryattributionp" align="right">' +
+                    'Image powered by <a target="_blank" href="https://www.mapillary.com/">Mapillary</a>.' +
+                '</p>';
+        }
+
         function getMapillaryImg(latlng) {
             var clientId = WebConfig.mapillary.clientId;
             var mapillaryRadius = WebConfig.mapillary.range;
@@ -692,7 +699,9 @@
                 .success(function(data) {
                     if (data.features.length !== 0) {
                         var mapillaryImg = document.querySelector('#mapillaryimg');
+                        var mapillaryAttributionP = document.querySelector('#mapillaryattributionp');
                         mapillaryImg.setAttribute('src', 'https://d1cuyjsrcm0gby.cloudfront.net/' + data.features[0].properties.key + '/thumb-320.jpg');
+                        mapillaryAttributionP.style.display = 'block';
                     }
                 })
                 .error(function(data, status) {
@@ -720,7 +729,7 @@
 
             // Mapillary Image in popup
             if (WebConfig.mapillary.enabled) {
-                str += '<img id="mapillaryimg" style="width:320px; display:block; margin-bottom:12px;"/>';
+                str += getMapillaryHtmlString();
                 getMapillaryImg(latlng);
             }
 
@@ -745,7 +754,7 @@
 
             // Mapillary Image in popup
             if (WebConfig.mapillary.enabled) {
-                str += '<img id="mapillaryimg" style="width:320px; display:block; margin-bottom:12px;"/>';
+                str += getMapillaryHtmlString();
                 getMapillaryImg(latlng);
             }
 

--- a/web/app/scripts/views/map/layers-controller.js
+++ b/web/app/scripts/views/map/layers-controller.js
@@ -574,7 +574,7 @@
 
                 new L.popup(popupOptions)
                     .setLatLng(e.latlng)
-                    .setContent(ctl.buildRecordPopup(e.data, popupParams))
+                    .setContent(ctl.buildRecordPopup(e.data, popupParams, e.latlng))
                     .openOn(ctl.map);
 
                 $compile($('#record-popup'))($scope);
@@ -733,7 +733,7 @@
          * @param {Object} UTFGrid interactivity data from interaction event object
          * @returns {String} HTML snippet for a Leaflet popup.
          */
-        ctl.buildRecordPopup = function(record, popupParams) {
+        ctl.buildRecordPopup = function(record, popupParams, latlng) {
             // add header with record date constant field
             /* jshint camelcase: false */
             // DateTimes come back from Windshaft without tz information, but they're all UTC
@@ -742,6 +742,12 @@
             str += '<div><h5>' + popupParams.label + ' ' + detailsLabel +
                 '</h5><h3>' + occurredStr + '</h3>';
             /* jshint camelcase: true */
+
+            // Mapillary Image in popup
+            if (WebConfig.mapillary.enabled) {
+                str += '<img id="mapillaryimg" style="width:320px; display:block; margin-bottom:12px;"/>';
+                getMapillaryImg(latlng);
+            }
 
             // The ng-click here refers to a function which sits on the map-controller's scope
             str += '<a ng-click="showDetailsModal(\'' + record.uuid + '\')">';

--- a/web/app/styles/partials/_map.scss
+++ b/web/app/styles/partials/_map.scss
@@ -70,3 +70,14 @@
         height: 24px;
     }
 }
+
+#mapillaryimg {
+    width: 320px;
+    display: block;
+}
+
+#mapillaryattributionp {
+    display: none;
+    font-size: 8pt;
+    margin-bottom: 12px;
+}


### PR DESCRIPTION
## Overview

Add Mapillary street-view image, if configured and available, to record popup and blackspot popup.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1680" alt="screen shot 2018-08-17 at 1 53 45 pm" src="https://user-images.githubusercontent.com/3959096/44281227-0ff4ef00-a225-11e8-9c52-defd83abedda.png">


<img width="1680" alt="screen shot 2018-08-17 at 1 54 07 pm" src="https://user-images.githubusercontent.com/3959096/44281236-16836680-a225-11e8-9a6f-4088c5d1f765.png">


## Testing Instructions

 * Copy the new `all.example` to `all`.
 * Get a Mapillary client ID. Make an account and create an app or Slack me to get mine to test. 
 * Change the `web_js_mapillary` variable in `all` to the client ID.
 * Re-provision the `app` VM.
 * Observe that the app does not show Mapillary images on any of the blackspot and record popups. 
 * Change the `web_js_mapillary` variable in `all` to `true`.
 * Re-provision the `app` VM.
 * Observe that the app does show Mapillary images on some of the blackspot and record popups. Clicking on the blackspot area will show you images close to the point clicked, so try a bunch of clicks on the same blackspot to find an image.

Closes [#155397050](https://www.pivotaltracker.com/story/show/155397050)