### PR TITLE
Pin Redis version to fix cache key type error

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -13,6 +13,7 @@ oic==0.10.0
 git+https://github.com/alexsdutton/django-oidc/@py3-dj1.10#egg=django-oidc
 celery[redis]==3.1.19
 django-redis==4.2.0
+redis==2.10.6
 python-dateutil==2.4.2
 pytz==2015.7
 mock==1.3.0


### PR DESCRIPTION
## Overview
Attempting to access records stored in the Redis cache has started failing recently, with the error message
```
Invalid input of type: 'UUID'. Convert to a byte, string or number first.
```

@shreshthkhilani's investigation found a very similar issue in https://github.com/andymccurdy/redis-py/issues/1071 which points to https://github.com/niwinz/django-redis/issues/342, which in turn was marked fixed by https://github.com/niwinz/django-redis/pull/344 and was released in `django-redis` `4.10.0`. However, upgrading to `4.10.0` didn't appear to resolve our error specifically, but the workaround suggesting pinning `redis` to `2.10.6` (https://github.com/andymccurdy/redis-py/issues/1071#issuecomment-439208481) does appears to.

Not wanting to look a gift horse in the mouth, this does exactly that.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
<img width="289" alt="screen shot 2019-01-07 at 5 37 22 pm" src="https://user-images.githubusercontent.com/1032849/50797474-ea838300-12a2-11e9-95d2-cdef9ce83500.png">

## Testing Instructions
- Provision
- Load the map page
  - Tiles on the map should load with dots reflecting records

Closes [PT162792894](https://www.pivotaltracker.com/story/show/162792894)

