### PR TITLE
Upgrade Docker Node template version

### DIFF
--- a/schema_editor/Dockerfile
+++ b/schema_editor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4-slim
+FROM node:8-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4-slim
+FROM node:8-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \


### PR DESCRIPTION
## Overview
Fixes an error encountered while building Docker containers from attempting to install packages from `jessie-updates`:
```
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found
```
It appears that the problem may be related to `jessie-updates` having been taken down:
> For Debian 8 "Jessie", jessie-updates no longer exists as this suite no longer receives updates since 2018-05-17.

This upgrades the Docker image to Node 8, which alleviates the error.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
- Travis test should pass
- Provision
  - It should succeed
- Use the UI
  - UI should still work
- Use the Editor
  - Editor should still work

