### PR TITLE
Upgrade django-extensions to fix shell_plus

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,7 +4,7 @@ djangorestframework==3.8.0
 coreapi==2.3.3
 djangorestframework-gis==0.13.0
 django-filter==1.1.0
-django-extensions==1.6.1
+django-extensions==2.1.2
 django-cors-headers==2.4.0
 django-storages==1.4.1
 oauth2client==2.0.1


### PR DESCRIPTION
## Overview

Upgrade `django-extensions` to fix `shell_plus` management command

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

This should be the last bit of fallout from the Django 1.11 upgrade.

## Testing Instructions

* `vagrant provision app`
* `sudo service driver-app restart` from within the `app` VM

Closes #160258442

