### PR TITLE
Restart driver-app service only after we have the new image

### DIFF
--- a/deployment/ansible/roles/driver.app/handlers/main.yml
+++ b/deployment/ansible/roles/driver.app/handlers/main.yml
@@ -1,3 +1,0 @@
----
-- name: Restart driver-app
-  service: name=driver-app state=restarted

--- a/deployment/ansible/roles/driver.app/tasks/main.yml
+++ b/deployment/ansible/roles/driver.app/tasks/main.yml
@@ -32,16 +32,12 @@
 - name: Pull application Docker image
   command: /usr/bin/docker pull {{ docker_repository }}driver-app:{{ docker_image_tag }}
   when: staging or production
-  notify:
-    - Restart driver-app
 
 - name: Configure Driver application service definition
   template: src=upstart-app.conf.j2 dest=/etc/init/driver-app.conf
-  notify:
-    - Restart driver-app
 
-- name: Ensure Driver application is running
-  service: name=driver-app state=started
+- name: Restart Driver application
+  service: name=driver-app state=restarted
 
 - name: Set up monit monitoring of driver-app container
   template: src=monit-driver-app.cfg.j2 dest=/etc/monit/conf.d/driver-app.cfg

--- a/deployment/ansible/roles/driver.celery/handlers/main.yml
+++ b/deployment/ansible/roles/driver.celery/handlers/main.yml
@@ -1,3 +1,0 @@
----
-- name: Restart driver-celery
-  service: name=driver-celery state=restarted

--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -18,16 +18,12 @@
 - name: Pull application Docker image
   command: /usr/bin/docker pull {{ docker_repository }}driver-app:{{ docker_image_tag}}
   when: staging or production
-  notify:
-    - Restart driver-celery
 
 - name: Configure Driver celery service definition
   template: src=upstart-celery.conf.j2 dest=/etc/init/driver-celery.conf
-  notify:
-    - Restart driver-celery
 
-- name: Ensure Driver celery service is running
-  service: name=driver-celery state=started
+- name: Restart Driver celery service
+  service: name=driver-celery state=restarted
 
 - name: Set up monit monitoring of driver-celery container
   template: src=monit-driver-celery.cfg.j2 dest=/etc/monit/conf.d/driver-celery.cfg


### PR DESCRIPTION
## Overview

This changes provisioning so that instead of restarting the service
after all the tasks have run via the handler, we now do so explicitly in
a dedicated task _after_ we pull/build the new image and _before_ we use
the app container.

Previously, we were running into issues where we would run migrations
against the previous version of the container.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

To reproduce the issue on `develop`:
* Add a Python dependency to `app/requirements.txt` (eg. `itsdangerous==0.24`)
* `vagrant provision app`
* `vagrant ssh app`
* `sudo docker exec -it driver-app bash`
* `pip freeze | grep its` (returns nothing)

Now `git stash`, check out this branch, `git stash pop` to add your new dep back in and repeat the steps. You should see that the new dependency is now listed.

