### PR TITLE
Add alternate languages to staging configuration

### DIFF
--- a/deployment/ansible/group_vars/staging
+++ b/deployment/ansible/group_vars/staging
@@ -82,6 +82,13 @@ osm_extract_url: 'https://download.geofabrik.de/asia/philippines-latest.osm.pbf'
 # If there is only one language defined, the drop-down will not be displayed.
 languages:
     - { id: 'en-us', label: 'English (US)', rtl: false  }
+    - { id: 'vi', label: 'Tiếng Việt', rtl: false }
+    - { id: 'bn', label: 'বাংলা', rtl: false }
+    - { id: 'es', label: 'Español', rtl: false }
+    - { id: 'pt-br', label: 'português do Brasil', rtl: false }
+    - { id: 'zh', label: '漢語', rtl: false }
+    - { id: 'lo', label: 'ລາວ', rtl: false }
+    - { id: 'ar-sa', label: 'العَرَبِيَّة', rtl: true }
 
 ## The following options may also be added to languages for display in the language picker
 ## - { id: 'ar-sa', label: 'Arabic (Saudi Arabia)', rtl: true }


### PR DESCRIPTION
## Overview
Adds non-English languages to the staging configuration so that internationalization issues can be tested.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
This cannot be tested directly, but the configuration was copied from the configuration in development added in #756

