### PR TITLE
 Remove remaining traces of Ashlar

### DIFF
--- a/app/Dockerfile.base
+++ b/app/Dockerfile.base
@@ -3,7 +3,7 @@ FROM quay.io/azavea/django:1.11-python2.7-slim
 # N.B. This will not work for docker versions above 1.10.x; Docker 1.11 and above contain
 # multiple binaries in a tarball; if we upgrade Docker to the 1.11 branch or beyond then
 # the RUN command below will need to be updated.
-ENV DOCKER_VERSION 1.10.3
+ENV DOCKER_VERSION 17.06.2
 
 # install libgdal1-dev
 RUN echo "deb http://deb.debian.org/debian jessie main contrib non-free " > /etc/apt/sources.list.d/jessie.list

--- a/app/data/management/commands/migrate_prs_description.py
+++ b/app/data/management/commands/migrate_prs_description.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from django.core.management.base import BaseCommand
 
-from ashlar.models import Record
+from grout.models import Record
 
 
 class Command(BaseCommand):

--- a/deployment/ansible/app.yml
+++ b/deployment/ansible/app.yml
@@ -14,6 +14,9 @@
   become: True
 
   pre_tasks:
+    - name: Add Docker APT key via curl
+      shell: "curl -sSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
+
     - name: Update APT cache
       apt: update_cache=yes
 

--- a/deployment/ansible/celery.yml
+++ b/deployment/ansible/celery.yml
@@ -17,6 +17,9 @@
     celery: True
 
   pre_tasks:
+    - name: Add Docker APT key via curl
+      shell: "curl -sSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
+
     - name: Update APT cache
       apt: update_cache=yes
 

--- a/deployment/ansible/database.yml
+++ b/deployment/ansible/database.yml
@@ -14,6 +14,9 @@
   become: True
 
   pre_tasks:
+    - name: Add Docker APT key via curl
+      shell: "curl -sSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
+
     - name: Update APT cache
       apt: update_cache=yes
 

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -6,7 +6,7 @@ staging: "{{ 'staging' in group_names }}"
 not_staging: "{{ 'staging' not in group_names }}"
 production: "{{ 'production' in group_names }}"
 
-docker_version: "1.10.*"
+docker_version: "17.06.*"
 docker_py_version: "1.2.3"
 docker_options: "--storage-driver=aufs"
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -9,7 +9,7 @@
 - src: azavea.nginx
   version: 0.2.1
 - src: azavea.docker
-  version: 1.0.2
+  version: 4.0.0
 - src: azavea.pip
   version: 1.0.1
 - src: azavea.redis

--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -30,7 +30,6 @@ exec /usr/bin/docker run \
   --volume {{ root_media_dir }}:{{ root_media_dir }} \
   {% if 'development' in group_names -%}
   --volume {{ root_app_dir }}:{{ root_app_dir }} \
-  --volume /opt/ashlar:/opt/ashlar \
   --env DJANGO_SETTINGS_MODULE=driver.settings_dev \
   {% endif -%}
   {% for k,v in driver_conf.items() -%}

--- a/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
+++ b/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
@@ -29,7 +29,6 @@ exec /usr/bin/docker run \
   --volume {{ root_media_dir }}:{{ root_media_dir }} \
   {% if 'development' in group_names -%}
   --volume {{ root_app_dir }}:{{ root_app_dir }} \
-  --volume /opt/ashlar:/opt/ashlar \
   --env DJANGO_SETTINGS_MODULE=driver.settings_dev \
   {% endif -%}
   {% for k,v in driver_conf.items() -%}

--- a/windshaft/server.js
+++ b/windshaft/server.js
@@ -22,8 +22,8 @@ redisClient.select(2);
 var config = {
         useProfiler: true,
         // :tablename parameter can be:
-        // ashlar_boundary to get the user-uploaded boundary polygon, or
-        // ashlar_record to get records points.
+        // grout_boundary to get the user-uploaded boundary polygon, or
+        // grout_record to get records points.
         // :id parameter can be either ALL to get all boundary polygons/record points, or
         // a UUID of a particular record type or boundary shapefile.
         base_url: '/tiles/table/:tablename/id/:id',
@@ -44,7 +44,7 @@ var config = {
             host: dbHost,
             port: dbPort,
             geometry_field: 'geom',
-            // this must match the ashlar SRID set in app/driver/settings.py
+            // this must match the Grout SRID set in app/driver/settings.py
             srid: 4326
           }
         }, //see grainstore npm for other options


### PR DESCRIPTION
## Overview
Removes references to Ashlar as able. Some remnants remain, in:
- CHANGELOG
- Existing migrations (Provisioning a new DRIVER instance installs migrations successfully)
- Ashlar Schema Editor

## Notes
Also fixes problems encountered preventing provisioning by upgrading Docker to version 17.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Make sure that no `ashlar/` directory exists in the same directory as your `DRIVER/` repo
- `vagrant provision`
 - The web interface should still work
- (Extra credit)
  - Delete the VMs with `vagrant destroy`
  - Reprovision from scratch with `vagrant up`
    - The web interface should still work

Closes [#164466001](https://www.pivotaltracker.com/story/show/164466001)

