### PR TITLE
Fix bug on editing record with old schema

### DIFF
--- a/web/app/scripts/views/record/add-edit-controller.js
+++ b/web/app/scripts/views/record/add-edit-controller.js
@@ -497,6 +497,7 @@
             /* jshint camelcase: false */
             if (ctl.record && ctl.record.geom) {
                 // set back coordinates and nominatim values
+                ctl.record.schema = ctl.recordSchema.uuid;
                 ctl.record.geom.coordinates = [ctl.geom.lng, ctl.geom.lat];
                 ctl.record.location_text = ctl.nominatimLocationText;
                 ctl.record.city = ctl.nominatimCity;


### PR DESCRIPTION
## Overview

Fix bug on editing record with old schema. This is fixed by assigning the new schema uuid to the record on editing.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Reproduce bug on attached story. Do this by creating a record, updating the schema using the schema editor (maybe add a field), and then edit the old record. This should fail.
 * Pull new branch and `./scripts/grunt.sh web serve`
 * Try to reproduce the bug and get a success instead. See that the new field added has data if updated to have data.

Closes [#160462409](https://www.pivotaltracker.com/story/show/160462409)

