### PR TITLE
Make relationship field value use the title

### DIFF
--- a/schema_editor/bower.json
+++ b/schema_editor/bower.json
@@ -12,7 +12,7 @@
     "angular-resource": "~1.5.8",
     "angular-sanitize": "~1.5.8",
     "angular-ui-router": "~0.2.14",
-    "json-editor": "azavea/json-editor#v10.7.26",
+    "json-editor": "azavea/json-editor#v10.7.29",
     "angular-local-storage": "~0.2.2",
     "angular-bootstrap": "~0.13.0",
     "lodash": "^3.8.0"

--- a/web/app/scripts/details/details-field-directive.js
+++ b/web/app/scripts/details/details-field-directive.js
@@ -10,6 +10,7 @@
               data: '=',
               property: '=',
               record: '=',
+              recordSchema: '=',
               isSecondary: '<'
             },
             templateUrl: 'scripts/details/details-field-partial.html',

--- a/web/app/scripts/details/details-field-partial.html
+++ b/web/app/scripts/details/details-field-partial.html
@@ -4,7 +4,7 @@
     </driver-details-image>
 
     <driver-details-reference ng-switch-when="reference"
-        property="ctl.property" data="ctl.data" record="ctl.record" compact="ctl.compact">
+        property="ctl.property" data="ctl.data" record="ctl.record" record-schema="ctl.recordSchema" compact="ctl.compact">
     </driver-details-reference>
 
     <driver-details-selectlist ng-switch-when="selectlist"

--- a/web/app/scripts/details/details-multiple-directive.js
+++ b/web/app/scripts/details/details-multiple-directive.js
@@ -9,6 +9,7 @@
                 data: '=',
                 properties: '=',
                 record: '=',
+                recordSchema: '=',
                 definition: '=',
                 isSecondary: '<'
             },

--- a/web/app/scripts/details/details-multiple-partial.html
+++ b/web/app/scripts/details/details-multiple-partial.html
@@ -17,6 +17,7 @@
                                   compact="true"
                                   data="::item[property.propertyName]"
                                   record="::ctl.record"
+                                  record-schema="::ctl.recordSchema"
                                   property="::property"
                                   is-secondary="ctl.isSecondary">
                               </driver-details-field>
@@ -29,6 +30,7 @@
                             data="item"
                             properties="ctl.properties"
                             record="ctl.record"
+                            record-schema="::ctl.recordSchema"
                             is-secondary="ctl.isSecondary">
                         </driver-details-single>
                     </div>

--- a/web/app/scripts/details/details-reference-controller.js
+++ b/web/app/scripts/details/details-reference-controller.js
@@ -19,7 +19,13 @@
             // have a -1 populated here, so we can just take the maxiumum of the array
             var index = _.max(candidateIndices);
             if (index > -1) {
-                ctl.referenceDisplay = ctl.property.propertyName + ' ' + (index + 1);
+                // Property name of the target
+                var targetKey = ctl.property.watch.target;
+
+                // Single title of the referenced target
+                var singleTitle = ctl.recordSchema.schema.definitions[targetKey].title;
+
+                ctl.referenceDisplay = singleTitle + ' ' + (index + 1);
             }
         }
     }

--- a/web/app/scripts/details/details-reference-directive.js
+++ b/web/app/scripts/details/details-reference-directive.js
@@ -9,6 +9,7 @@
                 data: '=',
                 property: '=',
                 record: '=',
+                recordSchema: '=',
                 compact: '='
             },
             templateUrl: 'scripts/details/details-reference-partial.html',

--- a/web/app/scripts/details/details-single-directive.js
+++ b/web/app/scripts/details/details-single-directive.js
@@ -9,6 +9,7 @@
                 data: '<',
                 properties: '<',
                 record: '<',
+                recordSchema: '<',
                 definition: '<',
                 isSecondary: '<'
             },

--- a/web/app/scripts/details/details-single-partial.html
+++ b/web/app/scripts/details/details-single-partial.html
@@ -6,6 +6,6 @@
 
 <div ng-repeat="property in ctl.properties" ng-if="!ctl.definition.pending">
     <driver-details-field
-       property="property" data="ctl.data[property.propertyName]" record="ctl.record" is-secondary="ctl.isSecondary">
+       property="property" data="ctl.data[property.propertyName]" record="ctl.record" record-schema="ctl.recordSchema" is-secondary="ctl.isSecondary">
     </driver-details-field>
 </div>

--- a/web/app/scripts/details/details-tabs-partial.html
+++ b/web/app/scripts/details/details-tabs-partial.html
@@ -8,6 +8,7 @@
             data="::ctl.record.data[definition.propertyKey]"
             properties="::properties"
             record="ctl.record"
+            record-schema="ctl.recordSchema"
             definition="::definition"
             is-secondary="ctl.isSecondary">
         </driver-details-single>
@@ -17,6 +18,7 @@
             data="::ctl.record.data[definition.propertyKey]"
             properties="::properties"
             record="ctl.record"
+            record-schema="ctl.recordSchema"
             definition="::definition"
             is-secondary="ctl.isSecondary">
         </driver-details-multiple>

--- a/web/bower.json
+++ b/web/bower.json
@@ -22,7 +22,7 @@
     "angular-translate-loader-static-files": "2.11.0",
     "bootstrap-sass-official": "twbs/bootstrap-sass#02c61388626f6942a8bcbb2129866a976b093acb",
     "ng-file-upload": "^4.0.0",
-    "json-editor": "azavea/json-editor#v10.7.26",
+    "json-editor": "azavea/json-editor#v10.7.29",
     "ng-debounce": "^0.1.7",
     "bootstrap-select": "1.7.3",
     "lodash": "^3.8.0",


### PR DESCRIPTION
## Overview

Relationship field values were being shown using the property key, which doesn't always match up with the actual single title of the target. This changes it to use the title.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

Many files needed to be changed, because the `recordSchema` needed to be threaded through the hierarchy of directives, so it could be used by the reference field. I chose to use either `=` or `<` by matching on how `record` was being set, as that seemed to be the safest bet.

## Testing Instructions
 * Provision your app VM and load the site up in a browser
 * Go to the record list view and experiment with viewing/creating/updating records with relationships
 * Verify the auto-incremented labels are displayed in each place the relationships are displayed or are selectable
 * (Optional) If you're using the Mumbai schema, you probably won't be able to really reproduce the problem. You can simulate it by modifying the title on the schema as it's being loaded. E.g. for the detail view, you can edit `web/app/scripts/views/record/list-controller.js` and add a line around line 33 with something like the following: `recordSchema.schema.definitions.driverVehicle.title = 'Overridden';`. Then `Overriden` will be displayed instead of `Vehicle`, as expected.

Closes [PT165648973](https://www.pivotaltracker.com/story/show/165648973)

