### PR TITLE
Update staging celery IP address

### DIFF
--- a/deployment/ansible/inventory/staging
+++ b/deployment/ansible/inventory/staging
@@ -1,6 +1,6 @@
 app ansible_ssh_host=52.201.236.109 ansible_ssh_user=ubuntu
 database ansible_ssh_host=34.203.36.37 ansible_ssh_user=ubuntu
-celery ansible_ssh_host=34.229.58.2 ansible_ssh_user=ubuntu
+celery ansible_ssh_host=18.215.181.196 ansible_ssh_user=ubuntu
 
 [app-servers]
 app


### PR DESCRIPTION
## Overview

The instance type of the staging celery instance was changed from `t2.micro` to `t2.small`. The instance was underprovisioned and was maxing out its CPU when trying to extract Docker images during a deploy, causing the build to time out.

After updating the instance type, the IP address has changed and this PR updates it.

Hopefully this will allow a staging deploy to be successful.

