### PR TITLE
Fix duplicates filtering on Django app

### DIFF
--- a/app/data/filters.py
+++ b/app/data/filters.py
@@ -29,7 +29,7 @@ class RecordAuditLogFilter(django_filters.FilterSet):
 class RecordDuplicateFilter(django_filters.FilterSet):
     record_type = django_filters.Filter(field_name='record_type', method='filter_record_type')
 
-    def filter_record_type(self, queryset, value):
+    def filter_record_type(self, queryset, name, value):
         """ Filter duplicates by the record type of their first record
 
         e.g. /api/duplicates/?record_type=44a51b83-470f-4e3d-b71b-e3770ec79772


### PR DESCRIPTION
## Overview

The duplicates view on the app is broken. This is because the filtering on Django returns a Type Error. This PR fixes this error by modifying the arguments of a method to make it what the `django_filters` package expects. This likely broke sometime during the Django upgrade so is only broken on staging and not on production. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Make sure you have some duplicates. Add a record that is at the same time and same lat lon as an existing record then run the management command to generate duplicates in the app container `./manage.py find_duplicate_records`.
 * Next, navigate to the duplicates window on the UI to recreate the error.
 * Pull this branch, see the error disappear. 

Closes #XXX

