### PR TITLE
Fix certbot to stop and restart nginx before and after renew

### DIFF
--- a/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
@@ -48,7 +48,7 @@
 # Copied from old azavea.letsencrypt role
 - name: Install cronjob for cert renewal
   cron:
-    job: "certbot renew"
+    job: "certbot renew --pre-hook 'service nginx stop' --post-hook 'service nginx start'"
     day: "1,11,21"
     hour: 4
     minute: 30


### PR DESCRIPTION
## Overview

Certbot isn't autorenewing because nginx sits on port 80, which it needs to do the renew. Certbot has inbuilt functionality for pre and post hooks and this PR uses those to stop nginx before renew and start after.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

* When certs aren't up for renewal, no hooks run, so nginx will be up except for when the certs are actually being renewed. This can actually be tested on any dev instance. 

## Testing Instructions

 * I'm not sure there's a way to test this without actually having an instance that needs a renew. But here's a screenshot of it working on the Vietnam instance. 

<img width="848" alt="screen shot 2018-09-06 at 9 22 24 am" src="https://user-images.githubusercontent.com/3959096/45160171-c873da00-b1b6-11e8-98a8-7eb695324a9f.png">

Closes [#156539687](https://www.pivotaltracker.com/story/show/156539687)