### PR TITLE
Fix map centering after geocoding address

### DIFF
--- a/web/app/scripts/state/zoom-to-address-directive.js
+++ b/web/app/scripts/state/zoom-to-address-directive.js
@@ -30,8 +30,7 @@
                     if (latlng === null) {
                         return;
                     }
-                    map.setZoom(16);
-                    map.panTo(new L.LatLng(parseFloat(latlng[0]), parseFloat(latlng[1])));
+                    map.setView([parseFloat(latlng[0]), parseFloat(latlng[1])], 16);
                 };
 
                 var geocodeAddress = function(query) {

--- a/web/app/scripts/state/zoom-to-address-directive.js
+++ b/web/app/scripts/state/zoom-to-address-directive.js
@@ -54,6 +54,7 @@
                         var addressSearchButton = L.DomUtil.create('button', 'address-search-button', addressSearchDiv);
                         L.DomUtil.create('span', 'glyphicon glyphicon-search', addressSearchButton);
 
+                        addressSearchButton.id = 'address-search-button';
                         addressSearchInput.id = 'address-search-input';
                         addressSearchInput.placeholder = 'Zoom to';
                         addressSearchInput.type = 'text';
@@ -65,6 +66,13 @@
                                 geocodeAddress(addressSearchInput);
                             } else {
                                 setLatlng(latlng);
+                            }
+                        });
+
+                        L.DomEvent.addListener(addressSearchInput, 'keyup', function(event) {
+                            event.preventDefault();
+                            if (event.keyCode === 13) {
+                                document.getElementById('address-search-button').click();
                             }
                         });
 


### PR DESCRIPTION
## Overview

Fix map centering after geocoding address. Currently, after searching the first time and zooming/panning the map, the second search won't work center correctly on the first click. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

Kind of unrelated: How do we handle cases when Pickpoint returns no data? Currently, we do nothing. 

Some addresses that work: `64 xavier st`, `160 Luna Mencias`

## Testing Instructions

 * Search for a latlng or an address in the Philippines. 
 * Pan/zoom a bit.
 * Search for another latlng or an address.
 * Ensure that it centers correctly on the first click.

Closes [#155396666](https://www.pivotaltracker.com/story/show/155396666)