### PR TITLE
Upgrade driver-gradle to OpenJDK 8 #161148068

### DIFF
--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -3,7 +3,7 @@
 # and partially based on android docker:
 # https://github.com/gfx/docker-android-project/blob/master/Dockerfile
 
-FROM java:7-jdk
+FROM openjdk:8-jdk
 MAINTAINER Kathryn Killebrew <kkillebrew@azavea.com>
 
 RUN apt-get update && apt-get install -yq apt-utils


### PR DESCRIPTION
## Overview

There is an issue with JitPack that prevents the downloading of
dependencies when building a new `models.jar` (see
https://github.com/jitpack/jitpack.io/issues/227).  Upgrading to OpenJDK
8 fixes the issue.

A models.jar file generated with this change has been confirmed to work
in the Android app.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

:warning: Warning: do not attempt to test :warning: 

Seriously... testing was a struggle. I have tested this end-to-end but there were several unrelated bugs and gotchas along the way, so it's better to just take my word for it that this works. My testing consisted of the following:

1. Upgrade `driver-gradle` image to OpenJDK 8
1. Modify a schema and use the UUID of the new schema to generate a new `models.jar` file
1. Use new `models.jar` file in Android app and run it successfully
1. Observe that form to add a new record has the changes to the schema 

I plan to open up a PR to document my struggles for the next person who might want to get up and running with the Android app.

EDIT: See https://github.com/WorldBank-Transport/DRIVER-Android/pull/71 

Closes #161148068

