### PR TITLE
Reconcile differences in production.j2 and production.example

### DIFF
--- a/deployment/ansible/group_vars/production.example
+++ b/deployment/ansible/group_vars/production.example
@@ -22,6 +22,7 @@ app_version: "0.0.0"
 app_domain_name: "your.driver-domain.here"
 
 ## DOCKER SETTINGS
+docker_image_tag: "{{app_version}}"
 # The docker repository you want your app to pull images from. The default is "quay.io/azavea/".
 # The trailing / is required.
 docker_repository: "quay.io/azavea/"
@@ -108,6 +109,19 @@ dedupe_distance_degrees: "0.0008"
 # Set this to "true" for slightly cleaner URLs, if you are sure that all your users have updated
 # browsers. Otherwise, it is safe to leave as "false"
 js_html5mode: "false"
+js_html5mode_prefix: "!"
+web_js_html5mode: "{{ js_html5mode }}"
+web_js_html5mode_prefix: "{{ js_html5mode_prefix }}"
+editor_js_html5mode: "{{ js_html5mode }}"
+editor_js_html5mode_prefix: "{{ js_html5mode_prefix }}"
+
+# DRIVER uses the Mapillary API for street view; this is the client ID that
+# should be used when accessing that API. You can sign up for an API key here:
+# https://www.mapillary.com/
+web_js_mapillary: "false"
+web_js_mapillary_client_id: ""
+# This is the radius (in meters) within which images are searchf for around the point clicked
+web_js_mapillary_range: 10
 
 # Whether to display a dropdown in the web app to allow users to switch between different record
 # types. To avoid user confusion, it is best to leave this false if you are only planning to track

--- a/deployment/ansible/group_vars/production.j2
+++ b/deployment/ansible/group_vars/production.j2
@@ -183,6 +183,9 @@ forecast_io_api_key: ""
 # DRIVER has the capability to enable Single-Sign-On via OAuth (usually via Google).
 # To enable this feature, you will need a client ID and secret, which can be obtained from the
 # Google API Console: https://developers.google.com/identity/sign-in/web/devconsole-project
+# CAUTION: We have had problems copy-pasting the client ID and client secret from this site; there
+# have sometimes been whitespace and invisible characters in the copied strings. We recommend
+# typing the client id and secret by hand.
 # The URLs that you will need to authorize for your application are:
 # https://<your domain name>
 # https://<your domain name>/


### PR DESCRIPTION
## Overview
Over time, a small number changes have been made to either `production.example` but not `production.j2` or vise versa. This confuses which one should be used, which is a significant impediment when creating a new instance or performing an instance upgrade.

This applies observed changes to the corresponding file, so the only differences should be differences of value.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Run
```
diff deployment/ansible/group_vars/production.{j2,example}
```
- The only differences should be variable value templating and `{% raw %}`/`{% endraw %}`


