### PR TITLE
Fix crash printing lookup error message

### DIFF
--- a/app/data/views.py
+++ b/app/data/views.py
@@ -1104,11 +1104,13 @@ class DriverRecordViewSet(RecordViewSet, mixins.GenerateViewsetQuery):
         """
         # Walk down the schema using the path components
         obj = schema.schema['definitions']  # 'definitions' is the root of all schema paths
-        try:
-            for key in path:
+        for key in path:
+            try:
                 obj = obj[key]
-        except KeyError as e:
-            raise ParseError(detail="Part of choices_path was not found: '{}'".format(e.message))
+            except KeyError as e:
+                raise ParseError(
+                    detail=u'Could not look up path "{}", "{}" was not found in schema'.format(
+                        u':'.join(path), key))
 
         # Checkbox types have an additional 'items' part at the end of the path
         if 'items' in obj:


### PR DESCRIPTION
## Overview
If a RecordType is misconfigured and has its Cost Aggregation reference a field that does not exist, we print a message and include in that message the original raw Python exception message. Broadly speaking displaying raw server errors can be potentially problematic in case it exposes sensitive information, but in this case specifically it lead to an exception if the raw Python exception message referenced a field name that contained a non-ASCII character, causing the server to raise a 500 server error instead of the desired 400 request error.

This restructures the error message to be hopefully more user friendly, and also makes it safe for non-ASCII characters.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Create a Select-type field for the Incident Details content type with a non-ASCII name such as "✓", and give it some options
- Change the Incident Detail's "Cost aggregation settings" to refer to the non-ASCII Select field created above
- Delete the non-ASCII Select field
- Load the UI, open your browser's Development Tools, and look for the request to `/api/records/costs/`
  - It should have returned with a 400 Bad Request HTTP code, and an error message along the lines of `{"detail":"Could not look up path \"driverIncidentDetails:properties:✓\", \"✓\" was not found in schema"}`

Closes [PT163093449](https://www.pivotaltracker.com/story/show/163093449)

