### PR TITLE
Upgrade to Django 1.11 #158323812

### DIFF
--- a/app/Dockerfile.base
+++ b/app/Dockerfile.base
@@ -1,9 +1,17 @@
-FROM quay.io/azavea/django:1.8-python2.7-slim
+FROM quay.io/azavea/django:1.11-python2.7-slim
 
 # N.B. This will not work for docker versions above 1.10.x; Docker 1.11 and above contain
 # multiple binaries in a tarball; if we upgrade Docker to the 1.11 branch or beyond then
 # the RUN command below will need to be updated.
 ENV DOCKER_VERSION 1.10.3
+
+# install libgdal1-dev
+RUN echo "deb http://deb.debian.org/debian jessie main contrib non-free " > /etc/apt/sources.list.d/jessie.list
+RUN set -ex && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libgdal1-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /etc/apt/sources.list.d/jessie.list
 
 # install dependencies for django-oidc
 RUN apt-get update && apt-get install -y \
@@ -16,8 +24,7 @@ RUN apt-get update && apt-get install -y \
 # install dependencies for generate_training_input script
 RUN apt-get update && apt-get install -y \
     libgeos-dev \
-    libspatialindex-dev \
-    libgdal1-dev
+    libspatialindex-dev
 
 # Dependencies for installing docker locally
 RUN apt-get update && apt-get install -y \
@@ -29,7 +36,7 @@ WORKDIR /opt/app
 
 COPY . /opt/app
 
-RUN pip install --no-cache-dir --process-dependency-links --allow-external djsonb -r requirements.txt
+RUN pip install --no-cache-dir --process-dependency-links djsonb -r requirements.txt
 
 EXPOSE 4000
 

--- a/app/Dockerfile.development
+++ b/app/Dockerfile.development
@@ -1,6 +1,6 @@
 FROM driver-app:latest
 
-RUN pip install --no-cache-dir --process-dependency-links --allow-external djsonb -r dev-requirements.txt --src /opt
+RUN pip install --no-cache-dir --process-dependency-links djsonb -r dev-requirements.txt --src /opt
 EXPOSE 8000
 
 CMD ["driver.wsgi", "-w1", "-b:4000", "--reload", "-kgevent"]

--- a/app/black_spots/serializers.py
+++ b/app/black_spots/serializers.py
@@ -12,6 +12,7 @@ class BlackSpotSerializer(ModelSerializer):
     class Meta:
         model = BlackSpot
         read_only_fields = ('uuid',)
+        fields = '__all__'
 
 
 class BlackSpotSetSerializer(ModelSerializer):
@@ -19,12 +20,14 @@ class BlackSpotSetSerializer(ModelSerializer):
     class Meta:
         model = BlackSpotSet
         read_only_fields = ('uuid',)
+        fields = '__all__'
 
 
 class BlackSpotConfigSerializer(ModelSerializer):
     """Serializer for singleton BlackSpotConfig object"""
     class Meta:
         model = BlackSpotConfig
+        fields = '__all__'
 
 
 class EnforcerAssignmentSerializer(ModelSerializer):

--- a/app/data/filters.py
+++ b/app/data/filters.py
@@ -5,8 +5,8 @@ from models import RecordAuditLogEntry, RecordDuplicate
 
 class RecordAuditLogFilter(django_filters.FilterSet):
     """Allow filtering audit log entries by user, record, min_date, max_date"""
-    min_date = django_filters.IsoDateTimeFilter(name="date", lookup_type='gte')
-    max_date = django_filters.IsoDateTimeFilter(name="date", lookup_type='lte')
+    min_date = django_filters.IsoDateTimeFilter(name="date", lookup_expr='gte')
+    max_date = django_filters.IsoDateTimeFilter(name="date", lookup_expr='lte')
     action = django_filters.ChoiceFilter(choices=RecordAuditLogEntry.ActionTypes.choices)
 
     class Meta:

--- a/app/data/filters.py
+++ b/app/data/filters.py
@@ -15,7 +15,7 @@ class RecordAuditLogFilter(django_filters.FilterSet):
 
 
 class RecordDuplicateFilter(django_filters.FilterSet):
-    record_type = django_filters.MethodFilter(name='record_type', action='filter_record_type')
+    record_type = django_filters.Filter(field_name='record_type', method='filter_record_type')
 
     def filter_record_type(self, queryset, value):
         """ Filter duplicates by the record type of their first record

--- a/app/data/serializers.py
+++ b/app/data/serializers.py
@@ -82,6 +82,7 @@ class RecordDuplicateSerializer(ModelSerializer):
 
     class Meta:
         model = RecordDuplicate
+        fields = '__all__'
 
 
 class RecordCostConfigSerializer(ModelSerializer):

--- a/app/dev-requirements.txt
+++ b/app/dev-requirements.txt
@@ -1,3 +1,2 @@
 ipython==3.0.0
 ipdb==0.8.1
--e git+https://github.com/azavea/ashlar.git@legacy#egg=ashlar

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = (
 
     'django_extensions',
     'djangooidc',
+    'django_filters',
 
     'ashlar',
 

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -241,7 +241,10 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
-    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend','rest_framework.filters.OrderingFilter'),
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+        'rest_framework.filters.OrderingFilter',
+    ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 10,
 }

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = (
 
     'ashlar',
 
+    'driver',
     'driver_auth',
     'data',
     'user_filters',

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = (
     'django_extensions',
     'djangooidc',
     'django_filters',
+    'rest_framework_gis',
 
     'ashlar',
 

--- a/app/driver_auth/apps.py
+++ b/app/driver_auth/apps.py
@@ -3,14 +3,13 @@ Override app config to register signal for setting default user group on user cr
 """
 from django.apps import AppConfig
 from django.conf import settings
-from django.db.models.signals import post_save
-from django.contrib.auth.models import Group, User
 
 READ_GROUP = settings.DRIVER_GROUPS['READ_ONLY']
 
 def add_to_default_group(sender, **kwargs):
     user = kwargs["instance"]
     if kwargs["created"]:
+        from django.contrib.auth.models import Group
         group = Group.objects.get(name=READ_GROUP)
         user.groups.add(group)
 
@@ -19,4 +18,6 @@ class DriverConfig(AppConfig):
     name = 'driver_auth'
     verbose_name = 'Authentication and Permissions for DRIVER'
     def ready(self):
+        from django.contrib.auth.models import User
+        from django.db.models.signals import post_save
         post_save.connect(add_to_default_group, sender=User)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
 djangorestframework==3.1.3
 djangorestframework-gis==0.9.1
-django-filter==0.11.0
+django-filter==1.0.2
 django-extensions==1.6.1
 django-cors-headers==2.4.0
 django-storages==1.4.1

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,7 +2,7 @@ djangorestframework==3.1.3
 djangorestframework-gis==0.9.1
 django-filter==0.11.0
 django-extensions==1.6.1
-django-cors-headers==1.0.0
+django-cors-headers==2.4.0
 django-storages==1.4.1
 oauth2client==2.0.1
 git+https://github.com/rohe/pyoidc.git@c9880cac2e5435f4197bda4364ace82206795f92#egg=oic

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
-djangorestframework==3.1.3
-djangorestframework-gis==0.9.1
-django-filter==1.0.2
+djangorestframework==3.8.0
+djangorestframework-gis==0.13.0
+django-filter==1.1.0
 django-extensions==1.6.1
 django-cors-headers==2.4.0
 django-storages==1.4.1
@@ -15,7 +15,7 @@ python-dateutil==2.4.2
 pytz==2015.7
 mock==1.3.0
 djangorestframework-csv==1.4.1
-git+https://github.com/azavea/ashlar.git@legacy#egg=ashlar
+git+https://github.com/azavea/ashlar.git@develop#egg=ashlar
 # Dependencies for generate_training_input script
 argparse==1.2.1
 Fiona==1.6.3

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,6 @@
 djangorestframework==3.8.0
+# coreapi is an optional requirement for djangorestframework
+coreapi==2.3.3
 djangorestframework-gis==0.13.0
 django-filter==1.1.0
 django-extensions==1.6.1

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -8,9 +8,7 @@ django-cors-headers==2.4.0
 django-storages==1.4.1
 oauth2client==2.0.1
 git+https://github.com/rohe/pyoidc.git@c9880cac2e5435f4197bda4364ace82206795f92#egg=oic
-# TODO: revert to marcanpilami django-oidc when https://github.com/rohe/pyoidc/issues/161 fixed
-git+https://github.com/flibbertigibbet/django-oidc.git
-#git+https://github.com/marcanpilami/django-oidc.git
+git+https://github.com/alexsdutton/django-oidc/@py3-dj1.10#egg=django-oidc
 celery[redis]==3.1.19
 django-redis==4.2.0
 python-dateutil==2.4.2

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -7,7 +7,7 @@ django-extensions==1.6.1
 django-cors-headers==2.4.0
 django-storages==1.4.1
 oauth2client==2.0.1
-git+https://github.com/rohe/pyoidc.git@c9880cac2e5435f4197bda4364ace82206795f92#egg=oic
+oic==0.14.0
 git+https://github.com/alexsdutton/django-oidc/@py3-dj1.10#egg=django-oidc
 celery[redis]==3.1.19
 django-redis==4.2.0

--- a/app/user_filters/serializers.py
+++ b/app/user_filters/serializers.py
@@ -14,3 +14,4 @@ class SavedFilterSerializer(ModelSerializer):
     class Meta:
         model = SavedFilter
         read_only_fields = ('uuid', 'owner')
+        fields = '__all__'


### PR DESCRIPTION
## Overview

Upgrade Django from 1.8.6 to 1.11.15 (LTS). 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

This consists mostly of dependency upgrades which were required as a result of upgrading Django. There were also a variety of code changes that were necessary as a result of these upgrades, many of which relate to filters and serialization.

This PR for upgrading Ashlar to Django 1.11 contains many of the same changes: https://github.com/azavea/ashlar/pull/84/files

## Testing Instructions

First make sure `ashlar` is checked out to latest `develop`.

* `vagrant destroy app`
* `vagrant up --provision app`
* `vagrant ssh app`
* `sudo docker exec -it driver-app bash`
* `./manage.py version` (should be 1.11.15)
* `./manage.py test` (all tests should pass)
* Manually test app

Closes #158323812

