### PR TITLE
Prevent failed post-stop script task from stopping Upstart respawning

### DIFF
--- a/deployment/ansible/roles/driver.app/tasks/main.yml
+++ b/deployment/ansible/roles/driver.app/tasks/main.yml
@@ -33,10 +33,10 @@
   command: /usr/bin/docker pull {{ docker_repository }}driver-app:{{ docker_image_tag }}
   when: staging or production
 
-- name: Configure Driver application service definition
+- name: Configure DRIVER application service definition
   template: src=upstart-app.conf.j2 dest=/etc/init/driver-app.conf
 
-- name: Restart Driver application
+- name: Restart DRIVER application
   service: name=driver-app state=restarted
 
 - name: Set up monit monitoring of driver-app container

--- a/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/driver.app/templates/upstart-app.conf.j2
@@ -45,6 +45,6 @@ exec /usr/bin/docker run \
 {% endif %}
 
 post-stop script
-  /usr/bin/docker kill driver-app
-  /usr/bin/docker rm driver-app
+  /usr/bin/docker kill driver-app || true
+  /usr/bin/docker rm driver-app || true
 end script

--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -19,7 +19,7 @@
   command: /usr/bin/docker pull {{ docker_repository }}driver-app:{{ docker_image_tag}}
   when: staging or production
 
-- name: Configure Driver celery service definition
+- name: Configure DRIVER Celery service definition
   template: src=upstart-celery.conf.j2 dest=/etc/init/driver-celery.conf
 
 - name: Restart DRIVER Celery service

--- a/deployment/ansible/roles/driver.celery/tasks/main.yml
+++ b/deployment/ansible/roles/driver.celery/tasks/main.yml
@@ -22,8 +22,11 @@
 - name: Configure Driver celery service definition
   template: src=upstart-celery.conf.j2 dest=/etc/init/driver-celery.conf
 
-- name: Restart Driver celery service
+- name: Restart DRIVER Celery service
   service: name=driver-celery state=restarted
+
+- name: Restart DRIVER Gradle service
+  service: name=driver-gradle state=restarted
 
 - name: Set up monit monitoring of driver-celery container
   template: src=monit-driver-celery.cfg.j2 dest=/etc/monit/conf.d/driver-celery.cfg

--- a/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
+++ b/deployment/ansible/roles/driver.celery/templates/upstart-celery.conf.j2
@@ -43,6 +43,6 @@ exec /usr/bin/docker run \
   --maxtasksperchild=1
 
 post-stop script
-  /usr/bin/docker kill driver-celery
-  /usr/bin/docker rm driver-celery
+  /usr/bin/docker kill driver-celery || true
+  /usr/bin/docker rm driver-celery || true
 end script

--- a/deployment/ansible/roles/driver.gradle/templates/upstart-gradle.conf.j2
+++ b/deployment/ansible/roles/driver.gradle/templates/upstart-gradle.conf.j2
@@ -31,6 +31,6 @@ exec /usr/bin/docker run \
   {{ docker_repository }}driver-gradle:{{ docker_image_tag }}
 
 post-stop script
-  /usr/bin/docker kill driver-gradle
-  /usr/bin/docker rm driver-gradle
+  /usr/bin/docker kill driver-gradle || true
+  /usr/bin/docker rm driver-gradle || true
 end script

--- a/gradle/sub.py
+++ b/gradle/sub.py
@@ -14,46 +14,55 @@ DRIVER_REDIS_JAR_DB = os.getenv('DRIVER_REDIS_JAR_DB', 3)
 TIMEOUT_SECONDS = 60
 
 
-print('\nSetting up redis subscription for gradle task')
-sys.stdout.flush()
+def logmsg(msg, *args, **kwargs):
+    print(msg.format(*args, **kwargs))
+    sys.stdout.flush()
+
+
+logmsg('\nSetting up redis subscription for gradle task')
 r = redis.StrictRedis(host=DRIVER_REDIS_HOST,
                       port=DRIVER_REDIS_PORT,
                       db=DRIVER_REDIS_JAR_DB,
                       socket_connect_timeout=10)
 
+logmsg('Pinging Redis to test connectivity')
 if not r.ping():
-    print('Cannot ping redis!')
-    sys.stdout.flush()
+    logmsg('Cannot ping redis!')
     sys.exit(1)
+
+logmsg("Starting Redis subscription...")
 
 pub = r.pubsub()
 pub.subscribe('jar-build')
 
+logmsg("Listening for messages...")
 for message in pub.listen():
-    if message['type'] == 'message':
+    logmsg('Received item')
+    if message['type'] != 'message':
+        logmsg("Item was not a message, it was a {}", message['type'])
+    else:
+        logmsg('Received message, processing...')
         try:
             data = message['data']
             data = json.loads(data.decode('utf-8'))
             uuid = data['uuid']
             schema = json.dumps(data['schema'])
             if r.get(uuid):
-                print('Jar already exists for {uuid}; skipping'.format(uuid=uuid))
-                sys.stdout.flush()
+                logmsg('Jar already exists for {uuid}; skipping', uuid=uuid)
                 continue
             subprocess.check_call(['/bin/bash', 'run.sh', uuid, schema],
-                timeout=TIMEOUT_SECONDS)
+                                  timeout=TIMEOUT_SECONDS)
         except (ValueError, KeyError) as ex:
-            print('malformed message received: {message}'.format(message=message))
-            sys.stdout.flush()
+            logmsg('malformed message received: {message}', message=message)
         except subprocess.CalledProcessError as ex:
-            print('jar build process failed with: {ex}'.format(ex=ex))
+            logmsg('jar build process failed with: {ex}', ex=ex)
             r.delete(uuid)
         except subprocess.TimeoutExpired as ex:
-            print('jar build process timed out: {ex}'.format(ex=ex))
+            logmsg('jar build process timed out: {ex}', ex=ex)
             r.delete(uuid)
+        else:
+            logmsg('Finished processing successfully')
 
-        sys.stdout.flush()
 
-print('Redis subscription loop exited! Was there an error with the connection?')
-sys.stdout.flush()
+logmsg('Redis subscription loop exited! Was there an error with the connection?')
 pub.close()

--- a/scripts/generate_deployment_config
+++ b/scripts/generate_deployment_config
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #########################################
-# Set up Driver for deployment.
+# Set up DRIVER for deployment.
 # Requires python3.6 with pip installed.
 #########################################
 


### PR DESCRIPTION
## Overview
After one of our Docker processes ends, we configure Upstart to kill the container and delete it. However, because the process has ended, the command Upstart is configured to kill the container fails:
```
Error response from daemon: Cannot kill container driver-gradle: Container 6c9afdbe941ae917002f069761f1584d0093ac420f330333a364241a9c9a5d28 is not running
```

This failed `docker kill` command would cause Upstart to abort the process respawn, leaving the service stopped.

It's not clear if `docker kill` is needed in the `post-stop script` section, but in order to prevent a failure from stopping Upstart from attempting to respawn the process this appends `|| true` to each command so that they will be respawned even if one of the `post-stop` commands fails.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- `vagrant provision celery`
- Open a terminal and SSH into the celery server
- `sudo tail -f /var/log/upstart/driver-gradle.log`
- Open a second terminal and SSH into the database server
- `sudo service redis-server stop`
  - You should see messages in the `celery` SSH terminal showing the Gradle process being repeatedly respawned and failing 
- `sudo service redis-server start`
  - You should see the messages stop and diagnostic messages showing the process is waiting for messages
- Exit the database server
- `vagrant reload database`
  - You should see messages in the `celery` SSH terminal showing the Gradle process being respawned, and recover when the database server has finished reloading

Closes [#164140129](https://www.pivotaltracker.com/story/show/164140129)
