### PR TITLE
Add address search functionality

### DIFF
--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -127,6 +127,7 @@
     <script src="scripts/state/boundarystate-service.js"></script>
     <script src="scripts/state/geographystate-service.js"></script>
     <script src="scripts/state/zoom-to-boundary-directive.js"></script>
+    <script src="scripts/state/zoom-to-address-directive.js"></script>
     <script src="scripts/state/languagestate-service.js"></script>
 
     <script src="scripts/nominatim/module.js"></script>


### PR DESCRIPTION
## Overview

Add address search functionality to latlng input on map.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

<img width="1208" alt="screen shot 2018-09-10 at 3 02 38 pm" src="https://user-images.githubusercontent.com/3959096/45318502-28e27e80-b50b-11e8-8e0b-5ca2447192fd.png">

## Testing Instructions

 * If you don't have Pickpoint set up yet, make an account, get a free API key, and add it to `web_js_nominatim_key` on your `all` file.
 * If you did this, reprovision app.
 * Run the app and try to enter an address or a location in the Philippines. Examples are "San Juan, Manila" or "64 Xavier Street". See that it zooms you in to that location. 
 * Verify that latlng inputs still work correctly. 

Closes [#155396666](https://www.pivotaltracker.com/story/show/155396666)