### PR TITLE
Update pickpoint API URL

### DIFF
--- a/web/app/scripts/nominatim/nominatim-service.js
+++ b/web/app/scripts/nominatim/nominatim-service.js
@@ -4,7 +4,7 @@
     /* ngInject */
     function Nominatim($http, WebConfig) {
 
-        var PICKPOINT_NOMINATIM_URL = 'https://pickpoint.io/api/v1/';
+        var PICKPOINT_NOMINATIM_URL = 'https://api.pickpoint.io/v1/';
         var SUGGEST_LIMIT = 15;
 
         var module = {


### PR DESCRIPTION
## Overview

An issue with the geocoding was reported by users in Mumbai. I was looking at the failed requests to get a sense of how involved this fix might be. I realized the URL in the [pickpoint docs ](https://pickpoint.io/api-reference) was different, so when I updated that and tested in Postman it worked perfectly. So putting up the change here in hopes it will just work.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs
- [x] PR is targeting the `develop` branch (unless this is a release)

### Demo

Here's the same request we are making in the app (`https://pickpoint.io/api/v1/forward?`):
![image](https://user-images.githubusercontent.com/14098314/71130810-ece3a200-21c0-11ea-8396-1bd24c716ae3.png)


Here's the request with the URL updated (`https://api.pickpoint.io/v1/forward?`):
![image](https://user-images.githubusercontent.com/14098314/71130760-c3c31180-21c0-11ea-8c7a-4537f6e8b119.png)


### Notes

We haven't touched this code in 4 years, so I assume it's a change that Pickpoint made. I looked in our inbox and didn't see any notifications that this was changing, so I'm kind of puzzled how they would just go and make a change like that.

## Testing Instructions

 * Load up the environment
 * Create an incident
 * Start typing in the `Location` box and pickpoint should make a request to search
