### PR TITLE
Fix deploying to staging #158669739

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
   - secure: wc2LNYrPX8OfaytX9iQi4Wp9CBdMzBEt2PGiJIzcxALl8CS/PnP4/efnSuuAW49zaKvtSZ2kwqXObH0E0PamcCufkR3QCbnG+pxuq+Zxu11152inz3FO8UiaYksmzBcO3tidGuehWFPr+ULinlbT3RYaItXmPoPTAfO5l/0r1F4=
   - secure: hZNrcEi/XfMpdjegA9AAFm/XDM6+aP+NV7NfQAo4/P5IN2rBz20TEHcLmtDs0YODPnT0mneoqWaEM1V55VFZIp4FhDJetOA3nk+MhKpo6jAy+E5au+jJ8R5yWkwGAosedBBEYhU5T6iF073SpYcjfyun4fgC58o7yuYNoBISWVg=
   - secure: fcgtvICGfCMqxgbF2A0i+FCImh/vNC5lTyBvwztPLShhIg0z/SxE1aDcHRGEFu5hkqw04B4kQN17XPpcRS2CKgne/Fv7n+k/7mPiVImTVk oWL/TZHPplmYFm9szQKR5RWnAVKcejjC4PK6E1w9jgwK+7U6usnPHF9BcvPpKOYN8=
-language: bash
+language: python
+python: "2.7.15"
 services:
 - docker
 install:
@@ -27,7 +28,7 @@ install:
 script: ".travis/script.sh"
 before_deploy:
 - docker login -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io
-- sudo pip install ansible==2.6.3.0
+- pip install ansible==2.6.3.0
 - openssl aes-256-cbc -K "${encrypted_71b51a189c16_key}" -iv "${encrypted_71b51a189c16_iv}"
   -in deployment/driver.pem.enc -out deployment/driver.pem -d
 - export PATH="$PATH:$HOME/.rvm/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 script: ".travis/script.sh"
 before_deploy:
 - docker login -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io
-- sudo pip install ansible==2.0.0.2
+- sudo pip install ansible==2.6.3.0
 - openssl aes-256-cbc -K "${encrypted_71b51a189c16_key}" -iv "${encrypted_71b51a189c16_iv}"
   -in deployment/driver.pem.enc -out deployment/driver.pem -d
 - export PATH="$PATH:$HOME/.rvm/bin"


### PR DESCRIPTION
## Overview

This PR fixes deploying to staging when changes are made to develop.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

This PR contains two separate fixes to make `ansible-galaxy` able to fetch roles (see: https://github.com/WorldBank-Transport/DRIVER/blob/master/.travis/deploy_staging.sh#L32):
1. Upgrade Ansible to a newer version
1. Have `ansible-galaxy` use a newer version of Python to get around SNI issues related to Python 2.7.6

Once `ansible-galaxy` was fixed, there was a separate issue provisioning the staging instance itself, specifically around installing the correct `linux-headers` package for Postgresql. That issue had to be resolved via manual intervention, ssh-ing into the machine.

## Testing Instructions

Verify the build has passed

Closes #158669739

