### PR TITLE
Add latlng input as Leaflet control

### DIFF
--- a/web/app/scripts/state/zoom-to-address-directive.js
+++ b/web/app/scripts/state/zoom-to-address-directive.js
@@ -1,0 +1,56 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function zoomToAddress() {
+        var module = {
+            restrict: 'A',
+            scope: false,
+            replace: false,
+            controller: '',
+            require: 'leafletMap',
+            link: link
+        };
+
+        return module;
+
+        function link(scope, element, attrs, controller) {
+            controller.getMap().then(function(map) {
+                L.Control.LatLngInput = L.Control.extend({
+                    onAdd: function() {
+                        var latlngDiv = L.DomUtil.create('div');
+                        var latlngInput = L.DomUtil.create('input', 'latlng-input', latlngDiv);
+                        var latlngButton = L.DomUtil.create('button', 'latlng-button', latlngDiv);
+                        L.DomUtil.create('span', 'glyphicon glyphicon-search', latlngButton);
+
+                        latlngInput.id = 'latlng-input';
+                        latlngInput.placeholder = 'Zoom to';
+                        latlngInput.type = 'text';
+
+                        L.DomEvent.addListener(latlngButton, 'click', function() {
+                            var latlngInput = document.getElementById('latlng-input').value;
+                            var latlng = latlngInput.split(',');
+                            if (latlng.length !== 2 || isNaN(latlng[0]) || isNaN(latlng[1])) {
+                                return;
+                            }
+                            map.setZoom(16);
+                            map.panTo(new L.LatLng(parseFloat(latlng[0]), parseFloat(latlng[1])));
+                        });
+
+                        return latlngDiv;
+                    }
+                });
+
+                L.control.latlngInput = function(opts) {
+                    return new L.Control.LatLngInput(opts);
+                };
+            
+                L.control.latlngInput({ position: 'topleft' }).addTo(map);
+            });
+        }
+    }
+
+    angular.module('driver.state')
+        .directive('zoomToAddress', zoomToAddress);
+
+})();

--- a/web/app/scripts/views/map/map-partial.html
+++ b/web/app/scripts/views/map/map-partial.html
@@ -1,5 +1,5 @@
 <main class="map-view">
-    <div class="records-map" leaflet-map driver-map-layers zoom-to-boundary></div>
+    <div class="records-map" leaflet-map driver-map-layers zoom-to-boundary zoom-to-address></div>
     <div class="tools">
         <driver-charts stepwise="ctl.stepwise"
                        min-date="ctl.minDate"

--- a/web/app/styles/partials/_map.scss
+++ b/web/app/styles/partials/_map.scss
@@ -81,3 +81,10 @@
     font-size: 8pt;
     margin-bottom: 12px;
 }
+
+.latlng-button {
+    height: 24px;
+    padding: 2px 5px 2px 5px;
+    border-radius: 4px;
+    margin-left: 4px;
+}


### PR DESCRIPTION
## Overview

Add ability to enter comma separated latlng values and zoom to it.

## Testing Instructions

 * Get a comma separated latlng (`39.961380,-75.154123` is for Azavea's office building) and paste in the latlng input below the zoom controls. Hit the search button and confirm that it works. 

Closes [#155396644](https://www.pivotaltracker.com/story/show/155396644)

