### PR TITLE
Show numeric filter for number and integer filters

### DIFF
--- a/web/app/scripts/filterbar/filterbar.html
+++ b/web/app/scripts/filterbar/filterbar.html
@@ -13,7 +13,7 @@
             <li text-search-field="__createdBy"></li>
         </ul>
         <ul class="nav navbar-nav" ng-repeat="(key, value) in filterbar.filterables">
-            <li ng-if="value.format === 'number'"
+            <li ng-if="(value.format === 'number') || (value.fieldType === 'integer') || (value.fieldType === 'number')"
                 numeric-range-field
                 label="key"
                 data="value"

--- a/web/test/spec/filterbar/numeric-range-directive.spec.js
+++ b/web/test/spec/filterbar/numeric-range-directive.spec.js
@@ -32,8 +32,7 @@ describe('driver.filterbar: Numeric Range', function () {
 
         // set the list of filterable things on the parent controller with an option filter
         var testFilterables = {'my#amplifier': {
-            format: 'number',
-            fieldType: 'text',
+            fieldType: 'number',
             isSearchable: true,
             propertyOrder: 0,
             type: 'string'


### PR DESCRIPTION
## Overview
Fixes a broken expectation that numeric filters can be identified by `format === 'number'`. It appears only checkbox and text filters have a `format` attribute - all others must be identified via their `fieldType` attribute. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
<img width="248" alt="screen shot 2018-09-11 at 4 19 15 pm" src="https://user-images.githubusercontent.com/1032849/45385333-7bd93600-b5de-11e8-8038-b22153317d47.png">

## Testing Instructions
- In the schema editor, define a number and integer field for a related item of a Record Type, and mark it as "Filterable/Searchable"
  - In the UI map and record views, you should see a filter that corresponds to the fields you created

Closes [PT160325267](https://www.pivotaltracker.com/story/show/160325267)

