### PR TITLE
Upgrade Grout to fix exception searching using non-ASCII characters

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -18,7 +18,7 @@ python-dateutil==2.4.2
 pytz==2015.7
 mock==1.3.0
 djangorestframework-csv==1.4.1
-grout==2.0.0
+grout==2.0.1
 # Dependencies for generate_training_input script
 argparse==1.2.1
 Fiona==1.6.3


### PR DESCRIPTION
## Overview
Incorporates a fix in Grout to address an unhandled exception error when searching using non-ASCII characters (See azavea/grout#15). 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Provision the `app` VM
- In the web view, create a record using a non-ASCII character in its description such as `✓`
- Search for that character
  - The record should appear

Closes [PT163297205](https://www.pivotaltracker.com/story/show/163297205)

