### PR TITLE
Add one-off script for PRS data migration

### DIFF
--- a/app/data/management/commands/migrate_prs_description.py
+++ b/app/data/management/commands/migrate_prs_description.py
@@ -22,8 +22,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         source_type = 'incidentDetails'
         source_field = 'Description'
-        target_type = 'driverSensitiveInformation'
-        target_field = 'Description'
+        target_type = 'driverNotes'
+        target_field = 'Notes'
 
         qs = Record.objects.filter(
             schema__record_type__label='Incident'

--- a/app/data/management/commands/migrate_prs_description.py
+++ b/app/data/management/commands/migrate_prs_description.py
@@ -1,0 +1,49 @@
+import uuid
+from datetime import datetime, timedelta
+
+from django.core.management.base import BaseCommand
+
+from ashlar.models import Record
+
+
+class Command(BaseCommand):
+    """One-off script for PRS to hide sensitive information in incident Description
+
+    To accomplish this we manually create a Related Object type with a Paragraph text field, and
+    use this script to migrate all existing records to have their incident's Description in that
+    new field instead.
+
+    This may result in records who do not accurately match any schema, but their data should still
+    be accessible.
+    """
+
+    help = 'Migrate values in Incident Details\' Description to a Related Content type.'
+
+    def handle(self, *args, **options):
+        source_type = 'incidentDetails'
+        source_field = 'Description'
+        target_type = 'driverSensitiveInformation'
+        target_field = 'Description'
+
+        qs = Record.objects.filter(
+            schema__record_type__label='Incident'
+        ).extra(where=["data->'{}'->>'{}' != ''".format(source_type, source_field)])
+
+        total = qs.count()
+        print "{} - Updating {} records".format(datetime.now(), total)
+
+        last_print = datetime.now()
+
+        for index, record in enumerate(qs.iterator()):
+            if datetime.now() - last_print > timedelta(minutes=1):
+                percent = int(100.0 * index / total)
+                print "{} - {}% - Updated {} of {}".format(datetime.now(), percent, index, total)
+                last_print = datetime.now()
+
+            record.data[target_type] = {
+                '_localId': uuid.uuid4(),
+                target_field: record.data[source_type][source_field]
+            }
+            record.data[source_type][source_field] = ''
+            record.save()
+        print "{} - Completed".format(datetime.now())


### PR DESCRIPTION
## Overview
Adds into source control a script intended to be used to migration information in the PRS environment that is undesirably available for public view. This script will move all values in the Incident Details' "Description" field into a similarly named "Description" in a related content type (In this script it is currently "driverSensitiveInformation" to correspond with "Sensitive Information", but that is a placeholder expected to change) - information within a related content type is not visible to a public user, so although no official information access permissions feature exists, this will enable us to hide this information.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
```
2018-12-11 23:14:55.434344 - Updating 187060 records
2018-12-11 23:15:55.439622 - 6% - Updated 12045 of 187060
2018-12-11 23:16:55.440528 - 12% - Updated 23053 of 187060
[...]
2018-12-11 23:28:55.529485 - 87% - Updated 162901 of 187060
2018-12-11 23:29:55.531652 - 93% - Updated 175636 of 187060
2018-12-11 23:30:46.657398 - Completed
```

### Notes
- Migrates all values in the `Description` field, including benign values.
- PRS is currently on an Ashlar version of DRIVER, so this branch is based off of the `pre-grout` tag.

## Testing Instructions
- Set up an environment for Ashlar
- Install data (Dump is available)
  - A snapshot of the `database` VM here may be useful for repeated testing
- In Ashlar editor, edit "Incident" to add a "Sensitive Information" related content type
- Add a "Description" field for this related content type, of type Text/subtype paragraph
- Run migration with
```
./scripts/manage.sh migrate_prs_description
```
  - Migration should complete successfully
- Open database shell
```
./scripts/manage.sh dbshell
```
- Obtain the UUID for records that were migrated
```
SELECT uuid FROM ashlar_record WHERE data->'driverSensitiveInformation'->>'Description' != '' limit 5;
```
- Examine the records to ensure they were migrated correctly `http://localhost:7000/#!/record/[UUID]/details`
  - Description field should be blank, but in the "Sensitive Information" tab should have the value

