### PR TITLE
Add Django Debug Toolbar

### DIFF
--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -74,6 +74,20 @@ MIDDLEWARE_CLASSES = (
     'corsheaders.middleware.CorsMiddleware',
 )
 
+if DEBUG:
+    import debug_toolbar
+    # Perform set up for Django Debug Toolbar
+    INSTALLED_APPS += (
+        'debug_toolbar',
+    )
+    # Prepend the Debug Toolbar middleware class to the begining of the list
+    MIDDLEWARE_CLASSES = (
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ) + MIDDLEWARE_CLASSES
+    # Show toolbar in local dev
+    INTERNAL_IPS = ["127.0.0.1"]
+
+
 ROOT_URLCONF = 'driver.urls'
 
 TEMPLATES = [

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -75,7 +75,6 @@ MIDDLEWARE_CLASSES = (
 )
 
 if DEBUG:
-    import debug_toolbar
     # Perform set up for Django Debug Toolbar
     INSTALLED_APPS += (
         'debug_toolbar',

--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -85,7 +85,12 @@ if DEBUG:
         'debug_toolbar.middleware.DebugToolbarMiddleware',
     ) + MIDDLEWARE_CLASSES
     # Show toolbar in local dev
-    INTERNAL_IPS = ["127.0.0.1"]
+    DEBUG_TOOLBAR_CONFIG = {
+        # Since REMOTE_HOST gets overloaded by routing through Docker and Nginx, we can't rely on
+        # it like DDT normally does internally.
+        # Until an alternative is available, we have to trust DEBUG=True is safety enough
+        'SHOW_TOOLBAR_CALLBACK': lambda(request): True
+    }
 
 
 ROOT_URLCONF = 'driver.urls'

--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -46,3 +46,10 @@ urlpatterns = [
 
 # Allow login to the browseable API
 urlpatterns.append(url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')))
+
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns

--- a/app/driver/urls.py
+++ b/app/driver/urls.py
@@ -51,5 +51,5 @@ urlpatterns.append(url(r'^api-auth/', include('rest_framework.urls', namespace='
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns = [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        url(r'^api/__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,6 +3,7 @@ djangorestframework==3.8.0
 # authentication
 coreapi==2.3.3
 djangorestframework-gis==0.13.0
+django-debug-toolbar==1.9.1
 django-filter==1.1.0
 django-extensions==1.6.1
 django-cors-headers==2.4.0


### PR DESCRIPTION
## Overview
Adds Django Debug Toolbar to DRIVER, which can be very useful in investigating endpoint performance and finding potential optimizations.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
<img width="202" alt="screen shot 2018-09-05 at 3 33 16 pm" src="https://user-images.githubusercontent.com/1032849/45116586-31a90e00-b121-11e8-96b7-0009998611f5.png">
<img width="824" alt="screen shot 2018-09-05 at 3 33 25 pm" src="https://user-images.githubusercontent.com/1032849/45116587-31a90e00-b121-11e8-87a5-290e8184aec9.png">
<img width="846" alt="screen shot 2018-09-05 at 3 33 56 pm" src="https://user-images.githubusercontent.com/1032849/45116588-31a90e00-b121-11e8-8511-9a0fae823762.png">
<img width="847" alt="screen shot 2018-09-05 at 3 34 05 pm" src="https://user-images.githubusercontent.com/1032849/45116589-31a90e00-b121-11e8-9883-c7906742f3e0.png">
<img width="373" alt="screen shot 2018-09-05 at 3 34 57 pm" src="https://user-images.githubusercontent.com/1032849/45116607-44234780-b121-11e8-9a82-ae32e84ce1c9.png">


### Notes
- Because `REMOTE_ADDR` appears to be replaced with the IP address of the Docker interface, we're unable to use Django Debug Toolbar's default `show_toolbar()` check (Which verifies that `settings.DEBUG` is enabled and that [the request's `REMOTE_ADDR` is in `settings.INTERNAL_IPS`)](https://github.com/jazzband/django-debug-toolbar/blob/155044c90a62bb3602b3bc7471767a450613ca4c/debug_toolbar/middleware.py#L23-L30). It may be possible to augment this check another way, but this removes the check when `settings.DEBUG` is enabled. We should make absolutely sure that `settings.DEBUG` is never enabled in a publicly accessible environment.

## Testing Instructions
- Navigate to the Django API list - http://localhost:7000/api/
- Load different API endpoints from the list
  - The Django Debug Toolbar should load and be accessible 

Closes [#160149072](https://www.pivotaltracker.com/story/show/160149072)

