### PR TITLE
Allow customizing deduplication configuration variables from group_vars

### DIFF
--- a/app/driver/settings.py
+++ b/app/driver/settings.py
@@ -344,9 +344,9 @@ CELERY_DOWNLOAD_PREFIX = '/download/'
 CELERY_EXPORTS_FILE_PATH = '/var/www/media'
 
 # Deduplication settings
-DEDUPE_TIME_RANGE_HOURS = 12
+DEDUPE_TIME_RANGE_HOURS = float(os.environ.get('DRIVER_DEDUPE_TIME_RANGE_HOURS', '12'))
 # .001 ~= 110m
-DEDUPE_DISTANCE_DEGREES = 0.0008
+DEDUPE_DISTANCE_DEGREES = float(os.environ.get('DRIVER_DEDUPE_DISTANCE_DEGREES', '0.0008'))
 
 GROUT = {
     # It is suggested to change this if you know that your data will be limited to

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -37,6 +37,10 @@ driver_admin_username: "admin"
 driver_admin_password: "admin"
 driver_admin_email: "systems+driver@azavea.com"
 
+## DEDUPLICATION SETTINGS
+dedupe_time_range_hours: "12"
+dedupe_distance_degrees: "0.0008"
+
 ## WEB SETTINGS
 js_html5mode: "false"
 js_html5mode_prefix: "!"

--- a/deployment/ansible/group_vars/production.example
+++ b/deployment/ansible/group_vars/production.example
@@ -95,6 +95,10 @@ driver_admin_username: "admin"
 #driver_admin_password: "uncomment and change me!"
 driver_admin_email: "you@yourdomain.com"
 
+## DEDUPLICATION SETTINGS
+dedupe_time_range_hours: "12"
+dedupe_distance_degrees: "0.0008"
+
 ## WEB SETTINGS
 # DRIVER uses the PickPoint API (which runs Nominatim) for geocoding; this is the API key that
 # should be used when accessing that API. You can sign up for an API key here:

--- a/deployment/ansible/group_vars/production.j2
+++ b/deployment/ansible/group_vars/production.j2
@@ -96,6 +96,10 @@ driver_admin_username: "admin"
 driver_admin_password: "{{ driver_admin_password }}"
 driver_admin_email: "you@yourdomain.com"
 
+## DEDUPLICATION SETTINGS
+dedupe_time_range_hours: "12"
+dedupe_distance_degrees: "0.0008"
+
 ## WEB SETTINGS
 # DRIVER uses the PickPoint API (which runs Nominatim) for geocoding; this is the API key that
 # should be used when accessing that API. You can sign up for an API key here:

--- a/deployment/ansible/group_vars/staging
+++ b/deployment/ansible/group_vars/staging
@@ -34,6 +34,10 @@ driver_admin_username: "admin"
 driver_admin_password: "admin"
 driver_admin_email: "systems+driver@azavea.com"
 
+## DEDUPLICATION SETTINGS
+dedupe_time_range_hours: "12"
+dedupe_distance_degrees: "0.0008"
+
 ## WEB SETTINGS
 js_html5mode: "false"
 js_html5mode_prefix: "!"

--- a/deployment/ansible/roles/driver.app/defaults/main.yml
+++ b/deployment/ansible/roles/driver.app/defaults/main.yml
@@ -26,6 +26,8 @@ driver_conf:
   DJANGO_ENV: "{% if developing %}development{% elif staging %}staging{% else %}production{% endif %}"
   DRIVER_OSM_EXTRACT_URL: "{{ osm_extract_url }}"
   ALLOWED_HOST: "{{ allowed_host }}"
+  DRIVER_DEDUPE_TIME_RANGE_HOURS: "{{ dedupe_time_range_hours }}"
+  DRIVER_DEDUPE_DISTANCE_DEGREES: "{{ dedupe_distance_degrees }}"
 
 driver_postgis_version: 2.1.3
 


### PR DESCRIPTION
## Overview
For our duplicate record heuristics, we compare records that are within a given distance from each other and take place within a given time range. At low scale these factors work well for finding records that likely reflect the same incident, but as scale increases the default values may become too coarse, and result in a undesired number of false positives.

This PR exposes the values to be customized in system-wide configuration, allowing us to easily set higher or lower values for different environments without requiring code changes.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Edit `deployment/ansible/group_vars/development` and change the `dedupe_time_range_hours` option to a different value
- Run `vagrant provision app`
- Enter into the `driver-app` Docker container and run `./manage.py shell_plus`
- Run
```
from django.conf import settings
settings.DEDUPE_TIME_RANGE_HOURS
```
- The result should reflect the value you gave for `dedupe_time_range_hours` above

Closes [PT163071741](https://www.pivotaltracker.com/story/show/163071741)
