### PR TITLE
Pin to specific version of karma-jasmine #162584877

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,7 @@
     "jasmine-core": "2.99.1",
     "jshint-stylish": "^1.0.0",
     "karma": "^1.6.0",
-    "karma-jasmine": "*",
+    "karma-jasmine": "1.1.2",
     "karma-ng-html2js-preprocessor": "^0.1.2",
     "karma-phantomjs-launcher": "*",
     "load-grunt-tasks": "^3.1.0",


### PR DESCRIPTION
## Overview

The newest version of karma-jasmine requires jasmine-core 3.3+, and any 3.0+
version of jasmine-core causes tests to break.

See also: https://github.com/WorldBank-Transport/DRIVER/pull/682

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

Build should pass on this PR.

Closes #162584877

