### PR TITLE
Expand demo EC2 instances root partition size

### DIFF
--- a/deployment/demo-cfn-template.yaml
+++ b/deployment/demo-cfn-template.yaml
@@ -121,6 +121,10 @@ Resources:
       SecurityGroups: [!Ref 'AppSecurityGroup']
       KeyName: !Ref 'KeyName'
       ImageId: !FindInMap [AWSRegionArch2AMI, !Ref 'AWS::Region', !FindInMap [AWSInstanceType2Arch, !Ref 'AppInstanceType', Arch]]
+      BlockDeviceMappings:
+        - DeviceName: "/dev/sda1"
+          Ebs:
+            VolumeSize: "16"
       Tags:
       - Key: Name
         Value:
@@ -145,6 +149,10 @@ Resources:
       SecurityGroups: [!Ref 'CelerySecurityGroup']
       KeyName: !Ref 'KeyName'
       ImageId: !FindInMap [AWSRegionArch2AMI, !Ref 'AWS::Region', !FindInMap [AWSInstanceType2Arch, !Ref 'CeleryInstanceType', Arch]]
+      BlockDeviceMappings:
+        - DeviceName: "/dev/sda1"
+          Ebs:
+            VolumeSize: "16"
       Tags:
       - Key: Name
         Value:
@@ -179,6 +187,10 @@ Resources:
       SecurityGroups: [!Ref 'DatabaseSecurityGroup']
       KeyName: !Ref 'KeyName'
       ImageId: !FindInMap [AWSRegionArch2AMI, !Ref 'AWS::Region', !FindInMap [AWSInstanceType2Arch, !Ref 'DatabaseInstanceType', Arch]]
+      BlockDeviceMappings:
+        - DeviceName: "/dev/sda1"
+          Ebs:
+            VolumeSize: "16"
       Tags:
       - Key: Name
         Value:


### PR DESCRIPTION
## Overview
When deploying demo instances, we suspect some failures occur because the environments ran out of disk space. By default EC2 instances are given 8GB of storage on EBS, so this expands the EBS allocation to 16GB in the default demo CloudFormation template.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Log into the AWS console
- Navigate to the CloudFormation service
- Click "Create Stack"
- Keep "Template is Ready", select "Upload a template file", and upload `demo-cfn-template.yaml` in the box
- Click Next
- Enter some value like "TestStack" for Stack Name
- Change instance sizes to `t2.nano` to minimize unnecessary cost
- In `KeyName` select `driver-demo-us-west-2`
- Enter some value like "Test" for NameSuffix
- Enter `66.212.12.106/32` for SSHCidr
- Click Next
- Click Next
- Review settings and click "Create Stack"
  - The stack should build and eventually complete successfully
- Navigate to the EC2 service
- Find the `app` EC2 instance created by the CloudFormation stack above
  - (It should be one of the few running `t2.nano` instances, and when selected should be titled `DriverDemoApp-{SUFFIX}`)
- Copy the public IP address
- In a SSH terminal, run
```
ssh -i ~/.ssh/driver-demo-us-west-2.pem ubuntu@{PUBLIC IP}
```
- Once in the VM, run
```
df -h
```
- You should see the VM has a 16GB partition for `/dev/xvda1`

