### PR TITLE
Fix relationship value not showing on record modal

### DIFF
--- a/web/app/scripts/details/details-tabs-partial.html
+++ b/web/app/scripts/details/details-tabs-partial.html
@@ -16,7 +16,7 @@
             ng-if="definition.multiple"
             data="::ctl.record.data[definition.propertyKey]"
             properties="::properties"
-            record="::ctl.record"
+            record="ctl.record"
             definition="::definition"
             is-secondary="ctl.isSecondary">
         </driver-details-multiple>


### PR DESCRIPTION
## Overview

Relationship field values weren't always showing up on the record modal, due to the use of one-time binding syntax for the record, which is subsequently altered. Removing the one-time binding syntax fixes the problem. 

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![Screenshot_2019-04-16 DRIVER](https://user-images.githubusercontent.com/6386/56243750-58410700-6069-11e9-9019-9fc5161b1d6c.png)

### Notes

The fix here is to remove the one-time binding syntax for `record`, as
is also performed above in the `driver-details-single` section. It appears
there is a sort of race condition, where the record data can possibly be
altered after its initial load. I imagine that's why this same change was
made to `driver-details-single`.

With the one-time binding syntax in place, there was some non-determinism,
where sometimes the relationship data would be loaded, but other times it
wouldn't be (because the data wasn't present on the record yet).

## Testing Instructions

 * Load the record list page
 * Either identify a record that contains a data relationship, or modify a record so it has one
 * Open this record modal with the View button and verify that the relationship data is present
 * Re-open the record modal a couple times, then refresh the page and do the same. Verify that the data is always there. Without this fix in place, you will sometimes see that the data is missing, as is described in the PT issue.
  * Click the View button on the modal to pop out to the details page, and ensure the relationship data is also present here

Closes [PT165286823](https://www.pivotaltracker.com/story/show/165286823)
