### PR TITLE
Fix bug with non-ASCII characters in filter name

### DIFF
--- a/app/data/tests/test_views.py
+++ b/app/data/tests/test_views.py
@@ -65,6 +65,12 @@ class ViewTestSetUpMixin(object):
             "definitions": {
                 "objectDetails": {
                     "properties": {
+                        u"Numb\xe9r": {
+                            "fieldType": "number",
+                            "maximum": 10,
+                            "minimum": 0,
+                            "type": "integer"
+                        },
                         "Itness": {
                             "displayType": "select",
                             "enum": ["It", "Not it"]
@@ -142,6 +148,11 @@ class DriverRecordViewTestCase(APITestCase, ViewTestSetUpMixin):
         self.set_up_audit_log()
         self.factory = APIRequestFactory()
 
+    def tearDown(self):
+        super(DriverRecordViewTestCase, self).tearDown()
+        DriverRecord.objects.all().delete()
+        RecordAuditLogEntry.objects.all().delete()
+
     def test_toddow(self):
         url = '/api/records/toddow/?record_type={}'.format(str(self.record_type.uuid))
         response = json.loads(self.admin_client.get(url).content)
@@ -199,6 +210,39 @@ class DriverRecordViewTestCase(APITestCase, ViewTestSetUpMixin):
         public_response_data = json.loads(self.public_client.get(url).content)
         self.assertTrue(all('created_by' not in result for result in public_response_data['results']))
 
+    def test_unicode_in_filters_number_field(self):
+        data = {
+            'objectDetails': {
+                u"Numb\xe9r": 1,
+            },
+        }
+        date = datetime(2016, 1, 29, 13, 0, 0, 0, pytz.timezone('Asia/Manila'))
+        test_record = DriverRecord.objects.create(
+            occurred_from=date,
+            occurred_to=date,
+            geom='POINT (120.97 14.62)',
+            location_text='Manila',
+            schema=self.schema,
+            data=data)
+
+        url = '/api/records/?details_only=True&tilekey=True&jsonb={jsonb}'.format(
+            jsonb=json.dumps({
+                "objectDetails": {
+                    u"Numb\xe9r": {
+                        "_rule_type":"intrange",
+                        "min": 0,
+                        "max": 2
+                    }
+                }
+            }))
+        with mock.patch('data.views.get_redis_connection') as mocked_get_redis_connection:
+            mocked_redis_connection = mock.Mock()
+            mocked_get_redis_connection.return_value = mocked_redis_connection
+            response = json.loads(self.admin_client.get(url).content)
+            self.assertEqual(mocked_redis_connection.set.call_count, 1)
+            self.assertEqual(type(mocked_redis_connection.set.call_args[0][1]), str)
+        self.assertTrue('tilekey' in response)
+
     def test_tilekey_param(self):
         """Ensure that the tilekey param stores a SQL query in Redis and returns an access token"""
         # Since the call to store in redis won't have access to a real Redis instance under test,
@@ -230,8 +274,8 @@ class DriverRecordViewTestCase(APITestCase, ViewTestSetUpMixin):
 
     def test_audit_log_creation(self):
         """Test that audit logs are generated on create operations"""
-        # Start from clean slate
-        RecordAuditLogEntry.objects.all().delete()
+        initial_num_records = DriverRecord.objects.count()
+        initial_num_audit_log_entries = RecordAuditLogEntry.objects.count()
 
         url = '/api/records/'
         post_data = {
@@ -263,12 +307,10 @@ class DriverRecordViewTestCase(APITestCase, ViewTestSetUpMixin):
             'occurred_from': '2015-12-31T16:00:00.000Z',
             'occurred_to': '2015-12-31T16:00:00.000Z'
         }
-        self.assertEqual(RecordAuditLogEntry.objects.count(), 0)
-        self.assertEqual(DriverRecord.objects.count(), 3)
         response = self.admin_client.post(url, post_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(DriverRecord.objects.all().count(), 4)
-        self.assertEqual(RecordAuditLogEntry.objects.count(), 1)
+        self.assertEqual(DriverRecord.objects.all().count(), initial_num_records + 1)
+        self.assertEqual(RecordAuditLogEntry.objects.count(), initial_num_audit_log_entries + 1)
 
 
 class DriverCustomReportViewTestCase(APITestCase, ViewTestSetUpMixin):

--- a/app/data/views.py
+++ b/app/data/views.py
@@ -182,7 +182,7 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
             response = Response(dict())
             query_sql = self.generate_query_sql(request)
             tile_token = uuid.uuid4()
-            self._cache_tile_sql(tile_token, query_sql.encode('utf-8'))
+            self._cache_tile_sql(tile_token, query_sql)
             response.data['tilekey'] = tile_token
         else:
             response = super(DriverRecordViewSet, self).list(self, request, *args, **kwargs)

--- a/app/driver/mixins.py
+++ b/app/driver/mixins.py
@@ -14,4 +14,4 @@ class GenerateViewsetQuery(object):
         # get properly escaped string representation of the query
         query_str = cursor.mogrify(sql, params)
         cursor.close()
-        return query_str
+        return query_str.decode('utf-8')


### PR DESCRIPTION
## Overview

Fixes bug whereby filtering number fields with non-ASCII characters causes a Unicode error.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

Follow the steps to reproduce on `develop` to observe the bug and then check out this branch and observe the bug is fixed.

Closes #160463826

