### PR TITLE
Fix issue causing text box searching to be ignored

### DIFF
--- a/web/app/scripts/filterbar/filterbar-controller.js
+++ b/web/app/scripts/filterbar/filterbar-controller.js
@@ -123,10 +123,6 @@
                 }
             });
 
-            if (ctl.filters.__weather) {
-                filterOn.push('__weather');
-            }
-
             _.each(filterOn, function(label) {
                 if (ctl.filters[label]) {
                     value = ctl.filters[label];

--- a/web/app/scripts/state/filters-service.js
+++ b/web/app/scripts/state/filters-service.js
@@ -150,7 +150,6 @@
             return [
                 '__dateRange',
                 '__createdRange',
-                '__searchText',
                 '__createdBy',
                 '__quality',
                 '__weather'


### PR DESCRIPTION
## Overview
The filter bar logic is weird and complex, and the text search box especially so. It filters for all custom fields that don't have their own element, so it's kind of a special-case grab bag. While doing some refactoring in 53a89a355e482fcd852928b98ebd2df201689edc a pair of seemingly arbitrary ad hoc lists of fields were moved to a method `getNonJsonFilterNames()` to help structure them by purpose, but although `__searchText` was used like `__dateRange` and `__weather` [in the `driver.filterbar:restore` event handler](https://github.com/WorldBank-Transport/DRIVER/blob/1c5c8afce240d5dcfe7564ce05d044997688640f/web/app/scripts/filterbar/filterbar-controller.js#L120-L130), it appears that might not be necessary behavior?

Either way, the problem with `__searchText`'s special nature appears in this case because we do not want it to be omitted in the `jsonPromise` construction here: https://github.com/WorldBank-Transport/DRIVER/blob/91535038b011d1f409575f92cdb013d6267bcfe7/web/app/scripts/resources/query-builder-service.js#L187-L189

This would cause the search text to be omitted from the request sent, though changing search text would trigger an (unchanged) request to be sent:
<img width="640" alt="screen shot 2019-01-10 at 11 55 14 am" src="https://user-images.githubusercontent.com/1032849/50983988-b55b7880-14ce-11e9-82d5-69b2eb73900b.png">

This removes `__searchText` from the `getNonJsonFilterNames()` list.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
<img width="693" alt="screen shot 2019-01-10 at 11 54 45 am" src="https://user-images.githubusercontent.com/1032849/50983995-bab8c300-14ce-11e9-8896-5e13c1b9406d.png">

## Testing Instructions
- Navigate to the Map or Records page
- Enter text into the search text bar
  - The records shown should change to reflect the search text.

Closes [PT163093035](https://www.pivotaltracker.com/story/show/163093035)

