### PR TITLE
Fix build by explicitly installing and pinning rb-inotify in web and schema_editor containers

### DIFF
--- a/schema_editor/Dockerfile
+++ b/schema_editor/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN gem install ffi -v 1.9.18
 RUN gem install sass -v 3.4.22
+RUN gem install rb-inotify -v 0.9.10
 RUN gem install compass
 
 RUN mkdir -p /opt/schema_editor /npm /bower

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN gem install ffi -v 1.9.18
 RUN gem install sass -v 3.4.22
+RUN gem install rb-inotify -v 0.9.10
 RUN gem install compass
 
 RUN mkdir -p /opt/web /npm /bower


### PR DESCRIPTION
## Overview

`rb-inotify` had a new release `v0.10.0` on Dec 15. A package we use, `compass`, uses this. Builds have been failing locally because this new version is incompatible with our version of ruby. This PR fixes that by installing `v0.9.10` of `rb-inotify` before `compass`.

### Checklist

- [ ] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Check that CI build passes