### PR TITLE
Fix deploy

### DIFF
--- a/deployment/ansible/group_vars/production.j2
+++ b/deployment/ansible/group_vars/production.j2
@@ -67,8 +67,8 @@ heimdall_lock_db: lockspace
 # IP addresses of the Celery machine and the Web server machine. For example (using variable
 # substitution), if deploying on bare metal:
 postgresql_hba_mapping:
-  - { type: "host", database: "all", user: "all", address: "{{ app_server_ip }}", method: "md5" }
-  - { type: "host", database: "all", user: "all", address: "{{ celery_server_ip }}", method: "md5" }
+  - { type: "host", database: "all", user: "all", address: "{{ app_server_ip }}/32", method: "md5" }
+  - { type: "host", database: "all", user: "all", address: "{{ celery_server_ip }}/32", method: "md5" }
 #
 # Alternatively, you can use a subnet range to specify the hosts that will be allowed to connect in a
 # single entry. This should only be used if your hosts have private IP addresses that they use to
@@ -108,12 +108,10 @@ dedupe_distance_degrees: "0.0008"
 
 # Set this to "true" for slightly cleaner URLs, if you are sure that all your users have updated
 # browsers. Otherwise, it is safe to leave as "false"
-js_html5mode: "false"
-js_html5mode_prefix: "!"
-web_js_html5mode: "{{ js_html5mode }}"
-web_js_html5mode_prefix: "{{ js_html5mode_prefix }}"
-editor_js_html5mode: "{{ js_html5mode }}"
-editor_js_html5mode_prefix: "{{ js_html5mode_prefix }}"
+web_js_html5mode: "false"
+web_js_html5mode_prefix: "!"
+editor_js_html5mode: "false"
+editor_js_html5mode_prefix: "!"
 
 # DRIVER uses the Mapillary API for street view; this is the client ID that
 # should be used when accessing that API. You can sign up for an API key here:

--- a/deployment/ansible/roles/driver.app/tasks/main.yml
+++ b/deployment/ansible/roles/driver.app/tasks/main.yml
@@ -51,6 +51,5 @@
 - name: Run Django migrations
   command: >
     /usr/bin/docker exec -i driver-app ./manage.py migrate
-  when: developing or staging
 
 - { include: firewall.yml }

--- a/deployment/ansible/roles/driver.database/tasks/main.yml
+++ b/deployment/ansible/roles/driver.database/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+# Restart PostgreSQL, since it may be in a bad state if a previous
+# provision attempt failed
+- name: Restart PostgreSQL
+  service: name=postgresql state=restarted
+
 - name: Create PostgreSQL super user
   become_user: postgres
   postgresql_user: name="{{ postgresql_username }}"

--- a/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
@@ -9,6 +9,12 @@
     dest: /usr/local/bin/certbot
     mode: 0755
 
+- name: Install certbot dependencies
+  command: certbot --non-interactive --os-packages-only
+
+- name: Install certbot
+  command: certbot --non-interactive --install-only
+
 - name: Stop nginx
   service:
     name: nginx

--- a/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
@@ -1,19 +1,13 @@
 ---
 # Set up certificates on the machine using CertBot
-- name: Install CertBot dependencies
-  apt:
-    pkg: software-properties-common
-    state: present
 
-- name: Add CertBot repository
-  apt_repository:
-    repo: "ppa:certbot/certbot"
-    state: present
-
-- name: Install CertBot
-  apt:
-    pkg: certbot
-    state: latest
+# Need to download certbot directly, since PPA no longer works
+# for this version of Ubuntu
+- name: Download certbot
+  get_url: >
+    url=https://dl.eff.org/certbot-auto
+    dest=/usr/local/bin/certbot
+    mode=0755
 
 - name: Stop nginx
   service:

--- a/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
+++ b/deployment/ansible/roles/driver.letsencrypt/tasks/main.yml
@@ -4,10 +4,10 @@
 # Need to download certbot directly, since PPA no longer works
 # for this version of Ubuntu
 - name: Download certbot
-  get_url: >
-    url=https://dl.eff.org/certbot-auto
-    dest=/usr/local/bin/certbot
-    mode=0755
+  get_url:
+    url: https://dl.eff.org/certbot-auto
+    dest: /usr/local/bin/certbot
+    mode: 0755
 
 - name: Stop nginx
   service:


### PR DESCRIPTION
## Overview

There were several problems with running a deployment, which have been fixed here:
 * Need to restart PostgreSQL at the beginning of the DB tasks, since it may be in a bad state if a previous provision attempt failed
 * The `certbot` PPA is no longer available for this version of Ubuntu, so it needed to be installed manually
 * The `production.j2` template had a couple problems: the CIDR range for single IPs were invalid, and the `js_html5mode` variables weren't set up correctly
 * Migrations weren't being run in production, so the database wasn't being initialized properly

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Demo

![driver-deploy-fix](https://user-images.githubusercontent.com/6386/67323423-6a03db00-f4e0-11e9-9287-e7af8d1e49a3.png)

## Testing Instructions

Unfortunately, the only real way to test this is to do a full deploy from scratch.

 * Clone the repo into a brand new directory and checkout this branch
 * Run: `touch gradle/data/driver.keystore`
 * Go to the DRIVER AWS account CloudFormation page, and create a new stack from the template in: `deployment/demo-cfn-template.yaml`
 * Once the resources are created, run `./scripts/generate_deployment_config` and plug in the values of the public/private IP addresses for the three instances
 * Create a Route53 A record that points to the public IP of the web machine, using the domain name you selected in the previous step
 * Open the production group_vars file in an editor and change the following (note -- some of these are probably not strictly necessarily, but it's what I did, so better safe than sorry):
    * Set `app_version` and `docker_image_tag` to "2.0.4"
    * Uncomment the `web_js_nominatim_key` line and add a working value
    * Uncomment the `monit_allow_password` line and add a working value
    * Add a new language: `- { id: 'fr', label: 'Français', rtl: false  }` (this was added in the 2.0.4 tag, so good to verify)
    * Add a valid `forecast_io_api_key`
    * Add a valid `google_analytics_id`
 * Use `ssh-add` to add the relevant PEM key
 * Run: `ansible-galaxy install -r deployment/ansible/roles.yml`
 * Run: `ansible-playbook -i deployment/ansible/inventory/production --user=ubuntu     deployment/ansible/database.yml     deployment/ansible/app.yml     deployment/ansible/celery.yml`
    * Note: you may want to connect to each machine via SSH first. I've noticed `ansible` isn't great at prompting for accepting connections from multiple machines at once.
 * It should run to completion with no errors :tada:
 * Go to `https://<your_subdomain>.roadsafety.io`, and verify that you can log in
 * Delete your CloudFormation stack when you're satisfied
 
Closes #807 
Closes #786
Closes #781