### PR TITLE
Add indexes for documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,16 @@
+# DRIVER Documentation
+DRIVER's documentation is spread across multiple files. This lists potentially relevant files.
+
+| Document | Description |
+| - | - |
+| [**System Administration**](system-administration.md) | General purpose information needed for configuring, deploying, and administering a DRIVER environment. |
+| [**Logging**](logging.md) | List of services, which host they run on, and log file destinations. |
+| [**Troubleshooting Android app issues**](android-troubleshooting.md) | Overview of common potential problems connecting a DRIVER environment with its DRIVER Android application. |
+| [**API Documentation**](api-documentation.md) | Description of API endpoints and response structure. |
+| [**API Use Case &mdash; Health Organization**](api-use-case-health-organization.md) | Step by step example of using the DRIVER application for a hypothetical health organization. |
+| [**Batch Data Loading**](batch-data-loading.md) | Guide for loading bulk data quickly using the API or shell directly. |
+| [**Best Practices for DRIVER data**](data-best-practices.md) | Collection of best practices for defining and managing DRIVER record schemas. |
+| [**Competencies for working with a DRIVER instance**](dev_ops_competencies.md) | Definition of what tools and technologies an administrator may need to be familiar with to manage a DRIVER instance. |
+| [**Domain Management**](domain-management.md) | Guide on obtaining and configuring a domain name for your DRIVER instance. |
+| [**Stopping/Starting a Stack in AWS**](stopping-starting-aws-stack.md) | Guide for how to safely turn off, and later restore, an AWS hosted DRIVER environment to reduce cost when not in use. |
+| [**Translating DRIVER**](translation.md) | Overview of how translations are performed in DRIVER and steps needed to add a new translated language. |

--- a/doc/android-troubleshooting.md
+++ b/doc/android-troubleshooting.md
@@ -6,6 +6,15 @@ users in the field to easily submit data to the DRIVER platform. Integrating the
 specific installation of DRIVER requires some configuration. This document provides a guide to
 troubleshooting some of the most common problems with the Android application.
 
+## Table of Contents
+- [**Prerequisites**](#prerequisites)
+- [**Troubleshooting instructions**](#troubleshooting-instructions)
+  - [**Symptom: Logging in to the app with username and password doesn't work**](#symptom-logging-in-to-the-app-with-username-and-password-doesnt-work)
+  - [**Symptom: Logging in to the app with Google doesn't work.**](#symptom-logging-in-to-the-app-with-google-doesnt-work)
+  - [**Symptom: Uploading records from the app doesn't work.**](#symptom-uploading-records-from-the-app-doesnt-work)
+  - [**Symptom: Updating the schema on the app doesn't work.**](#symptom-updating-the-schema-on-the-app-doesnt-work)
+  - [**Symptom: Updating the schema always returns the message "Schema update is not ready yet"**](#symptom-updating-the-schema-always-returns-the-message-schema-update-is-not-ready-yet)
+
 ## Prerequisites
 This document assumes that you are able to build a copy of the Android app and install it on an
 Android device, and that you have a working installation of DRIVER running at a publicly-available

--- a/doc/api-documentation.md
+++ b/doc/api-documentation.md
@@ -1,6 +1,20 @@
+# API Documentation
+## Overview
 DRIVER is a flexible app for storing crash data and related information. DRIVER provides a robust REST API for querying its data. This document describes how to interact with the DRIVER API.
 
-# Resource Types
+## Table of Contents
+- [**Resource Types**](#resource-types)
+- [**Authentication**](#authentication)
+- [**Requests and Responses**](#requests-and-responses)
+- [**Record Types**](#record-types)
+- [**Record Schemas**](#record-schemas)
+- [**Records**](#records)
+- [**Boundaries**](#boundaries)
+- [**Boundary Polygons**](#boundary-polygons)
+- [**Black Spot Sets**](#black-spot-sets)
+- [**Black Spots**](#black-spots)
+
+## Resource Types
 
 The following resources are made available via the API:
 
@@ -34,7 +48,7 @@ The following resources are made available via the API:
 
 Note : there are other resource types available but they are used primarily for internal purposes; a complete list of resource types is available by sending an authenticated GET request to /api/ (see below).
 
-# Authentication
+## Authentication
 
 In order to interact with the DRIVER API you will need a user account. This can be given to you as a username and password by an administrator, or you can use your Google account to sign up.
 
@@ -84,7 +98,7 @@ Once you have a token, you will be able to make requests to the API by including
 
 `Authorization: Token <token>`
 
-# Requests and Responses
+## Requests and Responses
 
 Communication with the API generally follows the principles of RESTful API design. API paths correspond to resources, GET requests are used to retrieve objects, while POST requests are used to create new objects. This pattern is followed in nearly all cases; any exceptions will be noted in the documentation.
 
@@ -92,7 +106,7 @@ Responses from the API are exclusively JSON, unless another format is clearly re
 
 Endpoint behavior can be configured using query parameters for GET requests, while POST requests require a payload in JSON format.
 
-## Pagination
+### Pagination
 
 All API endpoints that return lists of resources are paginated. The pagination takes the following format:
 ```
@@ -108,13 +122,13 @@ All API endpoints that return lists of resources are paginated. The pagination t
 ```
 In a real response, the domain and port for the next and previous fields will be that of the server responding to the request.
 
-This format applies to the API endpoints below and will not be repeated in the documentation for each individual endpoint. 
+This format applies to the API endpoints below and will not be repeated in the documentation for each individual endpoint.
 
-## JSON-Schema
+### JSON-Schema
 
 The DRIVER API makes heavy use of [JSON Schema](http://json-schema.org/) -- it's a good idea to gain familiarity with how JSON Schema works before interacting with the API.
 
-# Record Types
+## Record Types
 
 Paths
 
@@ -152,9 +166,9 @@ Results fields
 
 **Notes**
 
-Because the data schema for a RecordType can be changed by system administrators or programmatically, it is *highly* recommended to use the RecordType API in order to discover the most recent RecordSchema for the RecordType you are interested in before performing further queries. Record Types do not change frequently after initial setup is complete, so knowing the UUID of the Record Type you're interested in will usually be sufficient. 
+Because the data schema for a RecordType can be changed by system administrators or programmatically, it is *highly* recommended to use the RecordType API in order to discover the most recent RecordSchema for the RecordType you are interested in before performing further queries. Record Types do not change frequently after initial setup is complete, so knowing the UUID of the Record Type you're interested in will usually be sufficient.
 
-# Record Schemas
+## Record Schemas
 
 Paths
 
@@ -190,7 +204,7 @@ Results fields
 
     * A JSON Schema object
 
-# Records
+## Records
 
 **Paths**
 
@@ -353,7 +367,7 @@ Assuming a properly formatted enumeration is found at the path, each possible en
         "5": 2
     }
 }`
-                
+
                 * `table_labels`: Object
 
                     * Similarly to how `row_labels` and `col_labels` work, each key in this object corresponds to the tablekey of a table.
@@ -488,7 +502,7 @@ List / Detail Results fields
 
     * A JSON object representing the data associated with this Record. It is always true that the object stored in "data" conforms to the RecordSchema referenced by the "schema" UUID.
 
-# Boundaries
+## Boundaries
 
 Paths
 
@@ -540,7 +554,7 @@ Creating a new Boundary and its Polygons correctly is a two-step process.
 
 2. The response from the previous request will have a blank `display_field`. Select one of the fields in `data_fields` and make a PATCH request to `/api/boundaries/{uuid}/` with that value in `display_field`. You are now ready to use this Boundary and its associated Boundary Polygons.
 
-# Boundary Polygons
+## Boundary Polygons
 
 Paths
 
@@ -586,7 +600,7 @@ Query Parameters:
 
     * When passed with any value, causes the geometry field to be replaced with a bbox field. This reduces the response size and is sufficient for many purposes.
 
-# Black Spot Sets
+## Black Spot Sets
 
 Paths
 
@@ -624,7 +638,7 @@ Query Parameters
 
 **Notes**
 
-# Black Spots
+## Black Spots
 
 Paths
 

--- a/doc/batch-data-loading.md
+++ b/doc/batch-data-loading.md
@@ -1,6 +1,10 @@
 # System administration: Batch data loading
 
-The DRIVER system has provisions to programatically load data. There are two easy ways to do this. Sample python scripts are provided for both methods, but you will likely need to edit these scripts to match your data's format. 
+The DRIVER system has provisions to programatically load data. There are two easy ways to do this. Sample python scripts are provided for both methods, but you will likely need to edit these scripts to match your data's format.
+
+## Table of Contents
+- [**Loading data using the API**](#loading-data-using-the-api)
+- [**Loading data using Django shell**](#loading-data-using-django-shell)
 
 ## Loading data using the API
 
@@ -12,20 +16,20 @@ A sample script that loads data using the API can be found at `scripts/load_inci
 --authz AUTHZ               Authorization header
 ```
 
-It does 3 basic things: 
+It does 3 basic things:
 
-1. Creates a new schema. It does this using the default `scripts/incident_schema_v3.json` or a custom schema specified using the `--schema-path` flag. If you wish to add records to an existing schema, all you need to do is comment out the `create_schema` function call in `main` and assign the schema uuid you want to `schema_id`. 
+1. Creates a new schema. It does this using the default `scripts/incident_schema_v3.json` or a custom schema specified using the `--schema-path` flag. If you wish to add records to an existing schema, all you need to do is comment out the `create_schema` function call in `main` and assign the schema uuid you want to `schema_id`.
 
-2. Transforms the data. It transforms a row of the csv file into a json object that is compliant with the schema. It does this using the `transform` method. When you have to load batch data using this script, this is the function that should have the most changes depending on your csv. 
+2. Transforms the data. It transforms a row of the csv file into a json object that is compliant with the schema. It does this using the `transform` method. When you have to load batch data using this script, this is the function that should have the most changes depending on your csv.
 
-3. Loads the data. It loads the object that it transforms a row of the csv file into using an API call. The `load` function also includes a brief sleep so as to not overload the server with API calls. Remove this at your discretion. 
+3. Loads the data. It loads the object that it transforms a row of the csv file into using an API call. The `load` function also includes a brief sleep so as to not overload the server with API calls. Remove this at your discretion.
 
-The script will also inform you of the progress with a log message on loading every 100 data points and on successfully loading a csv file. 
+The script will also inform you of the progress with a log message on loading every 100 data points and on successfully loading a csv file.
 
 
 ## Loading data using Django shell
 
-This functions identically to the script that hits the API except that it runs in the Django shell and is therefore a quicker way to load a huge amount of data. If you have more than 5000 records to load, this is the recommended way to do so. A sample script is included at `scripts/django_batch_loader.py`. This script would have to be run on Django shell as follows: 
+This functions identically to the script that hits the API except that it runs in the Django shell and is therefore a quicker way to load a huge amount of data. If you have more than 5000 records to load, this is the recommended way to do so. A sample script is included at `scripts/django_batch_loader.py`. This script would have to be run on Django shell as follows:
 
 ```
 $ cp scripts/django_batch_loader.py app

--- a/doc/system-administration.md
+++ b/doc/system-administration.md
@@ -5,6 +5,18 @@ The goal of this document is to provide enough information to allow a system adm
 These instructions are designed to be run on a Linux- or Unix-like system.
 
 
+## Sections
+- [**General system architecture**](#general-system-architecture)
+- [**Deployment**](#deployment)
+- [**Deploying updates**](#deploying-updates)
+- [**Making custom changes**](#making-custom-changes)
+- [**Using Monit to restart services**](#using-monit-to-restart-services)
+- [**Logging into servers and viewing logs**](#logging-into-servers-and-viewing-logs)
+- [**Firewall configuration**](#firewall-configuration)
+- [**SSL certificate configuration**](#ssl-certificate-configuration)
+- [**Cleaning up after Docker**](#cleaning-up-after-docker)
+- [**General troubleshooting notes for server restarts**](#general-troubleshooting-notes-for-server-restarts)
+
 ## General system architecture
 
 The default DRIVER production setup consists of three servers, all running Ubuntu 14.04 LTS:


### PR DESCRIPTION
## Overview
In order to make identifying useful information in our documentation easier, this adds indexes for what documentation files exist and what they contain, as well as indexes for certain larger single files describing what sections they contain.

The goal is that providing this high-level information should aid users in locating information that they may not even know exists or not.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions
[Use this link to browse the PR changes in the standard GitHub interface](https://github.com/WorldBank-Transport/DRIVER/tree/feature/discoverable-docs/doc)
- Links and brief descriptions should appear when viewing the `doc/` directory
  - Links should work
- The pages `android-troubleshooting.md`, `api-documentation.md`, `batch-data-loading.md` and `system-administration.md` should all have table of contents for their sub sections
  - Links should work

Closes [PT164574260](https://www.pivotaltracker.com/story/show/164574260)

