### PR TITLE
Tweak README language and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,53 +18,65 @@ DRIVER - Data for Road Incident Visualization, Evaluation, and Reporting
 
 1. Install `vagrant-hostmanager` plugin via:
 
-    ```
+    ```bash
     vagrant plugin install vagrant-hostmanager
     ```
 
 1. Create `gradle/data/driver.keystore`
 
-    To run in development without support for JAR file building, `touch gradle/data/driver.keystore`. (If you just want to install the DRIVER web interface, do this. You can add Android integration later.)
+    - To run in development without support for JAR file building:
+      ```bash
+      touch gradle/data/driver.keystore
+      ```
+      (If you just want to install the DRIVER web interface, do this. You can add Android integration later.)
 
-    To build schema model JAR files for the Android app, copy the signing keystore to `gradle/data/driver.keystore`
+    - To build schema model JAR files for the Android app, copy the signing keystore to `gradle/data/driver.keystore`
     and set the password for the keystore under `keystore_password` in `deployment/ansible/group_vars/all`.
 
-1. Copy `deployment/ansible/group_vars/all.example` to `deployment/ansible/group_vars/all`
+1. Copy the example `group_vars` file:
+    ```bash
+    cp deployment/ansible/group_vars/all.example deployment/ansible/group_vars/all
+    ```
+
+1. (Optional) To enable geocoding, [set up Pickpoint in `group_vars/all`](#pickpoint)
 
 1. Install [NFS](https://en.wikipedia.org/wiki/Network_File_System). On Debian/Ubuntu, run:
 
-    ```
+    ```bash
     sudo apt-get install nfs-common nfs-kernel-server
     ```
 
 1. Clone the [Ashlar](https://github.com/azavea/ashlar) project such that it is a sibling of DRIVER (Ashlar is needed for generating dynamic schemas used by DRIVER).
 
     An example setup might be as follows:
-    ```
+    ```bash
     /home/username/
       git
         DRIVER
         ashlar
     ```
 
-1. Run `vagrant up`
+1. Start the Vagrant VM
+    ```bash
+    vagrant up
+    ```
 
-    If you run into issues provisioning the VMs or forget a step, try re-provisioning via `vagrant provision <vm-name>` as needed.
+    If you run into issues provisioning the VMs or forget a step, try re-provisioning as needed:
+    ```bash
+    vagrant provision <vm-name>
+    ```
 
 ### Pickpoint
 
-Obtain a pickpoint api key from https://pickpoint.io.
-
-Copy `deployment/ansible/group_vars/all.example` to `deployment/ansible/group_vars/all`
-and add the API key for pickpoint under `web_js_nominatim_key`.
+Pickpoint is a geocoding service used by DRIVER to obtain lat/lon coordinates from input addresses. DRIVER can work without Pickpoint configured, but to enable geocoding, obtain a pickpoint API key from https://pickpoint.io and enter the key in `deployment/ansible/group_vars/all` under `web_js_nominatim_key`.
 
 ### Running & Configuration
 
-The app runs on localhost on port 7000. The schema editor is available at /editor/.
+The app is available on http://localhost:7000/, and the schema editor at http://localhost:7000/editor/.
 
-A default django superuser will be created, but only on a development provision:
-  - username: `admin`
-  - password: `admin`
+In development environments a default Django superuser will be created for you:
+  - Username: `admin`
+  - Password: `admin`
 
 ### Google OAuth
 
@@ -80,33 +92,34 @@ http://localhost:7000
 
 http://localhost:7000/openid/callback/login/
 
-Once you have the client ID and client secret, add those values to `deployment/ansible/group_vars/all` and reprovision the `app` VM (`vagrant provision app`) as needed.
+Once you have the client ID and client secret, add those values to `deployment/ansible/group_vars/all` and reprovision the `app` VM  as needed:
+```bash
+vagrant provision app
+```
 
 ### Frontend
-
-For frontend development, ssh into the app vm with `vagrant ssh app`.
-
-Then, the Angular schema editor is located at: `/opt/schema_editor`
-The application Angular frontend is located at: `/opt/web`.
-
 Both Angular apps can be run in development mode via:
-```
+```bash
 ./scripts/grunt.sh {editor,web} serve
 ```
-
-The frontend app will be available on port 7002 and the schema editor will be available on port
-7001. Both will reload automatically as changes are made.
+The frontend app will be available on port 7002 at http://localhost:7002 and the schema editor will be available on port
+7001 at http://localhost:7001. Both will reload automatically as changes are made.
 
 To make requests to a Django runserver directly (for example, to perform interactive debugging in
-the request-response cycle), run `./scripts/manage.sh runserver 0.0.0.0:8000`. You should then be
-able to access the Django runserver on port 3001 of the `app` VM.
+the request-response cycle), run:
+```bash
+./scripts/manage.sh runserver 0.0.0.0:8000
+```
+You should then be able to access the Django runserver on port 3001 of the `app` VM at http://localhost:3001.
+
+Front end files are mounted inside the `app` Vagrant VM at `/opt/schema_editor` for the Angular editor and `/opt/web` for the Angular interface.
 
 #### Updating existing translation files
-New angular translation tokens should be added to i18n/exclaim.json with a value of "!<english>".
+New Angular translation tokens should be added to i18n/exclaim.json with a value of "!<english>".
 The English translation (en-us.json) is automatically built from exclaim.json. New tokens are also
 propagated to other translations via a grunt task:
 
-```
+```bash
 ./scripts/grunt.sh web translate
 ```
 
@@ -116,25 +129,25 @@ To enable the language to be selected via the language picker, add an item to th
 `deployment/ansible/group_vars/all`. Setting `rtl` to true will enable right-to-left CSS changes.
 
 
-## Docker
-
-As a shortcut to building the Docker container images contained within the `app`
-virtual machine, use the `Makefile` at the root of the project:
-
+### Docker
+To update the Docker container images to reflect environment changes (Such as changed Python packages), provision the `app` VM:
 ```bash
-export DOCKER_HOST=tcp://127.0.0.1:2375
-make {all,app,editor,web}
+vagrant provision app
 ```
 
-This will make use of a Docker client installed on the virtual machine host,
-telling it to communicate with the Docker daemon on the `app` virtual machine.
+### Testing
+
+#### Javascript
+To run the Javascript automated tests, use:
+```bash
+./scripts/grunt.sh web test
+```
 
 ## Testing Data
 
 ### Boundaries
 
-To load boundaries, upload the `regions.zip` and `states.zip` files to Ashlar.
-Ashlar runs on localhost:7001. For each file, first upload the file, then select
+To load boundaries, upload the `regions.zip` and `states.zip` files to the schema editor in http://localhost:7000/editor/. For each file, first upload the file, then select
 `name` as the display field, then hit save. Either refresh the page or
 navigate somewhere else in between any two uploads.
 
@@ -150,31 +163,43 @@ Then open the network tab in web developer tools and reload the page. Inspect th
 from an API request and pull out the value of the `Authorization` header, for example
 `Token f1acac96cc79c4822e9010d23ab425231d580875`.
 
-Run `python scripts/load_incidents_v3.py --authz 'Token YOUR_AUTH_TOKEN' /path/to/directory_containing_incident_csvs`.
+Using the API token, run:
+```bash
+python scripts/load_incidents_v3.py --authz 'Token <YOUR_AUTH_TOKEN>' /path/to/directory_containing_incident_csvs
+```
 Note that the import process will take roughly two hours for the full data set; you can cut down the
 number of records with `head` on the individual CSVs.
 
-To load mock black spots, run `python scripts/load_black_spots.py --authz 'Token YOUR_AUTH_TOKEN' /path/to/black_spots.json`.
+To load mock black spots, run:
+```bash
+python scripts/load_black_spots.py --authz 'Token <YOUR_AUTH_TOKEN>' /path/to/black_spots.json
+```
 Mock black spot data is available in `scripts/sample_data/black_spots.json`.
 
-To load mock interventions, run `python scripts/load_interventions.py --authz 'Token YOUR_AUTH_TOKEN' /path/to/interventions_sample_pts.geojson`.
+To load mock interventions, run:
+```bash
+python scripts/load_interventions.py --authz 'Token <YOUR_AUTH_TOKEN>' /path/to/interventions_sample_pts.geojson
+```
 Mock intervention data is available in `scripts/sample_data/interventions_sample_pts.json`.
 
-To generate black spot and load forecast training inputs, run `python scripts/generate_training_input.py /path/to/roads.shp /path/to/records.csv`.
+To generate black spot and load forecast training inputs, run:
+```bash
+python scripts/generate_training_input.py /path/to/roads.shp /path/to/records.csv
+```
 
-More information on the requirements for loading data can be found in the [`scripts`
-directory](./scripts/README/md).
+More information on the requirements for loading data can be found in the [`scripts/`
+directory](./scripts/README.md).
 
 ### Costs
 
 You can't request records with associated costs successfully until you configure some costs.
-To do this, navigate to your editor (by default on `localhost:7001`), select "Incident" from
+To do this, navigate to your editor (by default on http://localhost:7000/editor/), select "Incident" from
 record types in the menu on the left. (If there are multiple record types named "Incident", delete all but one.) Select "Cost aggregation settings", then:
 
-- choose a currency prefix in "Cost Prefix" (e.g., `$`, but anything is fine)
+- Choose a currency prefix in "Cost Prefix" (e.g., `$`, but anything is fine)
 - Select "Incident Details" in "Related Content Type"
 - Choose "Severity" in "Field"
-- then decide how much money you think human lives, human physical security, and property are worth
+- Then decide how much money you think human lives, human physical security, and property are worth
 
 ## Production
 
@@ -184,12 +209,12 @@ TODO: Notes on creating a production superuser and adding a production OAuth2 ap
 ## Using OAuth2 / Getting tokens
 
 Get a token:
-```
+```bash
 curl -X POST -d "grant_type=password&username=<user_name>&password=<password>" -u"<client_id>:<client_secret>" http://localhost:7000/o/token/
 ```
 
 Returns:
-```
+```json
 {
     "access_token": "<your_access_token>",
     "token_type": "Bearer",
@@ -200,7 +225,7 @@ Returns:
 ```
 
 Making requests with a token:
-```
+```bash
 # GET
 curl -H "Authorization: Bearer <your_access_token>" http://localhost:7000:/api/record/
 curl -H "Authorization: Bearer <your_access_token>" http://localhost:7000:/api/recordschema/
@@ -209,44 +234,43 @@ curl -H "Authorization: Bearer <your_access_token>" http://localhost:7000:/api/r
 Restricted access (disabled in development to allow access to the browsable API):
 
 Add an additional `scope` parameter to token request:
-```
+```bash
 curl -X POST -d "grant_type=password&username=<user_name>&password=<password>&scope=read" -u"<client_id>:<client_secret>" http://localhost:7000/o/token/
 ```
 
 Now, this token will have read-only access to the API.
 
-
-## Testing
-
-### Javascript
-
-First, ssh into the app vm: `vagrant ssh app`
-
-Then, cd to the web dir and run the grunt tests: `cd /opt/web && grunt test`
-
 ## Releases
 
 Releases use a `github_changelog_generator` tool written in `ruby`.
 
-- make sure your `develop` is up-to-date
-- `git flow release start <your release version>`
-- `docker run -ti --rm -v ${PWD}:/changelog -w /changelog ruby:2.3 /bin/bash`
-- From the container, `gem install github_changelog_generator`
+- Make sure your `develop` is up-to-date
+- Start the Gitflow release:
+    ```bash
+    git flow release start <your release version>
+    ```
+-
+    ```bash
+    docker run -ti --rm -v ${PWD}:/changelog -w /changelog ruby:2.3 /bin/bash
+    ```
+- From the container:
+    ```bash
+    gem install github_changelog_generator
+    ```
 - Then, to generate the changelog since the last release:
-
-```bash
-$ export RELEASE_VERSION=<your release version>
-$ export LAST_RELEASE=<the most recent tag>
-$ export GITHUB_TOKEN=<your github personal access token>
-$ github_changelog_generator "WorldBank-Transport/DRIVER" \
-      --token ${GITHUB_TOKEN} \
-      --since-tag ${LAST_RELEASE} \
-      --future-release ${RELEASE_VERSION} \
-      --base CHANGELOG.md \
-      --no-issues \
-      --no-issues-wo-labels \
-      --no-author
-```
+    ```bash
+    $ export RELEASE_VERSION=<your release version>
+    $ export LAST_RELEASE=<the most recent tag>
+    $ export GITHUB_TOKEN=<your github personal access token>
+    $ github_changelog_generator "WorldBank-Transport/DRIVER" \
+        --token ${GITHUB_TOKEN} \
+        --since-tag ${LAST_RELEASE} \
+        --future-release ${RELEASE_VERSION} \
+        --base CHANGELOG.md \
+        --no-issues \
+        --no-issues-wo-labels \
+        --no-author
+    ```
 
 It's important to include the `since-tag` argument, since without it, the changelog generator
 will include everything that went into 1.0.0, which is a lot of stuff and not super meaningful,
@@ -254,19 +278,21 @@ since `1.0.0` is "what was there when we decided to start using semantic version
 Note: We've had some problems with the `since-tag` argument not being respected; if this happens,
 manually delete the duplicate entries and update the GitHub diff link.
 
-- include the CHANGELOG in your release branch
-- `git flow release publish <your release version>`
-- open a PR for your release
+- Include the CHANGELOG in your release branch
+- Git flow publish the release:
+    ```
+    git flow release publish <your release version>
+    ```
+- Open a PR for your release
 - Wait for a successful build and approval (from whom?), then:
-
-```bash
-$ git flow release finish <your release version>
-$ git checkout master
-$ git tag -f <your version>  # git-flow puts the tag on `develop`
-$ git push origin master
-$ git checkout develop
-$ git push origin develop
-$ git push [-s] --tags
-```
+    ```bash
+    $ git flow release finish <your release version>
+    $ git checkout master
+    $ git tag -f <your version>  # git-flow puts the tag on `develop`
+    $ git push origin master
+    $ git checkout develop
+    $ git push origin develop
+    $ git push [-s] --tags
+    ```
 
 :tada:

--- a/README.md
+++ b/README.md
@@ -146,20 +146,16 @@ To run the Javascript automated tests, use:
 ## Testing Data
 
 ### Boundaries
+Geographic boundaries are used to filter records to a defined area, such as a region or state. These boundaries are created by uploading shape files to the editor, http://localhost:7000/editor under "Add new geographies".
 
-To load boundaries, upload the `regions.zip` and `states.zip` files to the schema editor in http://localhost:7000/editor/. For each file, first upload the file, then select
-`name` as the display field, then hit save. Either refresh the page or
-navigate somewhere else in between any two uploads.
+For developers at Azavea, use the `regions.zip` and `states.zip` files available in the DRIVER project folder on the fileshare. For non-Azavea users, upload a zipped shapefile containing the boundaries of the jurisdictions where you plan to operate DRIVER. If you don't have such a shapefile, [Natural Earth](https://www.naturalearthdata.com/features/) is a good place to start."
+
+After uploading each the file, select `name` as the display field, then hit save. Either refresh the page or navigate somewhere else in between uploads.
 
 ### Records
+Record data can be populated from a CSV file that contains named columns for `"lat"`, `"lon"`, and `"record_date"`. For developers at Azavea, CSV files containing historical data can be downloaded from the `/data` folder of the project's directory in the fileshare, with names of the format `<city or agency>_traffic.csv`.
 
-A CSV of historical data can be downloaded from the project /data folder.
-Good files are `<city or agency>_traffic.csv`.
-
-Once the app has been built, this data can be loaded.
-
-You will first have to obtain an authorization header. Log in to the web application.
-Then open the network tab in web developer tools and reload the page. Inspect the request headers
+In order to import record data you will have to obtain an Authorization header and its API token. To do this, log in to the web application, then open the network tab in web developer tools and reload the page. Inspect the request headers
 from an API request and pull out the value of the `Authorization` header, for example
 `Token f1acac96cc79c4822e9010d23ab425231d580875`.
 
@@ -180,7 +176,7 @@ To load mock interventions, run:
 ```bash
 python scripts/load_interventions.py --authz 'Token <YOUR_AUTH_TOKEN>' /path/to/interventions_sample_pts.geojson
 ```
-Mock intervention data is available in `scripts/sample_data/interventions_sample_pts.json`.
+Mock intervention data is available in `scripts/sample_data/interventions_sample_pts.geojson`.
 
 To generate black spot and load forecast training inputs, run:
 ```bash


### PR DESCRIPTION
## Overview
Revises language in the project README to ideally make it more welcoming to new users. Main points:
- Removed instances of the "schema editor" being referred to by "Ashlar"
- Inline bash commands moved to a code block to be more easily copy-pasted
- References to services being on specific ports in development have been annotated or replaced with links
- Reorganize a couple blocks to flow more smoothly
- Various minor linguistic typographical tweaks

### Checklist

- [ ] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- The README should read smoothly and avoid unclear or confusing language

Closes [#160100787](https://www.pivotaltracker.com/story/show/160100787)

