### PR TITLE
Reorder celery role dependencies

### DIFF
--- a/deployment/ansible/celery.yml
+++ b/deployment/ansible/celery.yml
@@ -24,7 +24,7 @@
       apt: update_cache=yes
 
   roles:
+    - { role: "driver.gradle" }
     - { role: "driver.celery" }
     - { role: "driver-celery.nginx" }
     - { role: "driver.r-docker" }
-    - { role: "driver.gradle" }


### PR DESCRIPTION
## Overview

Fix driver.gradle ansible role not running before its dependent driver.celery role.


## Notes

It looks like the roles were always ordered as they were, so it's unclear why this became an issue.


## Testing Instructions

 * Destroy and reprovision VMs from scratch
 

Closes #805 
