### PR TITLE
Pin redis_version in group_vars to fix redis-tools error

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -42,6 +42,7 @@ windshaft_tables:
     - black_spots_blackspot
 
 redis_port: 6379
+redis_version: 2:2.8.4-2ubuntu0.2
 
 ## Reload the nginx config after an SSL certificate is renewed
 letsencrypt_post_renew_cmd: "service nginx reload"


### PR DESCRIPTION
## Overview
Fixes an error encountered while trying to provision a fresh 2.0.0 instance:
```
Depends: redis-tools (= 2:2.8.4-2) but 2:2.8.4-2ubuntu0.2 is to be installed
```

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Destroy your `database` Vagrant instance
- Run `vagrant up`
  - It should succeed

