### PR TITLE
Upgrade certbot

### DIFF
--- a/deployment/ansible/roles/driver.letsencrypt/defaults/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-certbot_version: "v0.20.0"
+certbot_version: "v0.30.0"
 letsencrypt_root: "/etc/letsencrypt"
 letsencrypt_cert_root: "{{ letsencrypt_root }}/live/{{ allowed_host }}"
 

--- a/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Install CertBot
   apt:
     pkg: certbot
-    state: present
+    state: latest
 
 - name: Stop nginx
   service:


### PR DESCRIPTION
## Overview
Upgrades certbot to a more recent version to change the validation method used by Lets Encrypt. Hope is that upgrading to 0.28.0 or newer will fix the issue - see https://community.letsencrypt.org/t/how-to-stop-using-tls-sni-01-with-certbot/83210 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Notes
- Testing needs to be done with the `--dry-run` flag, since the deprecated validation method is still live in production. Lets Encrypt has disabled it in their test environment, however, and `--dry-run` causes `certbot` to hit that instead ([See this comment](https://community.letsencrypt.org/t/february-13-2019-end-of-life-for-all-tls-sni-01-validation-support/74209/2))
- The acceptance criteria for this issue is "Certificate renewal should be fixed on staging". It's difficult to say if this specifically has been accomplished (Especially since the problem of TLS-SNI being disabled won't happen until March 13th), but previously staging's SSL certificate was expired and running the command in `Testing instructions` without `--dry-run` fixed that, so I believe it's safe to expect that this issue will be resolved so long as the command with the `--dry-run` flag works.

## Testing Instructions
- SSH into the staging instance
- Run `sudo certbot renew --dry-run --pre-hook 'service nginx stop' --post-hook 'service nginx start'`
  - It should succeed

Closes [PT163326276](https://www.pivotaltracker.com/story/show/163326276)

