### PR TITLE
Add weather filter #160199812

### DIFF
--- a/app/data/filters.py
+++ b/app/data/filters.py
@@ -38,6 +38,7 @@ class DriverRecordFilter(RecordFilter):
     created_min = django_filters.IsoDateTimeFilter(name="created", lookup_expr='gte')
     created_max = django_filters.IsoDateTimeFilter(name="created", lookup_expr='lte')
     created_by = django_filters.Filter(field_name='created_by', method='filter_created_by')
+    weather = django_filters.Filter(field_name='weather')
 
     def filter_created_by(self, queryset, name, value):
         """ Filter records by the email or username of the creating user."""

--- a/deployment/ansible/roles/driver.web/templates/index.html.j2
+++ b/deployment/ansible/roles/driver.web/templates/index.html.j2
@@ -145,6 +145,8 @@
     <script src="scripts/filterbar/date-range-controller.js"></script>
     <script src="scripts/filterbar/options-directive.js"></script>
     <script src="scripts/filterbar/options-controller.js"></script>
+    <script src="scripts/filterbar/weather-directive.js"></script>
+    <script src="scripts/filterbar/weather-controller.js"></script>
 
     <script src="scripts/social-costs/module.js"></script>
     <script src="scripts/social-costs/social-costs-directive.js"></script>

--- a/web/app/scripts/filterbar/filterbar-controller.js
+++ b/web/app/scripts/filterbar/filterbar-controller.js
@@ -125,6 +125,10 @@
                 filterOn.push('__searchText');
             }
 
+            if (ctl.filters.__weather) {
+                filterOn.push('__weather');
+            }
+
             _.each(filterOn, function(label) {
                 if (ctl.filters[label]) {
                     value = ctl.filters[label];

--- a/web/app/scripts/filterbar/filterbar.html
+++ b/web/app/scripts/filterbar/filterbar.html
@@ -12,6 +12,9 @@
         <ul class="nav navbar-nav" ng-if="ctl.hasWriteAccess">
             <li text-search-field="__createdBy"></li>
         </ul>
+        <ul class="nav navbar-nav">
+            <li weather-field class="dropdown"></li>
+        </ul>
         <ul class="nav navbar-nav" ng-repeat="(key, value) in filterbar.filterables">
             <li ng-if="(value.format === 'number') || (value.fieldType === 'integer') || (value.fieldType === 'number')"
                 numeric-range-field

--- a/web/app/scripts/filterbar/weather-controller.js
+++ b/web/app/scripts/filterbar/weather-controller.js
@@ -1,0 +1,15 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function WeatherController(WeatherService) {
+        var ctl = this;
+
+        ctl.weatherValues = WeatherService.weatherValues;
+        return ctl;
+    }
+
+    angular.module('driver.filterbar')
+    .controller('weatherController', WeatherController);
+
+})();

--- a/web/app/scripts/filterbar/weather-controller.js
+++ b/web/app/scripts/filterbar/weather-controller.js
@@ -5,7 +5,9 @@
     function WeatherController(WeatherService) {
         var ctl = this;
 
-        ctl.weatherValues = WeatherService.weatherValues;
+        // Ignore first value, which is blank
+        ctl.weatherValues = WeatherService.weatherValues.slice(1);
+
         return ctl;
     }
 

--- a/web/app/scripts/filterbar/weather-directive.js
+++ b/web/app/scripts/filterbar/weather-directive.js
@@ -37,7 +37,7 @@
                 });
 
                 scope.$on('driver.filterbar:reset', function() {
-                    setValue('');
+                    setValue([]);
                 });
 
                 function setValue(value) {

--- a/web/app/scripts/filterbar/weather-directive.js
+++ b/web/app/scripts/filterbar/weather-directive.js
@@ -32,23 +32,22 @@
                 // restore previously set filter selection on page reload
                 scope.$on('driver.filterbar:restored', function(event, filter) {
                     if (filter.label === scope.ctl.label) {
-                        setValue(filter.value);
+                        update(filter.value);
                     }
                 });
 
                 scope.$on('driver.filterbar:reset', function() {
-                    setValue([]);
+                    update([]);
+                    updateFilter();
                 });
 
-                function setValue(value) {
+                function update(value) {
                     // Update model
                     scope.ctl.value = value;
                     $timeout(function() {
                         // Update UI
                         selectElem.selectpicker('refresh');
                         selectElem.val(value);
-                        // Update filters
-                        updateFilter();
                     });
                 }
 

--- a/web/app/scripts/filterbar/weather-directive.js
+++ b/web/app/scripts/filterbar/weather-directive.js
@@ -8,28 +8,30 @@
             require: ['^driver-filterbar', 'weather-field'],
             templateUrl: 'scripts/filterbar/weather.html',
             controller: 'weatherController',
-            scope: true,
+            bindToController: true,
+            controllerAs: 'ctl',
+            scope: {},
             link: function(scope, elem, attrs, ctlArray) {
                 var filterbarController = ctlArray[0];
                 var weatherController = ctlArray[1];
 
-                scope.updateFilter = updateFilter;
-                scope.weatherValues = weatherController.weatherValues;
-                scope.domID = 'weather-filter-select';
-                scope.label = '__weather';
+                scope.ctl.updateFilter = updateFilter;
+                scope.ctl.weatherValues = weatherController.weatherValues;
+                scope.ctl.domID = 'weather-filter-select';
+                scope.ctl.label = '__weather';
 
                 init();
 
                 function init() {
                     // use `%timeout` to ensure that the template is rendered before selectpicker logic
                     $timeout(function() {
-                        $('#' + scope.domID).selectpicker();
+                        $('#' + scope.ctl.domID).selectpicker();
                     });
                 }
 
                 // restore previously set filter selection on page reload
                 scope.$on('driver.filterbar:restored', function(event, filter) {
-                    if (filter.label === scope.label) {
+                    if (filter.label === scope.ctl.label) {
                         setValue(filter.value);
                     }
                 });
@@ -40,11 +42,11 @@
 
                 function setValue(value) {
                     // Update model
-                    scope.value = value;
+                    scope.ctl.value = value;
                     $timeout(function() {
                         // Update UI
-                        $('#' + scope.domID).selectpicker('refresh');
-                        $('#' + scope.domID).val(value);
+                        $('#' + scope.ctl.domID).selectpicker('refresh');
+                        $('#' + scope.ctl.domID).val(value);
                         // Update filters
                         updateFilter();
                     });
@@ -55,7 +57,7 @@
                 *  filters should only be updated when data validates
                 */
                 function updateFilter() {
-                    filterbarController.updateFilter(scope.label, scope.value);
+                    filterbarController.updateFilter(scope.ctl.label, scope.ctl.value);
                 }
             }
         };

--- a/web/app/scripts/filterbar/weather-directive.js
+++ b/web/app/scripts/filterbar/weather-directive.js
@@ -1,0 +1,68 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function WeatherField($timeout) {
+        var module = {
+            restrict: 'A',
+            require: ['^driver-filterbar', 'weather-field'],
+            templateUrl: 'scripts/filterbar/weather.html',
+            controller: 'weatherController',
+            scope: true,
+            link: function(scope, elem, attrs, ctlArray) {
+                var filterbarController = ctlArray[0];
+                var weatherController = ctlArray[1];
+
+                scope.updateFilter = updateFilter;
+                scope.weatherValues = weatherController.weatherValues;
+                scope.domID = 'weather-filter-select';
+                scope.label = '__weather';
+
+                init();
+
+                function init() {
+                    // use `%timeout` to ensure that the template is rendered before selectpicker logic
+                    $timeout(function() {
+                        $('#' + scope.domID).selectpicker();
+                    });
+                }
+
+                // restore previously set filter selection on page reload
+                scope.$on('driver.filterbar:restored', function(event, filter) {
+                    if (filter.label === scope.label) {
+                        setValue(filter.value);
+                    }
+                });
+
+                scope.$on('driver.filterbar:reset', function() {
+                    setValue('');
+                });
+
+                function setValue(value) {
+                    // Update model
+                    scope.value = value;
+                    $timeout(function() {
+                        // Update UI
+                        $('#' + scope.domID).selectpicker('refresh');
+                        $('#' + scope.domID).val(value);
+                        // Update filters
+                        updateFilter();
+                    });
+                }
+
+                /**
+                * A simple wrapper around driver-filterbar's updateFilter function;
+                *  filters should only be updated when data validates
+                */
+                function updateFilter() {
+                    filterbarController.updateFilter(scope.label, scope.value);
+                }
+            }
+        };
+        return module;
+    }
+
+    angular.module('driver.filterbar')
+    .directive('weatherField', WeatherField);
+
+})();

--- a/web/app/scripts/filterbar/weather-directive.js
+++ b/web/app/scripts/filterbar/weather-directive.js
@@ -14,10 +14,10 @@
             link: function(scope, elem, attrs, ctlArray) {
                 var filterbarController = ctlArray[0];
                 var weatherController = ctlArray[1];
+                var selectElem = angular.element(elem[0]).find('select');
 
                 scope.ctl.updateFilter = updateFilter;
                 scope.ctl.weatherValues = weatherController.weatherValues;
-                scope.ctl.domID = 'weather-filter-select';
                 scope.ctl.label = '__weather';
 
                 init();
@@ -25,7 +25,7 @@
                 function init() {
                     // use `%timeout` to ensure that the template is rendered before selectpicker logic
                     $timeout(function() {
-                        $('#' + scope.ctl.domID).selectpicker();
+                        selectElem.selectpicker();
                     });
                 }
 
@@ -45,8 +45,8 @@
                     scope.ctl.value = value;
                     $timeout(function() {
                         // Update UI
-                        $('#' + scope.ctl.domID).selectpicker('refresh');
-                        $('#' + scope.ctl.domID).val(value);
+                        selectElem.selectpicker('refresh');
+                        selectElem.val(value);
                         // Update filters
                         updateFilter();
                     });

--- a/web/app/scripts/filterbar/weather.html
+++ b/web/app/scripts/filterbar/weather.html
@@ -3,7 +3,6 @@
         <select data-selected-text-format="static"
                 data-title="{{ 'RECORD.WEATHER' | translate }}"
                 class="selectpicker form-control"
-                id="{{ ctl.domID }}"
                 multiple
                 name="options[]"
                 ng-model="ctl.value"

--- a/web/app/scripts/filterbar/weather.html
+++ b/web/app/scripts/filterbar/weather.html
@@ -1,0 +1,15 @@
+<div class="btn-group dropdown options open" ng-class="{ 'active': value }">
+    <div class="form-group">
+        <select data-selected-text-format="static"
+                data-title="{{ 'RECORD.WEATHER' | translate }}"
+                class="selectpicker form-control"
+                id="{{ domID }}"
+                name="options[]"
+                ng-model="value"
+                ng-change="updateFilter()">
+            <option ng-repeat="weatherVal in weatherValues" value="{{ weatherVal }}">
+                {{ weatherVal | weatherLabel | translate }}
+            </option>
+        </select>
+    </div>
+</div>

--- a/web/app/scripts/filterbar/weather.html
+++ b/web/app/scripts/filterbar/weather.html
@@ -1,13 +1,13 @@
-<div class="btn-group dropdown options open" ng-class="{ 'active': value }">
+<div class="btn-group dropdown options open" ng-class="{ 'active': ctl.value }">
     <div class="form-group">
         <select data-selected-text-format="static"
                 data-title="{{ 'RECORD.WEATHER' | translate }}"
                 class="selectpicker form-control"
-                id="{{ domID }}"
+                id="{{ ctl.domID }}"
                 name="options[]"
-                ng-model="value"
-                ng-change="updateFilter()">
-            <option ng-repeat="weatherVal in weatherValues" value="{{ weatherVal }}">
+                ng-model="ctl.value"
+                ng-change="ctl.updateFilter()">
+            <option ng-repeat="weatherVal in ctl.weatherValues" value="{{ weatherVal }}">
                 {{ weatherVal | weatherLabel | translate }}
             </option>
         </select>

--- a/web/app/scripts/filterbar/weather.html
+++ b/web/app/scripts/filterbar/weather.html
@@ -1,9 +1,10 @@
-<div class="btn-group dropdown options open" ng-class="{ 'active': ctl.value }">
+<div class="btn-group dropdown options open" ng-class="{ 'active': ctl.value.length }">
     <div class="form-group">
         <select data-selected-text-format="static"
                 data-title="{{ 'RECORD.WEATHER' | translate }}"
                 class="selectpicker form-control"
                 id="{{ ctl.domID }}"
+                multiple
                 name="options[]"
                 ng-model="ctl.value"
                 ng-change="ctl.updateFilter()">

--- a/web/app/scripts/resources/query-builder-service.js
+++ b/web/app/scripts/resources/query-builder-service.js
@@ -170,7 +170,12 @@
             }
 
             if (filterConfig.doJsonFilters) {
-                jsonPromise = svc.assembleJsonFilterParams(_.omit(FilterState.filters, ['__dateRange', '__createdRange'])).then(
+                var jsonFilterParams = _.omit(FilterState.filters, [
+                    '__dateRange',
+                    '__createdRange',
+                    '__weather'
+                ]);
+                jsonPromise = svc.assembleJsonFilterParams(jsonFilterParams).then(
                     function(jsonFilters) {
                         // Handle cases where no json filters are set
                         if (!_.isEmpty(jsonFilters)) {

--- a/web/app/scripts/resources/query-builder-service.js
+++ b/web/app/scripts/resources/query-builder-service.js
@@ -152,6 +152,11 @@
                 if (created_by_string) {
                     paramObj.created_by = created_by_string;
                 }
+
+                var weatherFilter = FilterState.getWeatherFilter();
+                if (weatherFilter) {
+                    paramObj.weather = weatherFilter;
+                }
             }
 
             if (filterConfig.doBoundaryFilter) {

--- a/web/app/scripts/saved-filters/saved-filter-as-html.js
+++ b/web/app/scripts/saved-filters/saved-filter-as-html.js
@@ -4,7 +4,7 @@
     // Angular filter for  transforming a saved filter object to an HTML representation.
     // Note: if a new filter rule type is implemented, a new case must be added here for display.
     /* ngInject */
-    function SavedFilterAsHTML($translate) {
+    function SavedFilterAsHTML($translate, $filter) {
         var searchTextLabel = $translate.instant('SAVED_FILTERS.SEARCH_TEXT');
         var textSearchLabel = $translate.instant('SAVED_FILTERS.TEXT_SEARCH');
         var unknownRuleType = $translate.instant('ERRORS.UNKNOWN_RULE_TYPE');
@@ -60,7 +60,10 @@
                         if (key === '__searchText') {
                             htmlBlocks.push('<strong>' + textSearchLabel + ':</strong> ' + val);
                         } else if (key === '__weather') {
-                            htmlBlocks.push('<strong>' + weatherLabel + ':</strong> ' + val);
+                            var valTranslation = _.map(val, function(weatherKey) {
+                                return $translate.instant($filter('weatherLabel')(weatherKey));
+                            }).join(', ');
+                            htmlBlocks.push('<strong>' + weatherLabel + ':</strong> ' + valTranslation);
                         } else {
                             htmlBlocks.push(unknownRuleType + ': ' + val._rule_type);
                         }

--- a/web/app/scripts/saved-filters/saved-filter-as-html.js
+++ b/web/app/scripts/saved-filters/saved-filter-as-html.js
@@ -8,6 +8,7 @@
         var searchTextLabel = $translate.instant('SAVED_FILTERS.SEARCH_TEXT');
         var textSearchLabel = $translate.instant('SAVED_FILTERS.TEXT_SEARCH');
         var unknownRuleType = $translate.instant('ERRORS.UNKNOWN_RULE_TYPE');
+        var weatherLabel = $translate.instant('RECORD.WEATHER');
 
         // Helper for determining if a value is a number
         function isNumeric(n) {
@@ -58,6 +59,8 @@
                     default:
                         if (key === '__searchText') {
                             htmlBlocks.push('<strong>' + textSearchLabel + ':</strong> ' + val);
+                        } else if (key === '__weather') {
+                            htmlBlocks.push('<strong>' + weatherLabel + ':</strong> ' + val);
                         } else {
                             htmlBlocks.push(unknownRuleType + ': ' + val._rule_type);
                         }

--- a/web/app/scripts/state/filters-service.js
+++ b/web/app/scripts/state/filters-service.js
@@ -19,6 +19,7 @@
         svc.getDateFilter = getDateFilter;
         svc.getCreatedFilter = getCreatedFilter;
         svc.getCreatedByFilter = getCreatedByFilter;
+        svc.getWeatherFilter = getWeatherFilter;
 
         // Need to debounce saveFilters, because it is called many times when the filters
         // are being initialized, and we only want the final one to take effect.
@@ -130,6 +131,10 @@
 
         function getCreatedByFilter() {
             return svc.filters.__createdBy;
+        }
+
+        function getWeatherFilter() {
+            return svc.filters.__weather;
         }
 
         // Helper for converting a datetime string to the proper format to work with moment.tz.

--- a/web/test/spec/filterbar/date-range-directive.spec.js
+++ b/web/test/spec/filterbar/date-range-directive.spec.js
@@ -7,6 +7,7 @@ describe('driver.filterbar: Date Range', function () {
     beforeEach(module('driver.filterbar'));
     beforeEach(module('driver.state'));
     beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('driver.weather'));
 
     var $compile;
     var $rootScope;

--- a/web/test/spec/filterbar/filterbar-controller.spec.js
+++ b/web/test/spec/filterbar/filterbar-controller.spec.js
@@ -2,6 +2,7 @@
 
 describe('driver.filterbar: FilterbarController', function () {
 
+    beforeEach(module('driver.weather'));
     beforeEach(module('driver.filterbar'));
     beforeEach(module('driver.state'));
     beforeEach(module('ase.mock.resources'));

--- a/web/test/spec/filterbar/filterbar-directive.spec.js
+++ b/web/test/spec/filterbar/filterbar-directive.spec.js
@@ -9,6 +9,7 @@ describe('driver.filterbar: FilterbarDirective', function () {
     beforeEach(module('driver.mock.resources'));
     beforeEach(module('ase.templates'));
     beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('driver.weather'));
 
     var $compile;
     var $httpBackend;

--- a/web/test/spec/filterbar/numeric-range-directive.spec.js
+++ b/web/test/spec/filterbar/numeric-range-directive.spec.js
@@ -7,6 +7,7 @@ describe('driver.filterbar: Numeric Range', function () {
     beforeEach(module('driver.filterbar'));
     beforeEach(module('driver.state'));
     beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('driver.weather'));
 
     var $compile;
     var $rootScope;

--- a/web/test/spec/filterbar/options-directive.spec.js
+++ b/web/test/spec/filterbar/options-directive.spec.js
@@ -7,6 +7,7 @@ describe('driver.filterbar: Options', function () {
     beforeEach(module('driver.filterbar'));
     beforeEach(module('driver.state'));
     beforeEach(module('pascalprecht.translate'));
+    beforeEach(module('driver.weather'));
 
     var $compile;
     var $rootScope;
@@ -45,11 +46,14 @@ describe('driver.filterbar: Options', function () {
         $rootScope.$apply();
 
         // should have no selection yet
-        expect(Element.find('select').val()).toEqual(null);
+        var getSelectValue = function() {
+            return Element.find('select[data-title=bar]').val();
+        };
+        expect(getSelectValue()).toEqual(null);
         $rootScope.$broadcast('driver.filterbar:restore', [{'foo#bar': {'_rule_type': 'containment', 'contains': ['baz']}}, null]);
         $rootScope.$digest();
         // should have baz selected now
-        expect(Element.find('select').val()).toEqual(['string:baz']);
+        expect(getSelectValue()).toEqual(['string:baz']);
     });
 
 });

--- a/web/test/spec/filterbar/weather-controller.spec.js
+++ b/web/test/spec/filterbar/weather-controller.spec.js
@@ -1,0 +1,26 @@
+'use strict';
+
+describe('driver.filterbar: WeatherController', function () {
+
+    beforeEach(module('driver.weather'));
+    beforeEach(module('driver.filterbar'));
+
+    var $controller;
+    var $rootScope;
+    var $scope;
+    var Controller;
+
+    beforeEach(inject(function (_$controller_, _$rootScope_) {
+        $controller = _$controller_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        Controller = $controller('weatherController', {
+            $scope: $scope
+        });
+        $scope.$apply();
+    }));
+
+    it('should initially have an empty selection', function () {
+        expect(Controller.selection).toBeFalsy();
+    });
+});

--- a/web/test/spec/resources/query-builder-service-spec.js
+++ b/web/test/spec/resources/query-builder-service-spec.js
@@ -16,6 +16,9 @@ describe('driver.resources: QueryBuilder', function () {
         },
         'getCreatedByFilter': function(){
             return '';
+        },
+        'getWeatherFilter': function(){
+            return '';
         }
     };
     beforeEach(module('ase.mock.resources'));


### PR DESCRIPTION
## Overview

Add a weather filter to the filter bar.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![weather_filter](https://user-images.githubusercontent.com/2926237/45972071-bbeddf00-c008-11e8-92bf-561ab3bfbcc7.png)

### Notes

This was largely based off of (and copied from) our `OptionsField` directive.

## Testing Instructions

**NOTE**: Make sure to reprovision app and test on port 7000. When testing on port 7002 there is a bug whereby options filters are not getting restored properly (event listener is never called) when the weather filter is present.

### Test weather filter works

Create or edit a record to have a certain weather value (eg. Clear night).

Verify that that record shows up in the list when you select that value in the filter and then disappears when you select a different one.

### Test the UI

The dropdown should turn blue when a filter is selected and the selected option should be highlighted when the dropdown is open.

### Test clearing weather filter

Click the clear filters icon to the right and test that the filter is no longer being applied and the dropdown is no longer blue.

### Test restoring weather filter

Select a filter and verify it's working. Then reload the page and make sure the state is the same.

Closes #160199812

