### PR TITLE
 Fix hyphenated language capitalization issue in Date Picker

### DIFF
--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -97,10 +97,7 @@ languages:
     - { id: 'zh', label: '漢語', rtl: false }
     - { id: 'lo', label: 'ລາວ', rtl: false }
     - { id: 'ar-sa', label: 'العَرَبِيَّة', rtl: true }
-
-## The following options may also be added to languages for display in the language picker
-## - { id: 'ar-sa', label: 'Arabic (Saudi Arabia)', rtl: true }
-## - { id: 'exclaim', label: 'Exclaim (Developer)', rtl: false }
+    - { id: 'exclaim', label: 'Exclaim (Developer)', rtl: false }
 
 ## Forecast.io settings
 forecast_io_api_key: ''

--- a/deployment/ansible/group_vars/staging
+++ b/deployment/ansible/group_vars/staging
@@ -89,10 +89,7 @@ languages:
     - { id: 'zh', label: '漢語', rtl: false }
     - { id: 'lo', label: 'ລາວ', rtl: false }
     - { id: 'ar-sa', label: 'العَرَبِيَّة', rtl: true }
-
-## The following options may also be added to languages for display in the language picker
-## - { id: 'ar-sa', label: 'Arabic (Saudi Arabia)', rtl: true }
-## - { id: 'exclaim', label: 'Exclaim (Developer)', rtl: false }
+    - { id: 'exclaim', label: 'Exclaim (Developer)', rtl: false }
 
 ## Django allowed hosts setting. Overridden since staging runs in non-DEBUG mode.
 allowed_host: 'prs.azavea.com'

--- a/web/app/scripts/localization/date-utils.js
+++ b/web/app/scripts/localization/date-utils.js
@@ -38,21 +38,23 @@
                     'short': 'M Y'
                 }
             },
-            'ar-DZ': {
+            'ar-dz': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'ar-DZ'
             },
-            'ar-EG': {
+            'ar-eg': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'ar-EG'
             },
             'ar-sa': {
                 calendar: 'ummalqura',
@@ -128,13 +130,14 @@
                     'short': 'M Y'
                 }
             },
-            'de-CH': {
+            'de-ch': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd.mm.yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'de-CH'
             },
             'el': {
                 formats: {
@@ -144,29 +147,32 @@
                     'short': 'M Y'
                 }
             },
-            'en-AU': {
+            'en-au': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'en-AU'
             },
-            'en-GB': {
+            'en-gb': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'en-GB'
             },
-            'en-NZ': {
+            'en-nz': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'en-NZ'
             },
             'en-us': {
                 formats: {
@@ -193,21 +199,23 @@
                     'short': 'M Y'
                 }
             },
-            'es-AR': {
+            'es-ar': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'es-AR'
             },
-            'es-PE': {
+            'es-pe': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'es-PE'
             },
             'et': {
                 formats: {
@@ -267,13 +275,14 @@
                     'short': 'M Y'
                 }
             },
-            'fr-CH': {
+            'fr-ch': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd.mm.yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'fr-CH'
             },
             'gl': {
                 formats: {
@@ -300,13 +309,14 @@
                     'short': 'M Y'
                 }
             },
-            'hi-IN': {
+            'hi-in': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'hi-IN'
             },
             'hr': {
                 formats: {
@@ -420,13 +430,14 @@
                     'short': 'M Y'
                 }
             },
-            'me-ME': {
+            'me-me': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'me-ME'
             },
             'mk': {
                 formats: {
@@ -477,13 +488,14 @@
                     'short': 'M Y'
                 }
             },
-            'nl-BE': {
+            'nl-be': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'nl-BE'
             },
             'no': {
                 formats: {
@@ -510,13 +522,14 @@
                     'short': 'M Y'
                 }
             },
-            'pt-BR': {
+            'pt-br': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'pt-BR'
             },
             'rm': {
                 formats: {
@@ -574,13 +587,14 @@
                     'short': 'M Y'
                 }
             },
-            'sr-SR': {
+            'sr-sr': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd/mm/yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'sr-SR'
             },
             'sv': {
                 formats: {
@@ -646,29 +660,32 @@
                     'short': 'M Y'
                 }
             },
-            'zh-CN': {
+            'zh-cn': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'yyyy-mm-dd',
                     'short': 'M Y'
-                }
+                },
+                language: 'zh-CN'
             },
-            'zh-HK': {
+            'zh-hk': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'dd-mm-yyyy',
                     'short': 'M Y'
-                }
+                },
+                language: 'zh-HK'
             },
-            'zh-TW': {
+            'zh-tw': {
                 formats: {
                     'long': 'd MM, Y',
                     'longNoTime': 'd MM, Y',
                     'numeric': 'yyyy/mm/dd',
                     'short': 'M Y'
-                }
+                },
+                language: 'zh-TW'
             }
         };
 


### PR DESCRIPTION
## Overview
When enabling locale-specific translations for the date picker for #756, we unknowingly encountered an issue that DRIVER references hyphenated language/locale codes using all lowercase code, like `pt-br`, while the Date Picker expects upper-case for the locale portion, like `pr-BR`. This caused the date picker configuration load logic to default to the `''` config with `language` set to `pt-br`, which thankfully exposed the mismatched expectations.

Currently, DRIVER has translation files for three languages involving a hyphenated language/locale code:
- `ar-sa`
- `en-us`
- `pt-br`

Out of anticipation of potential future additions, this changes all of the date picker configuration objects to use all lower case and include a defined `language` property when the previous value did not match to the code used by DRIVER.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
<img width="238" alt="screen shot 2019-03-08 at 2 06 11 pm" src="https://user-images.githubusercontent.com/1032849/54049800-949c6000-41ab-11e9-8419-2fd27ee0de25.png">

## Testing Instructions
- Use the language drop-down to switch to Portuguese language
- Navigate to the map page
- Open the Created Date filter and click on a date to open the Date Picker
  - The Date Picker should be rendered in Portuguese
- Enable the Arabic (Saudi Arabian) language
- Repeat steps above (Note that Arabic is LTR, so the UI will be reverse from in a RTL language)
  - The Date Picker should be rendered in Saudi

Closes [#164442398](https://www.pivotaltracker.com/story/show/164442398)