### PR TITLE
Remove deprecated --process-dependency-links flag from pip install

### DIFF
--- a/app/Dockerfile.base
+++ b/app/Dockerfile.base
@@ -36,7 +36,7 @@ WORKDIR /opt/app
 
 COPY . /opt/app
 
-RUN pip install --no-cache-dir --process-dependency-links djsonb -r requirements.txt
+RUN pip install --no-cache-dir djsonb -r requirements.txt
 
 EXPOSE 4000
 

--- a/app/Dockerfile.development
+++ b/app/Dockerfile.development
@@ -1,6 +1,6 @@
 FROM driver-app:latest
 
-RUN pip install --no-cache-dir --process-dependency-links djsonb -r dev-requirements.txt --src /opt
+RUN pip install --no-cache-dir djsonb -r dev-requirements.txt --src /opt
 EXPOSE 8000
 
 CMD ["driver.wsgi", "-w1", "-b:4000", "--reload", "-kgevent"]


### PR DESCRIPTION
## Overview
Removes `pip install` flag that was removed in pip version 12. It appears to no longer be necessary (Or had been previously unused).

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Run `vagrant provision`
  - It should succeed
- Open http://localhost:7000 in a browser
  - It should load

Closes [PT163762556](https://www.pivotaltracker.com/story/show/163762556)

