### PR TITLE
Use local time in CSV exports

### DIFF
--- a/app/data/tasks/export_csv.py
+++ b/app/data/tasks/export_csv.py
@@ -172,10 +172,9 @@ class DriverRecordExporter(object):
 
     def get_files_and_names(self):
         """Return all file objects maintained by this exporter along with suggested names"""
-        result = [(self.rec_outfile, 'records.csv')]
+        yield (self.rec_outfile, 'records.csv')
         for related_name, out_file in self.outfiles.viewitems():
-            result.append((out_file, related_name + '.csv'))
-        return result
+            yield (out_file, related_name + '.csv')
 
     def write_record(self, rec):
         """Pass rec's fields through all writers to output all info as CSVs"""

--- a/deployment/ansible/roles/driver.app/defaults/main.yml
+++ b/deployment/ansible/roles/driver.app/defaults/main.yml
@@ -25,6 +25,7 @@ driver_conf:
   DJANGO_SECRET_KEY: "{{ postgresql_password | md5 }}"
   DJANGO_ENV: "{% if developing %}development{% elif staging %}staging{% else %}production{% endif %}"
   DRIVER_OSM_EXTRACT_URL: "{{ osm_extract_url }}"
+  DRIVER_LOCAL_TIME_ZONE: "{{ local_time_zone_id }}"
   ALLOWED_HOST: "{{ allowed_host }}"
   DRIVER_DEDUPE_TIME_RANGE_HOURS: "{{ dedupe_time_range_hours }}"
   DRIVER_DEDUPE_DISTANCE_DEGREES: "{{ dedupe_distance_degrees }}"

--- a/deployment/ansible/roles/driver.celery/defaults/main.yml
+++ b/deployment/ansible/roles/driver.celery/defaults/main.yml
@@ -25,6 +25,7 @@ driver_conf:
   DJANGO_SECRET_KEY: "{{ postgresql_password | md5 }}"
   DJANGO_ENV: "{% if developing %}development{% elif staging %}staging{% else %}production{% endif %}"
   DRIVER_OSM_EXTRACT_URL: "{{ osm_extract_url }}"
+  DRIVER_LOCAL_TIME_ZONE: "{{ local_time_zone_id }}"
   BLACKSPOT_RECORD_TYPE_LABEL: "{{ web_js_record_type_primary_label }}"
   ALLOWED_HOST: "{{ allowed_host }}"
 


### PR DESCRIPTION
## Overview
Microsoft Excel and other applications generally have poor support for date times represented in ISO 8601, or even with any timezone suffix at all. Because CSV export is predominantly targeted towards users who will analyze the data in applications of that sort (As the API exists for more programatic usage where ISO 8601 would be more conventional), this removes the timezone from the date times in CSV export and formats them in a standard YYYY-MM-DD format using the configured timezone.

For consistency and data completeness this also adds a column including the timezone the dates are rendered in.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo
```csv
record_id,timezone,created,modified,occurred_from,occurred_to,lat,lon,location_text,city,city_district,county,neighborhood,road,state,weather,light,Hit & Run,Police Station,District,Type of Collision - Others (specify),Crash Severity,Type of Collision,State,Charges against - Other  (please specify),Crime Registration Number,driverIncidentDetails_id,Charges against,Type of Area
1590043d-3e47-4dca-a3e5-2d664d276b78,Asia/Calcutta,2019-03-07 16:39:41,2019-04-17 03:27:07,2019-01-31 20:25:00,2019-01-31 20:25:00,19.057719,72.92541,"Deonar Colony, M/E Ward, Mumbai, Mumbai Suburban, Maharashtra, 400088, India",Mumbai,None,None,Deonar Colony,None,Maharashtra,clear-night,night,No,Deonar,Mumbai,,Serious Injury,Vehicle to Pedestrian,Maharashtra,,37/2019,f25f85b3-f8c0-41ba-b8fc-9e3ac2eca6e0,"[u'184', u'279', u'338']",Urban
```

### Notes
- Tweaks a few instances where dictionary key lookups were duplicated to use `.get()` with the intention of streamlining the logic and marginally improve performance

## Testing Instructions
- Provision VMs to ensure that Celery processes are up to date and Django is set to use configured timezone
- Open Map page
- Filter so that some records are shown
- Export and Download CSV
- Open CSV file
  - Dates should be represented as `YYYY-MM-DD HH:MM:SS`, without timezone suffix
  - Timezone column should be included and match configured timezone
- Open details list for a record in the CSV export (`http://localhost:7000/#!/record/{Record UUID}/details`
  - Times should match times in CSV export for that record

Closes [PT164776646](https://www.pivotaltracker.com/story/show/164776646)

