### PR TITLE
Bump version of azavea.pip to 1.0.1

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -11,6 +11,6 @@
 - src: azavea.docker
   version: 1.0.2
 - src: azavea.pip
-  version: 0.1.1
+  version: 1.0.1
 - src: azavea.redis
   version: 0.1.0


### PR DESCRIPTION
This change is already on master and was deployed in the latest release (see https://github.com/WorldBank-Transport/DRIVER/releases/tag/1.2.3).

This PR is to keep `develop` in sync with `master`.