### PR TITLE
Prevent address search click propagation to map

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ ANSIBLE_GROUPS = {
   "celery-servers" => [ "celery" ]
 }
 MOUNT_OPTIONS = if Vagrant::Util::Platform.linux? then
-                  ['rw', 'vers=4', 'tcp', 'nolock']
+                  ['rw', 'tcp', 'nolock']
                 else
                   ['vers=3', 'udp']
                 end

--- a/web/app/scripts/state/zoom-to-address-directive.js
+++ b/web/app/scripts/state/zoom-to-address-directive.js
@@ -76,6 +76,8 @@
                             }
                         });
 
+                        L.DomEvent.disableClickPropagation(addressSearchDiv);
+
                         return addressSearchDiv;
                     }
                 });


### PR DESCRIPTION
## Overview

Prevents clicks in the address search from propagating to the map.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Notes
Also includes a fix to take out an NFS parameter from the Vagrantfile that causes problems on Ubuntu 18.04. Everyone is using 18.04 except @pcaisse and we've tested this on his machine to confirm that there don't seem to be any problems. If something crops up later we can reconsider.

## Testing Instructions

 * Provision or run `./scripts/grunt.sh web serve` and navigate to `localhost:7000` or `localhost:7002`, depending.
 * Go to the map page.
 * Click-and-drag on the address search text box, and double-click in the box and on the search button. Confirm that the map does not react to the these clicks.
 * Confirm that the address search maintains existing functionality.

Closes #161460901

